### PR TITLE
Write metadata file

### DIFF
--- a/crates/catalog/src/service.rs
+++ b/crates/catalog/src/service.rs
@@ -251,6 +251,7 @@ impl Catalog for CatalogImpl {
         let metadata = result.metadata.clone();
         let metadata_file_id = Uuid::new_v4().to_string();
         let metadata_relative_location = format!("{table_location}/metadata/{metadata_file_id}.metadata.json");
+        // TODO un-hardcode "file://" and make it dynamic - filesystem or s3 (at least)
         let metadata_full_location = format!("file://object_store/{metadata_relative_location}");
 
         let table = Table {

--- a/crates/catalog/src/service.rs
+++ b/crates/catalog/src/service.rs
@@ -266,15 +266,9 @@ impl Catalog for CatalogImpl {
         let local_dir = "object_store";
         fs::create_dir_all(local_dir).await.unwrap();
         let store = LocalFileSystem::new_with_prefix(local_dir).expect("Failed to initialize filesystem object store");
-
         let path = Path::from(metadata_relative_location);
-
         let json_data = serde_json::to_string(&table.metadata).unwrap();
-
-        // The content to be written to the file
         let content = Bytes::from(json_data);
-
-        // Writing the content to the file
         store.put(&path, PutPayload::from(content)).await.expect("Failed to write file");
 
         Ok(table)

--- a/crates/catalog/src/service.rs
+++ b/crates/catalog/src/service.rs
@@ -111,6 +111,9 @@ impl Catalog for CatalogImpl {
             .map(TableRequirementExt::new)
             .try_for_each(|req| req.assert(&table.metadata, true))?;
 
+        // TODO rewrite metadata file? need to research when metadata rewrite is needed
+        // Currently the metadata file is only written once - during table creation
+
         let mut builder =
             TableMetadataBuilder::new_from_metadata(table.metadata, Some(table.metadata_location.clone()));
 

--- a/crates/control_plane/src/service.rs
+++ b/crates/control_plane/src/service.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use datafusion::prelude::*;
 use iceberg_catalog_rest::{RestCatalog, RestCatalogConfig};
 use iceberg_datafusion::IcebergCatalogProvider;
+use datafusion::catalog_common::CatalogProvider;
 use std::collections::HashMap;
 
 #[async_trait]
@@ -110,10 +111,14 @@ impl ControlService for ControlServiceImpl {
 
         let catalog = RestCatalog::new(config);
 
-        // TODO need manifest file written before the code below works
-        // let catalog = IcebergCatalogProvider::try_new(Arc::new(catalog))
-        //     .await
-        //     .unwrap();
+        let catalog = IcebergCatalogProvider::try_new(Arc::new(catalog))
+            .await
+            .unwrap();
+
+        // Test that catalog loaded successfully
+        println!("SCHEMAS: {:?}", catalog.schema_names());
+
+        // TODO rest of the query code
 
         Ok(("OK"))
     }


### PR DESCRIPTION
Now when the table is created - the metadata file is written using `object_store` to the filesystem. Because we use `object_store` interface, this could be easily extended to s3.
In the `query_table` method we now successfully init the catalog using iceberg-rust library, that reads the metadata file.
In the following PRs I will continue implementing querying functionality and whatever is missing in our catalog.

This is how I write the metadata file:
<img width="585" alt="Screenshot 2024-10-26 at 16 25 01" src="https://github.com/user-attachments/assets/eb7cdc7a-635e-43a3-b226-f800ae0b2509">
