### PR TITLE
Fix tables relations

### DIFF
--- a/crates/control_plane/src/sql/functions/convert_timezone.rs
+++ b/crates/control_plane/src/sql/functions/convert_timezone.rs
@@ -1,0 +1,95 @@
+use arrow::array::Array;
+use arrow::datatypes::DataType::{Date32, Date64, Time32, Time64, Timestamp, Utf8};
+use arrow::datatypes::TimeUnit::{Microsecond, Millisecond, Nanosecond, Second};
+use arrow::datatypes::{DataType, Fields};
+use datafusion::common::{plan_err, Result};
+use datafusion::logical_expr::TypeSignature::Exact;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarUDFImpl, Signature, Volatility, TIMEZONE_WILDCARD,
+};
+use std::any::Any;
+
+#[derive(Debug)]
+pub struct ConvertTimezoneFunc {
+    signature: Signature,
+    aliases: Vec<String>,
+}
+
+impl Default for ConvertTimezoneFunc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConvertTimezoneFunc {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    Exact(vec![Utf8, Date32]),
+                    Exact(vec![Utf8, Date64]),
+                    Exact(vec![Utf8, Time32(Second)]),
+                    Exact(vec![Utf8, Time32(Nanosecond)]),
+                    Exact(vec![Utf8, Time32(Microsecond)]),
+                    Exact(vec![Utf8, Time32(Millisecond)]),
+                    Exact(vec![Utf8, Time64(Second)]),
+                    Exact(vec![Utf8, Time64(Nanosecond)]),
+                    Exact(vec![Utf8, Time64(Microsecond)]),
+                    Exact(vec![Utf8, Time64(Millisecond)]),
+                    Exact(vec![Utf8, Timestamp(Second, None)]),
+                    Exact(vec![Utf8, Timestamp(Millisecond, None)]),
+                    Exact(vec![Utf8, Timestamp(Microsecond, None)]),
+                    Exact(vec![Utf8, Timestamp(Nanosecond, None)]),
+                    Exact(vec![
+                        Utf8,
+                        Timestamp(Second, Some(TIMEZONE_WILDCARD.into())),
+                    ]),
+                    Exact(vec![
+                        Utf8,
+                        Timestamp(Millisecond, Some(TIMEZONE_WILDCARD.into())),
+                    ]),
+                    Exact(vec![
+                        Utf8,
+                        Timestamp(Microsecond, Some(TIMEZONE_WILDCARD.into())),
+                    ]),
+                    Exact(vec![
+                        Utf8,
+                        Timestamp(Nanosecond, Some(TIMEZONE_WILDCARD.into())),
+                    ]),
+                ],
+                Volatility::Immutable,
+            ),
+            aliases: vec![String::from("convert_timezone")],
+        }
+    }
+}
+
+impl ScalarUDFImpl for ConvertTimezoneFunc {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "convert_timezone"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        //two or three
+        if arg_types.len() != 2 {
+            return plan_err!("function requires three arguments");
+        }
+        Ok(arg_types[1].clone())
+    }
+    //TODO: FIX general logic
+    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
+        if args.len() != 2 {
+            return plan_err!("function requires three arguments");
+        }
+
+        Ok(args[1].clone())
+    }
+}

--- a/crates/control_plane/src/sql/functions/date_add.rs
+++ b/crates/control_plane/src/sql/functions/date_add.rs
@@ -83,22 +83,22 @@ impl DateAddFunc {
     fn add_years(val: &ScalarValue, years: i64) -> Result<ColumnarValue> {
         Ok(ColumnarValue::Scalar(
             val.add(ScalarValue::new_interval_ym(i32::try_from(years)
-            .unwrap_or(0), 0)
-        ).unwrap_or(ScalarValue::new_interval_ym(0, 0))
+                                                     .unwrap_or(0), 0)
+            ).unwrap_or(ScalarValue::new_interval_ym(0, 0))
         ))
     }
     fn add_months(val: &ScalarValue, months: i64) -> Result<ColumnarValue> {
         Ok(ColumnarValue::Scalar(
             val.add(ScalarValue::new_interval_ym(0, i32::try_from(months)
-            .unwrap_or(0))
-        ).unwrap_or(ScalarValue::new_interval_ym(0, 0))
+                .unwrap_or(0))
+            ).unwrap_or(ScalarValue::new_interval_ym(0, 0))
         ))
     }
     fn add_days(val: &ScalarValue, days: i64) -> Result<ColumnarValue> {
         Ok(ColumnarValue::Scalar(
             val.add(ScalarValue::new_interval_dt(i32::try_from(days)
-            .unwrap_or(0), 0)
-        ).unwrap_or(ScalarValue::new_interval_dt(0, 0))
+                                                     .unwrap_or(0), 0)
+            ).unwrap_or(ScalarValue::new_interval_dt(0, 0))
         ))
     }
 }
@@ -163,6 +163,7 @@ impl ScalarUDFImpl for DateAddFunc {
         };
         let date_or_time_expr = match &args[2] {
             ColumnarValue::Scalar(val) => val.clone(),
+            ColumnarValue::Array(array) => ScalarValue::try_from_array(&array, 0)?,
             _ => return plan_err!("Invalid datetime type"),
         };
         //there shouldn't be overflows

--- a/crates/control_plane/src/sql/functions/date_add.rs
+++ b/crates/control_plane/src/sql/functions/date_add.rs
@@ -85,8 +85,7 @@ impl DateAddFunc {
             val.add(ScalarValue::new_interval_ym(
                 i32::try_from(years).unwrap_or(0),
                 0,
-            ))
-                .unwrap_or(ScalarValue::new_interval_ym(0, 0)),
+            )).unwrap_or(ScalarValue::new_interval_ym(0, 0)),
         ))
     }
     fn add_months(val: &ScalarValue, months: i64) -> Result<ColumnarValue> {
@@ -94,8 +93,7 @@ impl DateAddFunc {
             val.add(ScalarValue::new_interval_ym(
                 0,
                 i32::try_from(months).unwrap_or(0),
-            ))
-                .unwrap_or(ScalarValue::new_interval_ym(0, 0)),
+            )).unwrap_or(ScalarValue::new_interval_ym(0, 0)),
         ))
     }
     fn add_days(val: &ScalarValue, days: i64) -> Result<ColumnarValue> {
@@ -103,8 +101,7 @@ impl DateAddFunc {
             val.add(ScalarValue::new_interval_dt(
                 i32::try_from(days).unwrap_or(0),
                 0,
-            ))
-                .unwrap_or(ScalarValue::new_interval_dt(0, 0)),
+            )).unwrap_or(ScalarValue::new_interval_dt(0, 0)),
         ))
     }
 }

--- a/crates/control_plane/src/sql/functions/date_add.rs
+++ b/crates/control_plane/src/sql/functions/date_add.rs
@@ -82,23 +82,29 @@ impl DateAddFunc {
     }
     fn add_years(val: &ScalarValue, years: i64) -> Result<ColumnarValue> {
         Ok(ColumnarValue::Scalar(
-            val.add(ScalarValue::new_interval_ym(i32::try_from(years)
-                                                     .unwrap_or(0), 0)
-            ).unwrap_or(ScalarValue::new_interval_ym(0, 0))
+            val.add(ScalarValue::new_interval_ym(
+                i32::try_from(years).unwrap_or(0),
+                0,
+            ))
+                .unwrap_or(ScalarValue::new_interval_ym(0, 0)),
         ))
     }
     fn add_months(val: &ScalarValue, months: i64) -> Result<ColumnarValue> {
         Ok(ColumnarValue::Scalar(
-            val.add(ScalarValue::new_interval_ym(0, i32::try_from(months)
-                .unwrap_or(0))
-            ).unwrap_or(ScalarValue::new_interval_ym(0, 0))
+            val.add(ScalarValue::new_interval_ym(
+                0,
+                i32::try_from(months).unwrap_or(0),
+            ))
+                .unwrap_or(ScalarValue::new_interval_ym(0, 0)),
         ))
     }
     fn add_days(val: &ScalarValue, days: i64) -> Result<ColumnarValue> {
         Ok(ColumnarValue::Scalar(
-            val.add(ScalarValue::new_interval_dt(i32::try_from(days)
-                                                     .unwrap_or(0), 0)
-            ).unwrap_or(ScalarValue::new_interval_dt(0, 0))
+            val.add(ScalarValue::new_interval_dt(
+                i32::try_from(days).unwrap_or(0),
+                0,
+            ))
+                .unwrap_or(ScalarValue::new_interval_dt(0, 0)),
         ))
     }
 }
@@ -169,30 +175,40 @@ impl ScalarUDFImpl for DateAddFunc {
         //there shouldn't be overflows
         match date_or_time_part.as_str() {
             //should consider leap year (365-366 days)
-            "year" | "y" | "yy" | "yyy" | "yyyy" | "yr" | "years" => DateAddFunc::add_years(
-                &date_or_time_expr, value),
+            "year" | "y" | "yy" | "yyy" | "yyyy" | "yr" | "years" => {
+                DateAddFunc::add_years(&date_or_time_expr, value)
+            }
             //should consider months 28-31 days
-            "month" | "mm" | "mon" | "mons" | "months" => DateAddFunc::add_months(
-                &date_or_time_expr, value),
-            "day" | "d" | "dd" | "days" | "dayofmonth" => DateAddFunc::add_days(
-                &date_or_time_expr, value),
-            "week" | "w" | "wk" | "weekofyear" | "woy" | "wy" => DateAddFunc::add_days(
-                &date_or_time_expr, value * 7),
+            "month" | "mm" | "mon" | "mons" | "months" => {
+                DateAddFunc::add_months(&date_or_time_expr, value)
+            }
+            "day" | "d" | "dd" | "days" | "dayofmonth" => {
+                DateAddFunc::add_days(&date_or_time_expr, value)
+            }
+            "week" | "w" | "wk" | "weekofyear" | "woy" | "wy" => {
+                DateAddFunc::add_days(&date_or_time_expr, value * 7)
+            }
             //should consider months 28-31 days
-            "quarter" | "q" | "qtr" | "qtrs" | "quarters" => DateAddFunc::add_months(
-                &date_or_time_expr, value * 3),
-            "hour" | "h" | "hh" | "hr" | "hours" | "hrs" => DateAddFunc::add_nanoseconds(
-                &date_or_time_expr, value * 3_600_000_000_000),
-            "minute" | "m" | "mi" | "min" | "minutes" | "mins" => DateAddFunc::add_nanoseconds(
-                &date_or_time_expr, value * 60_000_000_000),
-            "second" | "s" | "sec" | "seconds" | "secs" => DateAddFunc::add_nanoseconds(
-                &date_or_time_expr, value * 1_000_000_000),
-            "millisecond" | "ms" | "msec" | "milliseconds" => DateAddFunc::add_nanoseconds(
-                &date_or_time_expr, value * 1_000_000),
-            "microsecond" | "us" | "usec" | "microseconds" => DateAddFunc::add_nanoseconds(
-                &date_or_time_expr, value * 1000),
-            "nanosecond" | "ns" | "nsec" | "nanosec" | "nsecond" | "nanoseconds" | "nanosecs" | "nseconds" =>
-                DateAddFunc::add_nanoseconds(&date_or_time_expr, value),
+            "quarter" | "q" | "qtr" | "qtrs" | "quarters" => {
+                DateAddFunc::add_months(&date_or_time_expr, value * 3)
+            }
+            "hour" | "h" | "hh" | "hr" | "hours" | "hrs" => {
+                DateAddFunc::add_nanoseconds(&date_or_time_expr, value * 3_600_000_000_000)
+            }
+            "minute" | "m" | "mi" | "min" | "minutes" | "mins" => {
+                DateAddFunc::add_nanoseconds(&date_or_time_expr, value * 60_000_000_000)
+            }
+            "second" | "s" | "sec" | "seconds" | "secs" => {
+                DateAddFunc::add_nanoseconds(&date_or_time_expr, value * 1_000_000_000)
+            }
+            "millisecond" | "ms" | "msec" | "milliseconds" => {
+                DateAddFunc::add_nanoseconds(&date_or_time_expr, value * 1_000_000)
+            }
+            "microsecond" | "us" | "usec" | "microseconds" => {
+                DateAddFunc::add_nanoseconds(&date_or_time_expr, value * 1000)
+            }
+            "nanosecond" | "ns" | "nsec" | "nanosec" | "nsecond" | "nanoseconds" | "nanosecs"
+            | "nseconds" => DateAddFunc::add_nanoseconds(&date_or_time_expr, value),
             _ => return plan_err!("Invalid date_or_time_part type"),
         }
     }

--- a/crates/control_plane/src/sql/functions/mod.rs
+++ b/crates/control_plane/src/sql/functions/mod.rs
@@ -5,3 +5,4 @@ pub mod date_add;
 pub mod greatest;
 pub mod greatest_least_utils;
 pub mod least;
+pub mod convert_timezone;

--- a/crates/control_plane/src/sql/sql.rs
+++ b/crates/control_plane/src/sql/sql.rs
@@ -85,7 +85,6 @@ impl SqlExecutor {
         let re = regex::Regex::new(r"(\w+)\[(\d+)]\.(\w+)").unwrap();
         let date_add = regex::Regex::new(r"(date|time|timestamp)(_?add)\(\s*([a-zA-Z]+),").unwrap();
 
-        // Replace what is not supported by sql parser
         let query = re
             .replace_all(query, "json_get(json_get($1, $2), '$3')")
             .to_string();

--- a/crates/control_plane/src/sql/sql.rs
+++ b/crates/control_plane/src/sql/sql.rs
@@ -1,5 +1,6 @@
 use crate::models::created_entity_response;
 use crate::sql::context::CustomContextProvider;
+use crate::sql::functions::convert_timezone::ConvertTimezoneFunc;
 use crate::sql::functions::date_add::DateAddFunc;
 use crate::sql::functions::greatest::GreatestFunc;
 use crate::sql::functions::least::LeastFunc;
@@ -16,8 +17,8 @@ use datafusion::logical_expr::sqlparser::ast::Insert;
 use datafusion::logical_expr::{LogicalPlan, ScalarUDF};
 use datafusion::sql::parser::Statement as DFStatement;
 use datafusion::sql::sqlparser::ast::{
-    CreateTable as CreateTableStatement, Ident, ObjectName, Query, SchemaName, Statement,
-    TableFactor, TableWithJoins,
+    CreateTable as CreateTableStatement, Expr, Ident, ObjectName, Query, SchemaName,
+    Statement, TableFactor, TableWithJoins,
 };
 use datafusion_functions_json::register_all;
 use datafusion_iceberg::catalog::catalog::IcebergCatalog;
@@ -41,6 +42,7 @@ impl SqlExecutor {
         ctx.register_udf(ScalarUDF::from(DateAddFunc::new()));
         ctx.register_udf(ScalarUDF::from(LeastFunc::new()));
         ctx.register_udf(ScalarUDF::from(GreatestFunc::new()));
+        ctx.register_udf(ScalarUDF::from(ConvertTimezoneFunc::new()));
         register_all(&mut ctx).expect("Cannot register UDF JSON funcs");
         Self { ctx }
     }
@@ -81,7 +83,9 @@ impl SqlExecutor {
     pub fn preprocess_query(&self, query: &String) -> String {
         // Replace field[0].subfield -> json_get(json_get(field, 0), 'subfield')
         let re = regex::Regex::new(r"(\w+)\[(\d+)]\.(\w+)").unwrap();
-        let date_add = regex::Regex::new(r"(date|time|timestamp)(_?add)\(([a-zA-Z]+),").unwrap();
+        let date_add = regex::Regex::new(r"(date|time|timestamp)(_?add)\(\s*([a-zA-Z]+),").unwrap();
+
+        // Replace what is not supported by sql parser
         let query = re
             .replace_all(query, "json_get(json_get($1, $2), '$3')")
             .to_string();
@@ -126,7 +130,7 @@ impl SqlExecutor {
             let updated_query = modified_statement.to_string();
 
             // Get schema of new table
-            let plan = self.get_custom_logical_plan(&updated_query, "").await?;
+            let plan = self.get_custom_logical_plan(&updated_query, warehouse_name).await?;
             self.ctx
                 .execute_logical_plan(plan.clone())
                 .await?
@@ -377,6 +381,19 @@ impl SqlExecutor {
                     self.update_tables_in_query(query.as_mut(), warehouse_name);
                     DFStatement::Statement(Box::new(Statement::Query(query)))
                 }
+                Statement::CreateTable(create_table_statement) => {
+                    if create_table_statement.query.is_some() {
+                        let mut query = create_table_statement.query.unwrap().clone();
+                        self.update_tables_in_query(&mut query, warehouse_name);
+                        let modified_statement = CreateTableStatement {
+                            query: Some(query),
+                            ..create_table_statement
+                        };
+                        DFStatement::Statement(Box::new(Statement::CreateTable(modified_statement)))
+                    } else {
+                        statement
+                    }
+                }
                 _ => statement,
             }
         } else {
@@ -390,7 +407,9 @@ impl SqlExecutor {
         mut table_name: Vec<Ident>,
         warehouse_name: &str,
     ) -> Vec<Ident> {
-        if warehouse_name.len() > 0 && !table_name.starts_with(&[Ident::new(warehouse_name)]) {
+        if warehouse_name.len() > 0
+            && !table_name.starts_with(&[Ident::new(warehouse_name)])
+            && table_name.len() > 1 {
             table_name.insert(0, Ident::new(warehouse_name));
         }
         if table_name.len() > 3 {
@@ -420,9 +439,29 @@ impl SqlExecutor {
                 for table_with_joins in &mut select.from {
                     self.update_tables_in_table_with_joins(table_with_joins, warehouse_name);
                 }
+
+                for expr in &mut select.selection {
+                    self.update_tables_in_expr(expr, warehouse_name);
+                }
             }
             datafusion::sql::sqlparser::ast::SetExpr::Query(q) => {
                 self.update_tables_in_query(q, warehouse_name);
+            }
+            _ => {}
+        }
+    }
+
+    fn update_tables_in_expr(&self, expr: &mut Expr, warehouse_name: &str) {
+        match expr {
+            Expr::BinaryOp { left, right, .. } => {
+                self.update_tables_in_expr(left, warehouse_name);
+                self.update_tables_in_expr(right, warehouse_name);
+            }
+            Expr::Subquery(q) => {
+                self.update_tables_in_query(q, warehouse_name);
+            }
+            Expr::Exists { subquery, .. } => {
+                self.update_tables_in_query(subquery, warehouse_name);
             }
             _ => {}
         }

--- a/crates/nexus/src/http/ui/handlers/tables.rs
+++ b/crates/nexus/src/http/ui/handlers/tables.rs
@@ -5,7 +5,7 @@ use crate::http::ui::models::properties::{
 };
 use crate::http::ui::models::table::{
     Table, TableCreatePayload, TableQueryRequest, TableQueryResponse, TableRegisterRequest,
-    TableUploadPayload
+    TableUploadPayload,
 };
 use crate::http::utils::get_default_properties;
 use crate::state::AppState;
@@ -428,7 +428,10 @@ pub async fn upload_data_to_table(
             continue;
         }
         let file_name = field.file_name().unwrap().to_string();
-        let data = field.bytes().await.unwrap();
+        let data = field.bytes().await.map_err(|e| {
+            let fmt = format!("{}: failed to read the file", e);
+            AppError::new(e, fmt.as_str())
+        })?;
 
         let _result = state
             .control_svc

--- a/crates/nexus/src/http/ui/models/errors.rs
+++ b/crates/nexus/src/http/ui/models/errors.rs
@@ -1,3 +1,4 @@
+use axum::extract::multipart::MultipartError;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use catalog::error::Error as CatalogError;
@@ -58,7 +59,9 @@ impl IntoResponse for AppError {
             AppError::InternalServerError(ref _e) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }
-            AppError::InvalidCredentials(ref _e) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
+            AppError::InvalidCredentials(ref _e) => {
+                (StatusCode::UNPROCESSABLE_ENTITY, self.to_string())
+            }
             AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
             AppError::UnprocessableEntity(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg),
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
@@ -92,5 +95,11 @@ impl From<CatalogError> for AppError {
             CatalogError::IcebergError(e) => AppError::IcebergError(e.to_string()),
             _ => AppError::InternalServerError(e.to_string()),
         }
+    }
+}
+
+impl From<MultipartError> for AppError {
+    fn from(e: MultipartError) -> Self {
+        AppError::InternalServerError(e.to_string())
     }
 }

--- a/crates/nexus/src/http/ui/router.rs
+++ b/crates/nexus/src/http/ui/router.rs
@@ -11,6 +11,7 @@ use crate::http::ui::handlers::warehouses::{
     create_warehouse, delete_warehouse, get_warehouse, list_warehouses, navigation,
 };
 use crate::state::AppState;
+use axum::extract::DefaultBodyLimit;
 use axum::routing::{delete, get, post};
 use axum::Router;
 use tower_http::sensitive_headers::SetSensitiveHeadersLayer;
@@ -83,4 +84,5 @@ pub fn create_router() -> Router<AppState> {
             axum::http::header::AUTHORIZATION,
         ]))
         .layer(axum::middleware::from_fn(add_request_metadata))
+        .layer(DefaultBodyLimit::disable())
 }

--- a/crates/nexus/src/main.rs
+++ b/crates/nexus/src/main.rs
@@ -243,6 +243,7 @@ where
     };
 
     if let Ok(body) = std::str::from_utf8(&bytes) {
+        // Skip upload endpoint logs as they can be large
         if !uri.contains("upload") {
             tracing::debug!("{direction} {method} {uri} body = {body}");
         }

--- a/crates/nexus/src/main.rs
+++ b/crates/nexus/src/main.rs
@@ -183,7 +183,7 @@ async fn shutdown_signal(db: Arc<Db>) {
     let terminate = async {
         signal::unix::signal(signal::unix::SignalKind::terminate())
             .expect("failed to install signal handler")
-            .recv() 
+            .recv()
             .await;
     };
 
@@ -243,7 +243,9 @@ where
     };
 
     if let Ok(body) = std::str::from_utf8(&bytes) {
-        tracing::debug!("{direction} {method} {uri} body = {body:?}");
+        if !uri.contains("upload") {
+            tracing::debug!("{direction} {method} {uri} body = {body}");
+        }
     }
 
     Ok(bytes)


### PR DESCRIPTION
- added convert_timezone stub to unblock sql queries
- added additional logic to fix table names
```sql
CREATE OR REPLACE TABLE snowplow_web_base_sessions_lifecycle_manifest AS (SELECT * FROM (WITH new_events_session_ids_init AS (SELECT COALESCE(e.domain_sessionid, NULL) AS session_identifier, max(COALESCE(e.domain_userid, NULL)) AS user_identifier, min(collector_tstamp) AS start_tstamp, max(collector_tstamp) AS end_tstamp FROM embucket.datasets.events AS e WHERE dvce_sent_tstamp <= dateadd('day', 3, dvce_created_tstamp) AND collector_tstamp >= CAST('2022-08-19 00:00:00' AS TIMESTAMP) AND collector_tstamp <= CAST('2022-09-18 00:00:00' AS TIMESTAMP) AND true AND true GROUP BY 1), new_events_session_ids AS (SELECT * FROM new_events_session_ids_init AS e WHERE session_identifier IS NOT NULL AND NOT EXISTS (SELECT 1 FROM datasets.public_snowplow_manifest.snowplow_web_base_quarantined_sessions AS a WHERE a.session_identifier = e.session_identifier)), session_lifecycle AS (SELECT * FROM new_events_session_ids) SELECT sl.session_identifier, sl.user_identifier, sl.start_tstamp, least(dateadd('day', 3, sl.start_tstamp), sl.end_tstamp) AS end_tstamp FROM session_lifecycle AS sl) ORDER BY (to_date(start_tstamp)))
```
table identifier should be fixed from 
datasets.public_snowplow_manifest.snowplow_web_base_quarantined_sessions to **embucket.datasets.public_snowplow_manifest.snowplow_web_base_quarantined_sessions**
- disabled size limit for CSV files for upload 