### PR TITLE
Update iceberg-rust version

### DIFF
--- a/crates/control_plane/Cargo.toml
+++ b/crates/control_plane/Cargo.toml
@@ -14,9 +14,9 @@ futures = { workspace = true }
 serde = { workspace = true }
 datafusion = { workspace = true }
 flatbuffers = { version = "24.3.25" }
-iceberg-rust = { git = "https://github.com/JanKaul/iceberg-rust.git", rev = "4f1bd30" }
-iceberg-rest-catalog = { git = "https://github.com/JanKaul/iceberg-rust.git", rev = "4f1bd30" }
-datafusion_iceberg = { git = "https://github.com/JanKaul/iceberg-rust.git", rev = "4f1bd30" }
+iceberg-rust = { git = "https://github.com/JanKaul/iceberg-rust.git", rev = "836f11f" }
+iceberg-rest-catalog = { git = "https://github.com/JanKaul/iceberg-rust.git", rev = "836f11f" }
+datafusion_iceberg = { git = "https://github.com/JanKaul/iceberg-rust.git", rev = "836f11f" }
 arrow = { version = "53" }
 arrow-json = { version = "53" }
 datafusion-functions-json = { version = "0.43.0" }

--- a/crates/control_plane/src/models/mod.rs
+++ b/crates/control_plane/src/models/mod.rs
@@ -3,7 +3,7 @@ use arrow::array::{RecordBatch, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 use chrono::{NaiveDateTime, Utc};
 use dotenv::dotenv;
-use iceberg_rust::catalog::bucket::ObjectStoreBuilder;
+use iceberg_rust::object_store::ObjectStoreBuilder;
 use object_store::aws::AmazonS3Builder;
 use object_store::local::LocalFileSystem;
 use object_store::ObjectStore;


### PR DESCRIPTION
Update to a newer version of iceberg-rust where dict_id no longer breaks the schema.
It was fixed in this PR: https://github.com/JanKaul/iceberg-rust/commit/393f008b6c952403ee90760b654d03fc9673bf8c
