### PR TITLE
Skip iceberg related keywords

### DIFF
--- a/crates/runtime/src/datafusion/execution.rs
+++ b/crates/runtime/src/datafusion/execution.rs
@@ -1091,8 +1091,17 @@ impl SqlExecutor {
                         #[allow(clippy::unwrap_used)]
                         let mut query = create_table_statement.query.unwrap();
                         self.update_tables_in_query(&mut query, warehouse_name);
+                        // TODO: Removing all iceberg properties is temporary solution. It should be
+                        // implemented properly in future.
+                        // https://github.com/Embucket/control-plane-v2/issues/199
                         let modified_statement = CreateTableStatement {
                             query: Some(query),
+                            iceberg: false,
+                            base_location: None,
+                            external_volume: None,
+                            catalog: None,
+                            catalog_sync: None,
+                            storage_serialization_policy: None,
                             ..create_table_statement
                         };
                         DFStatement::Statement(Box::new(Statement::CreateTable(modified_statement)))


### PR DESCRIPTION
I decided to skip all iceberg-related keywords because we are not using them now. 
It unblocks the current "create iceberg table" behavior. 