### PR TITLE
Preprocess ALTER ICEBERG TABLE

### DIFF
--- a/crates/runtime/src/datafusion/execution.rs
+++ b/crates/runtime/src/datafusion/execution.rs
@@ -171,6 +171,10 @@ impl SqlExecutor {
             .to_string();
         let query = date_add.replace_all(&query, "$1$2('$3',").to_string();
         // TODO implement alter session logic
+        let alter_iceberg_table = regex::Regex::new(r"alter\s+iceberg\s+table").unwrap();
+        let query = alter_iceberg_table
+            .replace_all(&query, "alter table")
+            .to_string();
         query
             .replace(
                 "alter session set query_tag = 'snowplow_dbt'",


### PR DESCRIPTION
I have no idea how did this work previously... Feel free to point me to actual broken code.
Most recent main fails to process `ALTER ICEBERG TABLE` by failing with `ParserError: Expected TABLE, VIEW, INDEX...`