### PR TITLE
Add partial support of arrow format for dbt/snowflake endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ snafu = { version = "0.8.5", features = ["futures"] }
 tracing = { version = "0.1" }
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ snafu = { version = "0.8.5", features = ["futures"] }
 tracing = { version = "0.1" }
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "2950e0be59f81fbd6593f7457f1f03e63a292820" }
+datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/crates/control_plane/Cargo.toml
+++ b/crates/control_plane/Cargo.toml
@@ -13,20 +13,20 @@ bytes = { version = "1.8.0" }
 
 chrono = { workspace = true }
 
-datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
-datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
-datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
-datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
+datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
+datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
+datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
 
 flatbuffers = { version = "24.3.25" }
 futures = { workspace = true }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d76a0ecc4ebaa2bfc5178e6589f76dc5d71c67" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d76a0ecc4ebaa2bfc5178e6589f76dc5d71c67" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d76a0ecc4ebaa2bfc5178e6589f76dc5d71c67" }
 
 icelake = { git = "https://github.com/Embucket/icelake.git", rev = "b4cbcaf" }
 
-datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "1cbcd2bffa2c5b56add996859d02053fd4bc21fc" }
+datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "86f5294d30b7bf53fbcb2e25dee409ad818b34cc" }
 
 object_store = { workspace = true }
 once_cell = "1.19.0"

--- a/crates/control_plane/Cargo.toml
+++ b/crates/control_plane/Cargo.toml
@@ -13,16 +13,20 @@ bytes = { version = "1.8.0" }
 
 chrono = { workspace = true }
 
-datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "2950e0be59f81fbd6593f7457f1f03e63a292820" }
-datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "2950e0be59f81fbd6593f7457f1f03e63a292820" }
-datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "2950e0be59f81fbd6593f7457f1f03e63a292820" }
-datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "a5bbbd1266447c26f3bfdb5314b4a326796bc784" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f2fef1d973f59309919d60aaaa32e83e04029d6d" }
+datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
 flatbuffers = { version = "24.3.25" }
 futures = { workspace = true }
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f2fef1d973f59309919d60aaaa32e83e04029d6d" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f2fef1d973f59309919d60aaaa32e83e04029d6d" }
+
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
 icelake = { git = "https://github.com/Embucket/icelake.git", rev = "b4cbcaf" }
+
+datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "1cbcd2bffa2c5b56add996859d02053fd4bc21fc" }
 
 object_store = { workspace = true }
 once_cell = "1.19.0"

--- a/crates/control_plane/Cargo.toml
+++ b/crates/control_plane/Cargo.toml
@@ -18,12 +18,12 @@ datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = 
 datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
 datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
 
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
 flatbuffers = { version = "24.3.25" }
 futures = { workspace = true }
-
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
 iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
+
 icelake = { git = "https://github.com/Embucket/icelake.git", rev = "b4cbcaf" }
 
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "1cbcd2bffa2c5b56add996859d02053fd4bc21fc" }

--- a/crates/nexus/Cargo.toml
+++ b/crates/nexus/Cargo.toml
@@ -54,6 +54,7 @@ utoipa-axum = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 uuid = { workspace = true, features = ["v4", "v5"] }
 validator = { version = "0.18.1", features = ["derive"] }
+base64 = { version = "0.22.1" }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/crates/nexus/src/http/dbt/handlers.rs
+++ b/crates/nexus/src/http/dbt/handlers.rs
@@ -25,7 +25,7 @@ use tracing::debug;
 use uuid::Uuid;
 
 // TODO: move out as a configurable parameter
-const SERIALIZATION_FORMAT: &str = "arrow"; // or "json"
+const SERIALIZATION_FORMAT: &str = "json"; // or "arrow"
 
 // https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
 // Buffer Alignment and Padding: Implementations are recommended to allocate memory 

--- a/crates/nexus/src/http/dbt/handlers.rs
+++ b/crates/nexus/src/http/dbt/handlers.rs
@@ -5,15 +5,27 @@ use crate::http::dbt::schemas::{
 };
 use crate::http::session::DFSessionId;
 use crate::state::AppState;
+use arrow::ipc::writer::{IpcWriteOptions, StreamWriter};
+use arrow::ipc::MetadataVersion;
+use arrow::json::writer::JsonArray;
+use arrow::json::WriterBuilder;
+use arrow::record_batch::RecordBatch;
 use axum::body::Bytes;
 use axum::extract::{Query, State};
 use axum::http::HeaderMap;
 use axum::Json;
+use base64;
+use base64::engine::general_purpose::STANDARD as engine_base64;
+use base64::prelude::*;
 use flate2::read::GzDecoder;
 use regex::Regex;
 use snafu::ResultExt;
 use std::io::Read;
+use tracing::debug;
 use uuid::Uuid;
+
+const SERIALIZATION_FORMAT: &str = "arrow"; // or "json"
+const ARROW_IPC_ALIGNMENT: usize = 8;
 
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
 pub async fn login(
@@ -32,8 +44,6 @@ pub async fn login(
     let _body_json: LoginRequestBody =
         serde_json::from_str(&s).context(dbt_error::LoginRequestParseSnafu)?;
 
-    //println!("Received login request: {:?}", query);
-    //println!("Body data parameters: {:?}", body_json);
     let token = Uuid::new_v4().to_string();
 
     let warehouses = state
@@ -54,6 +64,37 @@ pub async fn login(
         success: true,
         message: Option::from("successfully executed".to_string()),
     }))
+}
+
+fn records_to_arrow_string(recs: &Vec<RecordBatch>) -> Result<String, DbtError> {
+    let mut buf = Vec::new();
+    let options = IpcWriteOptions::try_new(ARROW_IPC_ALIGNMENT, false, MetadataVersion::V5)
+        .context(dbt_error::ArrowSnafu)?;
+    if !recs.is_empty() {
+        let mut writer =
+            StreamWriter::try_new_with_options(&mut buf, recs[0].schema_ref(), options)
+                .context(dbt_error::ArrowSnafu)?;
+        for rec in recs {
+            writer.write(rec).context(dbt_error::ArrowSnafu)?;
+        }
+        writer.finish().context(dbt_error::ArrowSnafu)?;
+        drop(writer);
+    };
+    Ok(engine_base64.encode(buf))
+}
+
+fn records_to_json_string(recs: &[RecordBatch]) -> Result<String, DbtError> {
+    let buf = Vec::new();
+    let write_builder = WriterBuilder::new().with_explicit_nulls(true);
+    let mut writer = write_builder.build::<_, JsonArray>(buf);
+    let record_refs: Vec<&RecordBatch> = recs.iter().collect();
+    writer
+        .write_batches(&record_refs)
+        .context(dbt_error::ArrowSnafu)?;
+    writer.finish().context(dbt_error::ArrowSnafu)?;
+
+    // Get the underlying buffer back,
+    String::from_utf8(writer.into_inner()).context(dbt_error::Utf8Snafu)
 }
 
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
@@ -86,30 +127,44 @@ pub async fn query(
 
     // let _ = log_query(&body_json.sql_text).await;
 
-    let (result, columns) = state
+    let (records, columns) = state
         .control_svc
-        .query_dbt(&session_id, &body_json.sql_text)
+        .query(&session_id, &body_json.sql_text)
+
         .await
         .context(dbt_error::ControlServiceSnafu)?;
 
-    // query_result_format now is JSON since arrow IPC has flatbuffers bug
-    // https://github.com/apache/arrow-rs/pull/6426
-    Ok(Json(JsonResponse {
+    debug!("serialized json: {}", records_to_json_string(&records)?.as_str());
+
+    let json_resp = Json(JsonResponse {
         data: Option::from(ResponseData {
             row_type: columns.into_iter().map(Into::into).collect(),
-            // row_set_base_64: Option::from(result.clone()),
-            row_set_base_64: None,
-            #[allow(clippy::unwrap_used)]
-            row_set: ResponseData::rows_to_vec(result.as_str())?,
+            query_result_format: Option::from(String::from(SERIALIZATION_FORMAT)),
+            row_set: if SERIALIZATION_FORMAT == "json" {
+                Option::from(ResponseData::rows_to_vec(
+                    records_to_json_string(&records)?.as_str(),
+                )?)
+            } else {
+                None
+            },
+            row_set_base_64: if SERIALIZATION_FORMAT == "arrow" {
+                Option::from(records_to_arrow_string(&records)?)
+            } else {
+                None
+            },
             total: Some(1),
-            query_result_format: Option::from("json".to_string()),
             error_code: None,
             sql_state: Option::from("ok".to_string()),
         }),
         success: true,
         message: Option::from("successfully executed".to_string()),
         code: Some(format!("{:06}", 200)),
-    }))
+    });
+    debug!(
+        "query {:?}, response: {:?}, records: {:?}",
+        body_json.sql_text, json_resp, records
+    );
+    Ok(json_resp)
 }
 
 pub async fn abort() -> DbtResult<Json<serde_json::value::Value>> {
@@ -139,3 +194,120 @@ pub fn extract_token(headers: &HeaderMap) -> Option<String> {
     file.write_all(b"\n").await?;
     Ok(())
 }*/
+
+// mod tests {
+//     use std::io::Cursor;
+//     use arrow::record_batch::RecordBatch;
+//     use arrow::ipc::writer::{ FileWriter, StreamWriter, IpcWriteOptions };
+//     use arrow::ipc::reader::{ FileReader, StreamReader };
+//     use arrow::array::{ArrayRef, StringArray, UInt32Array};
+//     use arrow::datatypes::{ Schema, Field, DataType };
+//     use tracing::span::Record;
+//     use std::sync::Arc;
+//     use std::any::Any;
+
+//     // fn roundtrip_ipc_stream(rb: &RecordBatch) -> RecordBatch {
+//     //     let mut buf = Vec::new();
+//     //     let mut writer = StreamWriter::try_new(&mut buf, rb.schema_ref()).unwrap();
+//     //     writer.write(rb).unwrap();
+//     //     writer.finish().unwrap();
+//     //     drop(writer);
+
+//     //     let mut reader = StreamReader::try_new(std::io::Cursor::new(buf), None).unwrap();
+//     //     reader.next().unwrap().unwrap()
+//     // }
+
+//     // if records.len() > 0 {
+//     //     println!("agahaha {:?}", roundtrip_ipc_stream(&records[0]));
+//     // }
+
+//     // Try to add flatbuffer verification
+//     ///////////////////
+//     // let base64 = general_purpose::STANDARD.encode(buffer);
+//     // Ok((base64, columns))
+//     // let encoded = general_purpose::STANDARD.decode(res.clone()).unwrap();
+
+//     // let mut verifier = Verifier::new(&VerifierOptions::default(), &encoded);
+//     // let mut builder = FlatBufferBuilder::new();
+//     // let result = general_purpose::STANDARD.encode(buf);
+//     ///////////////////
+
+//     #[test]
+//     fn test_slice_uint32() {
+//    /// Read/write a record batch to a File and Stream and ensure it is the same at the outout
+//         fn ensure_roundtrip(array: ArrayRef) {
+//             let num_rows = array.len();
+//             let orig_batch = RecordBatch::try_from_iter(vec![("a", array)]).unwrap();
+//             // take off the first element
+//             let sliced_batch = orig_batch.slice(1, num_rows - 1);
+
+//             let schema = orig_batch.schema();
+//             let stream_data = {
+//                 let mut writer = StreamWriter::try_new(vec![], &schema).unwrap();
+//                 writer.write(&sliced_batch).unwrap();
+//                 writer.into_inner().unwrap()
+//             };
+//             let read_batch = {
+//                 let projection = None;
+//                 let mut reader = StreamReader::try_new(Cursor::new(stream_data), projection).unwrap();
+//                 reader
+//                     .next()
+//                     .expect("expect no errors reading batch")
+//                     .expect("expect batch")
+//             };
+//             assert_eq!(sliced_batch, read_batch);
+
+//             let file_data = {
+//                 let mut writer = FileWriter::try_new_buffered(vec![], &schema).unwrap();
+//                 writer.write(&sliced_batch).unwrap();
+//                 writer.into_inner().unwrap().into_inner().unwrap()
+//             };
+//             let read_batch = {
+//                 let projection = None;
+//                 let mut reader = FileReader::try_new(Cursor::new(file_data), projection).unwrap();
+//                 reader
+//                     .next()
+//                     .expect("expect no errors reading batch")
+//                     .expect("expect batch")
+//             };
+//             assert_eq!(sliced_batch, read_batch);
+
+//             // TODO test file writer/reader
+//         }
+
+//         ensure_roundtrip(Arc::new(UInt32Array::from_iter((0..8).map(|i| {
+//             if i % 2 == 0 {
+//                 Some(i)
+//             } else {
+//                 None
+//             }
+//         }))));
+//     }
+
+//     #[test]
+//     fn test_flatbuffer_issue_8150() {
+//         fn roundtrip_ipc_stream(rb: &RecordBatch) -> RecordBatch {
+//             let mut buf = Vec::new();
+//             let mut writer = StreamWriter::try_new(&mut buf, rb.schema_ref()).unwrap();
+//             writer.write(rb).unwrap();
+//             writer.finish().unwrap();
+//             drop(writer);
+
+//             let mut reader = StreamReader::try_new(std::io::Cursor::new(buf), None).unwrap();
+//             reader.next().unwrap().unwrap()
+//         }
+
+//         let schema = Schema::new(vec![
+//             Field::new("hours", DataType::UInt32, true),
+//             Field::new("minutes", DataType::UInt32, true),
+//         ]);
+//         let batch = RecordBatch::try_new(
+//         Arc::new(schema),
+//         vec![
+//                 Arc::new(UInt32Array::from(vec![4, 7, 12, 16])),
+//                 Arc::new(UInt32Array::from(vec![20, 40, 00, 20])),
+//             ]
+//         ).unwrap();
+//         roundtrip_ipc_stream(&batch);
+//     }
+// }

--- a/crates/nexus/src/http/dbt/handlers.rs
+++ b/crates/nexus/src/http/dbt/handlers.rs
@@ -130,11 +130,13 @@ pub async fn query(
     let (records, columns) = state
         .control_svc
         .query(&session_id, &body_json.sql_text)
-
         .await
         .context(dbt_error::ControlServiceSnafu)?;
 
-    debug!("serialized json: {}", records_to_json_string(&records)?.as_str());
+    debug!(
+        "serialized json: {}",
+        records_to_json_string(&records)?.as_str()
+    );
 
     let json_resp = Json(JsonResponse {
         data: Option::from(ResponseData {

--- a/crates/nexus/src/http/dbt/handlers.rs
+++ b/crates/nexus/src/http/dbt/handlers.rs
@@ -28,10 +28,10 @@ use uuid::Uuid;
 const SERIALIZATION_FORMAT: &str = "json"; // or "arrow"
 
 // https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
-// Buffer Alignment and Padding: Implementations are recommended to allocate memory 
-// on aligned addresses (multiple of 8- or 64-bytes) and pad (overallocate) to a 
-// length that is a multiple of 8 or 64 bytes. When serializing Arrow data for interprocess 
-// communication, these alignment and padding requirements are enforced. 
+// Buffer Alignment and Padding: Implementations are recommended to allocate memory
+// on aligned addresses (multiple of 8- or 64-bytes) and pad (overallocate) to a
+// length that is a multiple of 8 or 64 bytes. When serializing Arrow data for interprocess
+// communication, these alignment and padding requirements are enforced.
 // For more info see issue #115
 const ARROW_IPC_ALIGNMENT: usize = 8;
 

--- a/crates/nexus/src/http/dbt/schemas.rs
+++ b/crates/nexus/src/http/dbt/schemas.rs
@@ -85,7 +85,7 @@ pub struct ResponseData {
     #[serde(rename = "rowsetBase64")]
     pub row_set_base_64: Option<String>,
     #[serde(rename = "rowset")]
-    pub row_set: Vec<Vec<serde_json::Value>>,
+    pub row_set: Option<Vec<Vec<serde_json::Value>>>,
     pub total: Option<u32>,
     #[serde(rename = "queryResultFormat")]
     pub query_result_format: Option<String>,

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -15,12 +15,15 @@ chrono = { workspace = true }
 datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
 datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
 datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "1cbcd2bffa2c5b56add996859d02053fd4bc21fc" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
-futures = { workspace = true }
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
 
 iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
+
+futures = { workspace = true }
 object_store = { workspace = true }
 
 paste = "1"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 url = { version = "2.5.4" }
 uuid = { workspace = true }
+datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "567a3f1c806eed61fe9fbcf12a71f3f8ab7faa95" }
 
 [lints]
 workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -12,15 +12,15 @@ async-trait = { workspace = true }
 
 chrono = { workspace = true }
 
-datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "2950e0be59f81fbd6593f7457f1f03e63a292820" }
-datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "2950e0be59f81fbd6593f7457f1f03e63a292820" }
-datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "2950e0be59f81fbd6593f7457f1f03e63a292820" }
-datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "a5bbbd1266447c26f3bfdb5314b4a326796bc784" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f2fef1d973f59309919d60aaaa32e83e04029d6d" }
+datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "1cbcd2bffa2c5b56add996859d02053fd4bc21fc" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
 futures = { workspace = true }
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f2fef1d973f59309919d60aaaa32e83e04029d6d" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
 
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f2fef1d973f59309919d60aaaa32e83e04029d6d" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
 object_store = { workspace = true }
 
 paste = "1"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -39,7 +39,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 url = { version = "2.5.4" }
 uuid = { workspace = true }
-datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "567a3f1c806eed61fe9fbcf12a71f3f8ab7faa95" }
 
 [lints]
 workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -12,16 +12,16 @@ async-trait = { workspace = true }
 
 chrono = { workspace = true }
 
-datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
-datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
-datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
-datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "8c1bb903792f9c90fa0b1501180bba16cac361d8" }
+datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
+datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
+datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
+datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
 
-datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "1cbcd2bffa2c5b56add996859d02053fd4bc21fc" }
+datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "86f5294d30b7bf53fbcb2e25dee409ad818b34cc" }
 
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "26b014d1fa6c0ffa33e4a7bfcc5db130e3cc6bc5" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d76a0ecc4ebaa2bfc5178e6589f76dc5d71c67" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d76a0ecc4ebaa2bfc5178e6589f76dc5d71c67" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d76a0ecc4ebaa2bfc5178e6589f76dc5d71c67" }
 
 futures = { workspace = true }
 object_store = { workspace = true }

--- a/crates/runtime/src/datafusion/execution.rs
+++ b/crates/runtime/src/datafusion/execution.rs
@@ -5,7 +5,7 @@ use super::error::{self as ih_error, IcehutSQLError, IcehutSQLResult};
 use crate::datafusion::functions::register_udfs;
 use crate::datafusion::planner::ExtendedSqlToRel;
 use crate::datafusion::session::SessionParams;
-use arrow::array::{RecordBatch, Int64Array};
+use arrow::array::{Int64Array, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 use datafusion::common::tree_node::{TransformedResult, TreeNode};
 use datafusion::datasource::default_table_source::provider_as_source;
@@ -769,7 +769,6 @@ impl SqlExecutor {
         warehouse_name: &str,
     ) -> IcehutSQLResult<Vec<RecordBatch>> {
         let plan = self.get_custom_logical_plan(query, warehouse_name).await?;
-        println!("plan: {:?}", plan);
         self.ctx
             .execute_logical_plan(plan)
             .await

--- a/crates/runtime/src/datafusion/execution.rs
+++ b/crates/runtime/src/datafusion/execution.rs
@@ -5,7 +5,7 @@ use super::error::{self as ih_error, IcehutSQLError, IcehutSQLResult};
 use crate::datafusion::functions::register_udfs;
 use crate::datafusion::planner::ExtendedSqlToRel;
 use crate::datafusion::session::SessionParams;
-use arrow::array::{RecordBatch, UInt64Array};
+use arrow::array::{RecordBatch, Int64Array};
 use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 use datafusion::common::tree_node::{TransformedResult, TreeNode};
 use datafusion::datasource::default_table_source::provider_as_source;
@@ -769,6 +769,7 @@ impl SqlExecutor {
         warehouse_name: &str,
     ) -> IcehutSQLResult<Vec<RecordBatch>> {
         let plan = self.get_custom_logical_plan(query, warehouse_name).await?;
+        println!("plan: {:?}", plan);
         self.ctx
             .execute_logical_plan(plan)
             .await
@@ -1251,11 +1252,11 @@ impl SqlExecutor {
 pub fn created_entity_response() -> Result<Vec<RecordBatch>, arrow::error::ArrowError> {
     let schema = Arc::new(ArrowSchema::new(vec![Field::new(
         "count",
-        DataType::UInt64,
+        DataType::Int64,
         false,
     )]));
     Ok(vec![RecordBatch::try_new(
         schema,
-        vec![Arc::new(UInt64Array::from(vec![0]))],
+        vec![Arc::new(Int64Array::from(vec![0]))],
     )?])
 }


### PR DESCRIPTION
Closes #115 

It has no breaking changes as "json" format is not replaced by "arrow" yet, as of known issues in arrow support.
This PR adds partial arrow support, that can be switched on using SERIALIZATION_FORMAT const.
In this PR UInt64 datatype replaced by Int64 in count batch of output schema.
Following queries return count batch that being fixed:
```
CREATE TABLE
CREATE SCHEMA
CREATE DATABASE
INSERT, UPDATE, DELETE
```

Datafusion repo updated as a part of fix: 
https://github.com/Embucket/datafusion/pull/17

Hash commit of change in datafusion propagated in repos too:
https://github.com/Embucket/datafusion-functions-json/pull/4
https://github.com/Embucket/iceberg-rust/pull/14