### PR TITLE
Fix dateadd function

### DIFF
--- a/crates/runtime/src/datafusion/functions/date_add.rs
+++ b/crates/runtime/src/datafusion/functions/date_add.rs
@@ -226,6 +226,37 @@ mod tests {
             ),
         };
         match DateAddFunc::new().invoke_with_args(fn_args) {
+            Ok(ColumnarValue::Scalar(result)) => {
+                let expected = ScalarValue::TimestampMicrosecond(
+                    Some(1736600400000000i64),
+                    Some(Arc::from(String::from("+00").into_boxed_str())),
+                );
+                assert_eq!(&result, &expected, "date_add created a wrong value")
+            }
+            _ => panic!("Conversion failed"),
+        }
+    }
+    #[test]
+    fn test_date_add_days_timestamp_array() {
+        let args = vec![
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("days")))),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(5i64))),
+            ColumnarValue::Array(ScalarValue::TimestampMicrosecond(
+                Some(1736168400000000i64),
+                Some(Arc::from(String::from("+00").into_boxed_str())),
+            )
+            .to_array()
+            .unwrap()),
+        ];
+        let fn_args = ScalarFunctionArgs {
+            args: args,
+            number_rows: 0,
+            return_type: &arrow_schema::DataType::Timestamp(
+                arrow_schema::TimeUnit::Microsecond,
+                Some(Arc::from(String::from("+00").into_boxed_str())),
+            ),
+        };
+        match DateAddFunc::new().invoke_with_args(fn_args) {
             Ok(ColumnarValue::Array(result)) => {
                 let expected = ScalarValue::TimestampMicrosecond(
                     Some(1736600400000000i64),
@@ -235,11 +266,37 @@ mod tests {
                 .unwrap();
                 assert_eq!(&result, &expected, "date_add created a wrong value")
             }
-            Ok(ColumnarValue::Scalar(result)) => {
-                let expected = ScalarValue::TimestampMicrosecond(
+            _ => panic!("Conversion failed"),
+        }
+    }
+    #[test]
+    fn test_date_add_days_timestamp_array_multiple_values() {
+        let args = vec![
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("days")))),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(5i64))),
+            ColumnarValue::Array(ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
+                Some(1736168400000000i64),
+                Some(Arc::from(String::from("+00").into_boxed_str())),
+            ))
+            .to_array(2)
+            .unwrap()),
+        ];
+        let fn_args = ScalarFunctionArgs {
+            args: args,
+            number_rows: 0,
+            return_type: &arrow_schema::DataType::Timestamp(
+                arrow_schema::TimeUnit::Microsecond,
+                Some(Arc::from(String::from("+00").into_boxed_str())),
+            ),
+        };
+        match DateAddFunc::new().invoke_with_args(fn_args) {
+            Ok(ColumnarValue::Array(result)) => {
+                let expected = ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
                     Some(1736600400000000i64),
                     Some(Arc::from(String::from("+00").into_boxed_str())),
-                );
+                ))
+                .to_array(2)
+                .unwrap();
                 assert_eq!(&result, &expected, "date_add created a wrong value")
             }
             _ => panic!("Conversion failed"),

--- a/crates/runtime/src/datafusion/functions/date_add.rs
+++ b/crates/runtime/src/datafusion/functions/date_add.rs
@@ -241,12 +241,14 @@ mod tests {
         let args = vec![
             ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("days")))),
             ColumnarValue::Scalar(ScalarValue::Int64(Some(5i64))),
-            ColumnarValue::Array(ScalarValue::TimestampMicrosecond(
-                Some(1736168400000000i64),
-                Some(Arc::from(String::from("+00").into_boxed_str())),
-            )
-            .to_array()
-            .unwrap()),
+            ColumnarValue::Array(
+                ScalarValue::TimestampMicrosecond(
+                    Some(1736168400000000i64),
+                    Some(Arc::from(String::from("+00").into_boxed_str())),
+                )
+                .to_array()
+                .unwrap(),
+            ),
         ];
         let fn_args = ScalarFunctionArgs {
             args: args,
@@ -274,12 +276,14 @@ mod tests {
         let args = vec![
             ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("days")))),
             ColumnarValue::Scalar(ScalarValue::Int64(Some(5i64))),
-            ColumnarValue::Array(ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-                Some(1736168400000000i64),
-                Some(Arc::from(String::from("+00").into_boxed_str())),
-            ))
-            .to_array(2)
-            .unwrap()),
+            ColumnarValue::Array(
+                ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
+                    Some(1736168400000000i64),
+                    Some(Arc::from(String::from("+00").into_boxed_str())),
+                ))
+                .to_array(2)
+                .unwrap(),
+            ),
         ];
         let fn_args = ScalarFunctionArgs {
             args: args,

--- a/crates/runtime/src/datafusion/functions/date_add.rs
+++ b/crates/runtime/src/datafusion/functions/date_add.rs
@@ -1,13 +1,16 @@
+use arrow::array::Array;
 use arrow::datatypes::DataType;
-use arrow::datatypes::DataType::{Date32, Date64, Int64, Time32, Time64, Timestamp, Utf8};
-use arrow::datatypes::TimeUnit::{Microsecond, Millisecond, Nanosecond, Second};
 use datafusion::common::{plan_err, Result};
-use datafusion::logical_expr::TypeSignature::Exact;
+use datafusion::logical_expr::TypeSignature::Coercible;
+use datafusion::logical_expr::TypeSignatureClass;
 use datafusion::logical_expr::{
-    ColumnarValue, ScalarUDFImpl, Signature, Volatility, TIMEZONE_WILDCARD,
+    ColumnarValue, ScalarUDFImpl, Signature, Volatility,
 };
 use datafusion::scalar::ScalarValue;
 use std::any::Any;
+use std::sync::Arc;
+use datafusion_common::types::{logical_string, logical_int64};
+use arrow::compute::kernels::numeric::add_wrapping;
 
 #[derive(Debug)]
 pub struct DateAddFunc {
@@ -28,39 +31,20 @@ impl DateAddFunc {
         Self {
             signature: Signature::one_of(
                 vec![
-                    Exact(vec![Utf8, Int64, Date32]),
-                    Exact(vec![Utf8, Int64, Date64]),
-                    Exact(vec![Utf8, Int64, Time32(Second)]),
-                    Exact(vec![Utf8, Int64, Time32(Nanosecond)]),
-                    Exact(vec![Utf8, Int64, Time32(Microsecond)]),
-                    Exact(vec![Utf8, Int64, Time32(Millisecond)]),
-                    Exact(vec![Utf8, Int64, Time64(Second)]),
-                    Exact(vec![Utf8, Int64, Time64(Nanosecond)]),
-                    Exact(vec![Utf8, Int64, Time64(Microsecond)]),
-                    Exact(vec![Utf8, Int64, Time64(Millisecond)]),
-                    Exact(vec![Utf8, Int64, Timestamp(Second, None)]),
-                    Exact(vec![Utf8, Int64, Timestamp(Millisecond, None)]),
-                    Exact(vec![Utf8, Int64, Timestamp(Microsecond, None)]),
-                    Exact(vec![Utf8, Int64, Timestamp(Nanosecond, None)]),
-                    Exact(vec![
-                        Utf8,
-                        Int64,
-                        Timestamp(Second, Some(TIMEZONE_WILDCARD.into())),
+                    Coercible(vec![
+                        TypeSignatureClass::Native(logical_string()),
+                        TypeSignatureClass::Native(logical_int64()),
+                        TypeSignatureClass::Timestamp,
                     ]),
-                    Exact(vec![
-                        Utf8,
-                        Int64,
-                        Timestamp(Millisecond, Some(TIMEZONE_WILDCARD.into())),
+                    Coercible(vec![
+                        TypeSignatureClass::Native(logical_string()),
+                        TypeSignatureClass::Native(logical_int64()),
+                        TypeSignatureClass::Time,
                     ]),
-                    Exact(vec![
-                        Utf8,
-                        Int64,
-                        Timestamp(Microsecond, Some(TIMEZONE_WILDCARD.into())),
-                    ]),
-                    Exact(vec![
-                        Utf8,
-                        Int64,
-                        Timestamp(Nanosecond, Some(TIMEZONE_WILDCARD.into())),
+                    Coercible(vec![
+                        TypeSignatureClass::Native(logical_string()),
+                        TypeSignatureClass::Native(logical_int64()),
+                        TypeSignatureClass::Date,
                     ]),
                 ],
                 Volatility::Immutable,
@@ -75,38 +59,54 @@ impl DateAddFunc {
         }
     }
 
-    fn add_years(val: &ScalarValue, years: i64) -> Result<ColumnarValue> {
-        Ok(ColumnarValue::Scalar(
-            val.add(ScalarValue::new_interval_ym(
-                i32::try_from(years).unwrap_or(0),
-                0,
-            ))
-            .unwrap_or_else(|_| ScalarValue::new_interval_ym(0, 0)),
+    fn add_years(val: &Arc<dyn Array>, years: i64) -> Result<ColumnarValue> {
+        Ok(ColumnarValue::Array(
+            add_wrapping(
+            &val, 
+            &ScalarValue::new_interval_ym(
+            i32::try_from(years).unwrap_or(0),
+            0,
+                )
+                .to_array()?
+            )?
         ))
     }
-    fn add_months(val: &ScalarValue, months: i64) -> Result<ColumnarValue> {
-        Ok(ColumnarValue::Scalar(
-            val.add(ScalarValue::new_interval_ym(
+    fn add_months(val: &Arc<dyn Array>, months: i64) -> Result<ColumnarValue> {
+        Ok(ColumnarValue::Array(
+            add_wrapping(
+                &val, 
+                &ScalarValue::new_interval_ym(
                 0,
                 i32::try_from(months).unwrap_or(0),
-            ))
-            .unwrap_or_else(|_| ScalarValue::new_interval_ym(0, 0)),
+                )
+                .to_array()?
+            )?
         ))
     }
-    fn add_days(val: &ScalarValue, days: i64) -> Result<ColumnarValue> {
-        Ok(ColumnarValue::Scalar(
-            val.add(ScalarValue::new_interval_dt(
+    fn add_days(val: &Arc<dyn Array>, days: i64) -> Result<ColumnarValue> {
+        Ok(ColumnarValue::Array(
+            add_wrapping(
+                &val, 
+                &ScalarValue::new_interval_dt(
                 i32::try_from(days).unwrap_or(0),
                 0,
-            ))
-            .unwrap_or_else(|_| ScalarValue::new_interval_dt(0, 0)),
+                )
+                .to_array()?
+            )?
         ))
     }
 
-    fn add_nanoseconds(val: &ScalarValue, nanoseconds: i64) -> Result<ColumnarValue> {
-        Ok(ColumnarValue::Scalar(
-            val.add(ScalarValue::new_interval_mdn(0, 0, nanoseconds))
-                .unwrap_or_else(|_| ScalarValue::new_interval_mdn(0, 0, 0)),
+    fn add_nanoseconds(val: &Arc<dyn Array>, nanoseconds: i64) -> Result<ColumnarValue> {
+        Ok(ColumnarValue::Array(
+            add_wrapping(
+                &val, 
+                &ScalarValue::new_interval_mdn(
+                0,
+                0,
+                nanoseconds,
+                )
+                .to_array()?
+            )?
         ))
     }
 }
@@ -154,8 +154,8 @@ impl ScalarUDFImpl for DateAddFunc {
         }
         Ok(arg_types[2].clone())
     }
-
-    fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    fn invoke_with_args(&self, args: datafusion_expr::ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let args = args.args;
         if args.len() != 3 {
             return plan_err!("function requires three arguments");
         }
@@ -170,13 +170,8 @@ impl ScalarUDFImpl for DateAddFunc {
             _ => return plan_err!("Invalid value type"),
         };
         let date_or_time_expr = match &args[2] {
-            ColumnarValue::Scalar(val) => val.clone(),
-            ColumnarValue::Array(array) => {
-                if array.len() == 0 {
-                    return Ok(ColumnarValue::Array(array.clone()));
-                }
-                ScalarValue::try_from_array(&array, 0)?
-            }
+            ColumnarValue::Scalar(val) => val.to_array()?,
+            ColumnarValue::Array(array) => array.clone(),
         };
         //there shouldn't be overflows
         match date_or_time_part.as_str() {
@@ -222,3 +217,44 @@ impl ScalarUDFImpl for DateAddFunc {
 }
 
 super::macros::make_udf_function!(DateAddFunc);
+#[cfg(test)]
+#[allow(clippy::unwrap_in_result)]
+mod tests {
+    use super::DateAddFunc;
+    use datafusion_common::ScalarValue;
+    use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_date_add_days_timestamp() {
+        let args = vec![
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("days")))),
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(5i64))),
+            ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
+                Some(1736168400000000i64), 
+                Some(Arc::from(String::from("+00").into_boxed_str()))
+            )),
+        ];
+        let fn_args = ScalarFunctionArgs {
+            args: args,
+            number_rows: 0,
+            return_type: &arrow_schema::DataType::Timestamp(
+                arrow_schema::TimeUnit::Microsecond, 
+                Some(Arc::from(String::from("+00").into_boxed_str()))
+            ),
+        };
+        match DateAddFunc::new().invoke_with_args(fn_args) {
+            Ok(ColumnarValue::Array(result)) => {
+                let expected = ScalarValue::TimestampMicrosecond(
+                    Some(1736600400000000i64), 
+                    Some(Arc::from(String::from("+00").into_boxed_str()))
+                ).to_array().unwrap();
+                assert_eq!(&result, &expected,
+                    "date_add created a wrong value"
+                )
+            },
+            _ => panic!("Conversion failed"),
+        }
+        
+    }
+}


### PR DESCRIPTION
This is a quick fix for `dateadd` UDF - it just makes it work such that its physical execution works for dbt snowplow 
workload.

 * Use interval instead of duration type for hour/minute/second
 * Handle empty array case


Ideally, it should be reimplemented differently:
 * Non-deprecated methods should be used
 * It should be designed to handle `ColumnarValue::Array` as a first class citizen (whereas scalar is an exception, not otherwise)
 * (Debatable) Perhaps even 2nd argument should be treated as a columnar value, not scalar

Good example is in [datafusion-examples directory](https://github.com/apache/datafusion/blob/main/datafusion-examples/examples/advanced_udf.rs).


Fixes - somewhat incorrect - #223 