### PR TITLE
Fix IPC arrow format issue

### DIFF
--- a/crates/control_plane/Cargo.toml
+++ b/crates/control_plane/Cargo.toml
@@ -20,7 +20,6 @@ datafusion-functions-json = { workspace = true }
 datafusion-physical-plan = { workspace = true }
 datafusion_iceberg = { workspace = true }
 
-flatbuffers = { version = "24.3.25" }
 futures = { workspace = true }
 iceberg-rest-catalog = { workspace = true }
 iceberg-rust = { workspace = true }

--- a/crates/control_plane/src/models/mod.rs
+++ b/crates/control_plane/src/models/mod.rs
@@ -734,7 +734,7 @@ mod tests {
         assert_eq!(column_info.byte_length.unwrap(), 8_388_608);
         assert_eq!(column_info.length.unwrap(), 8_388_608);
 
-        // Фтн щерук ензу
+        // Any other type
         let field = Field::new("test_field", DataType::Utf8View, false);
         let column_info = ColumnInfo::from_field(&field);
         assert_eq!(column_info.name, "test_field");

--- a/crates/control_plane/src/service.rs
+++ b/crates/control_plane/src/service.rs
@@ -2,7 +2,7 @@ use crate::error::{self, ControlPlaneError, ControlPlaneResult};
 use crate::models::{ColumnInfo, Credentials, StorageProfile, StorageProfileCreateRequest};
 use crate::models::{Warehouse, WarehouseCreateRequest};
 use crate::repository::{StorageProfileRepository, WarehouseRepository};
-use crate::utils::convert_record_batches;
+use crate::utils::{convert_record_batches, Config};
 use arrow::record_batch::RecordBatch;
 use arrow_json::writer::JsonArray;
 use arrow_json::WriterBuilder;
@@ -80,12 +80,14 @@ pub trait ControlService: Send + Sync {
     async fn create_session(&self, session_id: String) -> ControlPlaneResult<()>;
 
     async fn delete_session(&self, session_id: String) -> ControlPlaneResult<()>;
+    fn config(&self) -> &Config;
 }
 
 pub struct ControlServiceImpl {
     storage_profile_repo: Arc<dyn StorageProfileRepository>,
     warehouse_repo: Arc<dyn WarehouseRepository>,
     df_sessions: Arc<RwLock<HashMap<String, SqlExecutor>>>,
+    config: Config,
 }
 
 impl ControlServiceImpl {
@@ -98,6 +100,7 @@ impl ControlServiceImpl {
             storage_profile_repo,
             warehouse_repo,
             df_sessions,
+            config: Config::default(),
         }
     }
 }
@@ -327,8 +330,11 @@ impl ControlService for ControlServiceImpl {
             .context(crate::error::ExecutionSnafu)?
             .into_iter()
             .collect::<Vec<_>>();
+
+        let serialization_format = self.config().dbt_serialization_format;
         // Add columns dbt metadata to each field
-        convert_record_batches(records).context(crate::error::DataFusionQuerySnafu { query })
+        convert_record_batches(records, serialization_format)
+            .context(error::DataFusionQuerySnafu { query })
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -538,12 +544,15 @@ impl ControlService for ControlServiceImpl {
 
         Ok(())
     }
+
+    fn config(&self) -> &Config {
+        &self.config
+    }
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-
     use super::*;
     use crate::error::ControlPlaneError;
     use crate::models::{

--- a/crates/control_plane/src/utils.rs
+++ b/crates/control_plane/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::models::ColumnInfo;
 use arrow::array::{
-    Array, StringArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+    Array, Int64Array, StringArray, TimestampMicrosecondArray, TimestampMillisecondArray,
     TimestampNanosecondArray, TimestampSecondArray, UnionArray,
 };
 use arrow::datatypes::{Field, Schema, TimeUnit};
@@ -9,7 +9,45 @@ use chrono::DateTime;
 use datafusion::arrow::array::ArrayRef;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::Result as DataFusionResult;
+use std::fmt::Display;
 use std::sync::Arc;
+use std::{env, fmt};
+
+pub struct Config {
+    pub dbt_serialization_format: SerializationFormat,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            dbt_serialization_format: SerializationFormat::new(),
+        }
+    }
+}
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum SerializationFormat {
+    Arrow,
+    Json,
+}
+
+impl Display for SerializationFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Arrow => write!(f, "arrow"),
+            Self::Json => write!(f, "json"),
+        }
+    }
+}
+
+impl SerializationFormat {
+    fn new() -> Self {
+        let var = env::var("DBT_SERIALIZATION_FORMAT").unwrap_or_else(|_| "json".to_string());
+        match var.as_str() {
+            "arrow" => Self::Arrow,
+            _ => Self::Json,
+        }
+    }
+}
 
 #[must_use]
 pub fn first_non_empty_type(union_array: &UnionArray) -> Option<(DataType, ArrayRef)> {
@@ -25,6 +63,7 @@ pub fn first_non_empty_type(union_array: &UnionArray) -> Option<(DataType, Array
 
 pub fn convert_record_batches(
     records: Vec<RecordBatch>,
+    serialization_format: SerializationFormat,
 ) -> DataFusionResult<(Vec<RecordBatch>, Vec<ColumnInfo>)> {
     let mut converted_batches = Vec::new();
     let column_infos = ColumnInfo::from_batch(&records);
@@ -54,7 +93,8 @@ pub fn convert_record_batches(
                     }
                 }
                 DataType::Timestamp(unit, _) => {
-                    let converted_column = convert_timestamp_to_struct(column, *unit);
+                    let converted_column =
+                        convert_timestamp_to_struct(column, *unit, serialization_format);
                     fields.push(
                         Field::new(
                             field.name(),
@@ -87,58 +127,95 @@ pub fn convert_record_batches(
     clippy::as_conversions,
     clippy::cast_possible_truncation
 )]
-fn convert_timestamp_to_struct(column: &ArrayRef, unit: TimeUnit) -> ArrayRef {
-    let timestamps: Vec<_> = match unit {
-        TimeUnit::Second => column
-            .as_any()
-            .downcast_ref::<TimestampSecondArray>()
-            .unwrap()
-            .iter()
-            .map(|x| {
-                x.map(|ts| {
-                    let ts = DateTime::from_timestamp(ts, 0).unwrap();
-                    format!("{}", ts.timestamp())
-                })
-            })
-            .collect(),
-        TimeUnit::Millisecond => column
-            .as_any()
-            .downcast_ref::<TimestampMillisecondArray>()
-            .unwrap()
-            .iter()
-            .map(|x| {
-                x.map(|ts| {
-                    let ts = DateTime::from_timestamp_millis(ts).unwrap();
-                    format!("{}.{}", ts.timestamp(), ts.timestamp_subsec_millis())
-                })
-            })
-            .collect(),
-        TimeUnit::Microsecond => column
-            .as_any()
-            .downcast_ref::<TimestampMicrosecondArray>()
-            .unwrap()
-            .iter()
-            .map(|x| {
-                x.map(|ts| {
-                    let ts = DateTime::from_timestamp_micros(ts).unwrap();
-                    format!("{}.{}", ts.timestamp(), ts.timestamp_subsec_micros())
-                })
-            })
-            .collect(),
-        TimeUnit::Nanosecond => column
-            .as_any()
-            .downcast_ref::<TimestampNanosecondArray>()
-            .unwrap()
-            .iter()
-            .map(|x| {
-                x.map(|ts| {
-                    let ts = DateTime::from_timestamp_nanos(ts);
-                    format!("{}.{}", ts.timestamp(), ts.timestamp_subsec_nanos())
-                })
-            })
-            .collect(),
-    };
-    Arc::new(StringArray::from(timestamps)) as ArrayRef
+fn convert_timestamp_to_struct(
+    column: &ArrayRef,
+    unit: TimeUnit,
+    ser: SerializationFormat,
+) -> ArrayRef {
+    match ser {
+        SerializationFormat::Arrow => {
+            let timestamps: Vec<_> = match unit {
+                TimeUnit::Second => column
+                    .as_any()
+                    .downcast_ref::<TimestampSecondArray>()
+                    .unwrap()
+                    .iter()
+                    .collect(),
+                TimeUnit::Millisecond => column
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .unwrap()
+                    .iter()
+                    .collect(),
+                TimeUnit::Microsecond => column
+                    .as_any()
+                    .downcast_ref::<TimestampMicrosecondArray>()
+                    .unwrap()
+                    .iter()
+                    .collect(),
+                TimeUnit::Nanosecond => column
+                    .as_any()
+                    .downcast_ref::<TimestampNanosecondArray>()
+                    .unwrap()
+                    .iter()
+                    .collect(),
+            };
+            Arc::new(Int64Array::from(timestamps)) as ArrayRef
+        }
+        SerializationFormat::Json => {
+            let timestamps: Vec<_> = match unit {
+                TimeUnit::Second => column
+                    .as_any()
+                    .downcast_ref::<TimestampSecondArray>()
+                    .unwrap()
+                    .iter()
+                    .map(|x| {
+                        x.map(|ts| {
+                            let ts = DateTime::from_timestamp(ts, 0).unwrap();
+                            format!("{}", ts.timestamp())
+                        })
+                    })
+                    .collect(),
+                TimeUnit::Millisecond => column
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .unwrap()
+                    .iter()
+                    .map(|x| {
+                        x.map(|ts| {
+                            let ts = DateTime::from_timestamp_millis(ts).unwrap();
+                            format!("{}.{}", ts.timestamp(), ts.timestamp_subsec_millis())
+                        })
+                    })
+                    .collect(),
+                TimeUnit::Microsecond => column
+                    .as_any()
+                    .downcast_ref::<TimestampMicrosecondArray>()
+                    .unwrap()
+                    .iter()
+                    .map(|x| {
+                        x.map(|ts| {
+                            let ts = DateTime::from_timestamp_micros(ts).unwrap();
+                            format!("{}.{}", ts.timestamp(), ts.timestamp_subsec_micros())
+                        })
+                    })
+                    .collect(),
+                TimeUnit::Nanosecond => column
+                    .as_any()
+                    .downcast_ref::<TimestampNanosecondArray>()
+                    .unwrap()
+                    .iter()
+                    .map(|x| {
+                        x.map(|ts| {
+                            let ts = DateTime::from_timestamp_nanos(ts);
+                            format!("{}.{}", ts.timestamp(), ts.timestamp_subsec_nanos())
+                        })
+                    })
+                    .collect(),
+            };
+            Arc::new(StringArray::from(timestamps)) as ArrayRef
+        }
+    }
 }
 
 #[cfg(test)]
@@ -209,7 +286,8 @@ mod tests {
                     Arc::new(TimestampNanosecondArray::from(values)) as ArrayRef
                 }
             };
-            let result = convert_timestamp_to_struct(&timestamp_array, *unit);
+            let result =
+                convert_timestamp_to_struct(&timestamp_array, *unit, SerializationFormat::Json);
             let string_array = result.as_any().downcast_ref::<StringArray>().unwrap();
             assert_eq!(string_array.len(), 2);
             assert_eq!(string_array.value(0), *expected);
@@ -235,7 +313,8 @@ mod tests {
         ])) as ArrayRef;
         let batch = RecordBatch::try_new(schema, vec![int_array, timestamp_array]).unwrap();
         let records = vec![batch];
-        let (converted_batches, column_infos) = convert_record_batches(records).unwrap();
+        let (converted_batches, column_infos) =
+            convert_record_batches(records.clone(), SerializationFormat::Json).unwrap();
 
         let converted_batch = &converted_batches[0];
         assert_eq!(converted_batches.len(), 1);
@@ -255,5 +334,17 @@ mod tests {
         assert_eq!(column_infos[0].r#type, "fixed");
         assert_eq!(column_infos[1].name, "timestamp_col");
         assert_eq!(column_infos[1].r#type, "timestamp_ntz");
+
+        let (converted_batches, column_infos) =
+            convert_record_batches(records, SerializationFormat::Arrow).unwrap();
+        let converted_batch = &converted_batches[0];
+        let converted_timestamp_array = converted_batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(converted_timestamp_array.value(0), 1627846261);
+        assert!(converted_timestamp_array.is_null(1));
+        assert_eq!(converted_timestamp_array.value(2), 1627846262);
     }
 }

--- a/crates/nexus/src/http/dbt/handlers.rs
+++ b/crates/nexus/src/http/dbt/handlers.rs
@@ -17,15 +17,13 @@ use axum::Json;
 use base64;
 use base64::engine::general_purpose::STANDARD as engine_base64;
 use base64::prelude::*;
+use control_plane::utils::SerializationFormat;
 use flate2::read::GzDecoder;
 use regex::Regex;
 use snafu::ResultExt;
 use std::io::Read;
 use tracing::debug;
 use uuid::Uuid;
-
-// TODO: move out as a configurable parameter
-const SERIALIZATION_FORMAT: &str = "json"; // or "arrow"
 
 // https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
 // Buffer Alignment and Padding: Implementations are recommended to allocate memory
@@ -146,18 +144,19 @@ pub async fn query(
         records_to_json_string(&records)?.as_str()
     );
 
+    let serialization_format = state.control_svc.config().dbt_serialization_format;
     let json_resp = Json(JsonResponse {
         data: Option::from(ResponseData {
             row_type: columns.into_iter().map(Into::into).collect(),
-            query_result_format: Option::from(String::from(SERIALIZATION_FORMAT)),
-            row_set: if SERIALIZATION_FORMAT == "json" {
+            query_result_format: Some(serialization_format.to_string()),
+            row_set: if serialization_format == SerializationFormat::Json {
                 Option::from(ResponseData::rows_to_vec(
                     records_to_json_string(&records)?.as_str(),
                 )?)
             } else {
                 None
             },
-            row_set_base_64: if SERIALIZATION_FORMAT == "arrow" {
+            row_set_base_64: if serialization_format == SerializationFormat::Arrow {
                 Option::from(records_to_arrow_string(&records)?)
             } else {
                 None


### PR DESCRIPTION
- the issue was in NULL type that we send for **NULL as comment**
- NULL type was fixed
- Arrow IPC format [expects](https://github.com/snowflakedb/snowflake-connector-python/blob/main/src/snowflake/connector/nanoarrow_cpp/ArrowIterator/CArrowChunkIterator.cpp#L268-L293) all timestamps in i64 format with scale, for example 1627846261233222 scale 6
- JSON format [expects](https://github.com/snowflakedb/snowflake-connector-python/blob/main/src/snowflake/connector/converter.py#L769-L781) all timestamps in string format with point delimiter with scale, for example "1627846261.233222" scale 6
- Moved DBT_FORMAT to env variable with json default


Closes #115 and #67 
