### PR TITLE
Set warehouse location based on storage profile path

### DIFF
--- a/crates/catalog/src/service.rs
+++ b/crates/catalog/src/service.rs
@@ -188,7 +188,7 @@ impl Catalog for CatalogImpl {
         let base_part = storage_profile
             .get_base_url()
             .context(error::ControlPlaneSnafu)?;
-        let table_part = format!("{}/{}", warehouse.location, commit.ident.table);
+        let table_part = format!("{}/{}", warehouse.path(), commit.ident.table);
         let metadata_part = format!("metadata/{}", Self::generate_metadata_filename());
 
         let mut properties = table.properties.clone();
@@ -339,7 +339,7 @@ impl Catalog for CatalogImpl {
         let base_part = storage_profile
             .get_base_url()
             .context(error::ControlPlaneSnafu)?;
-        let table_part = format!("{}/{}", warehouse.location, table_creation.name);
+        let table_part = format!("{}/{}", warehouse.path(), table_creation.name);
         let metadata_part = format!("metadata/{}", Self::generate_metadata_filename());
 
         let table_creation = {

--- a/crates/control_plane/src/models/mod.rs
+++ b/crates/control_plane/src/models/mod.rs
@@ -378,29 +378,29 @@ impl Warehouse {
         storage_profile_id: Uuid,
     ) -> ControlPlaneModelResult<Self> {
         let id = Uuid::new_v4();
-        let location = format!("{prefix}/{id}");
         let now = Utc::now().naive_utc();
         Ok(Self {
             id,
             prefix,
             name,
-            location,
+            location: String::new(),
             storage_profile_id,
             created_at: now,
             updated_at: now,
         })
     }
-}
 
-impl TryFrom<WarehouseCreateRequest> for Warehouse {
-    type Error = ControlPlaneModelError;
+    pub fn with_location(&mut self, location: String) {
+        self.location = location;
+    }
 
-    fn try_from(value: WarehouseCreateRequest) -> ControlPlaneModelResult<Self> {
-        Self::new(
-            value.prefix.clone(),
-            value.name.clone(),
-            value.storage_profile_id,
-        )
+    #[must_use]
+    pub fn path(&self) -> String {
+        if self.prefix.is_empty() {
+            format!("{}", self.id)
+        } else {
+            format!("{}/{}", self.prefix, self.id)
+        }
     }
 }
 

--- a/crates/runtime/src/datafusion/execution.rs
+++ b/crates/runtime/src/datafusion/execution.rs
@@ -380,7 +380,6 @@ impl SqlExecutor {
                     .await
                     .context(ih_error::IcebergSnafu)?;
             };
-
             // Create new table
             rest_catalog
                 .create_table(


### PR DESCRIPTION
Related to #268 
- Set full warehouse location instead of relative path prefix/id 
- fixed incorrect path if the prefix was empty
```python
{
    "id": "0e9dc17a-899d-4e2c-92c1-a4d792e71a6a",
    "name": "snowplow",
    "keyPrefix": "warehouse-prefix",
    "location": "warehouse-prefix/id",
}
->
{
    "id": "0e9dc17a-899d-4e2c-92c1-a4d792e71a6a",
    "name": "snowplow",
    "keyPrefix": "warehouse-prefix",
    "location": "s3://artemembucket",
}
{
    "id": "0e9dc17a-899d-4e2c-92c1-a4d792e71a6a",
    "name": "snowplow",
    "keyPrefix": "warehouse-prefix",
    "location": "file://<full_path>",
}



{
    "id": "0e9dc17a-899d-4e2c-92c1-a4d792e71a6a",
    "name": "snowplow",
    "keyPrefix": "",
    "location": "/id",
}
->
{
    "id": "0e9dc17a-899d-4e2c-92c1-a4d792e71a6a",
    "name": "snowplow",
    "keyPrefix": "",
    "location": "s3://artemembucket",
}
{
    "id": "0e9dc17a-899d-4e2c-92c1-a4d792e71a6a",
    "name": "snowplow",
    "keyPrefix": "",
    "location": "file://<full_path>",
}
```