### PR TITLE
Fix object store for custom endpoint

### DIFF
--- a/crates/control_plane/src/models/mod.rs
+++ b/crates/control_plane/src/models/mod.rs
@@ -273,6 +273,11 @@ impl StorageProfile {
 
         if let Some(endpoint) = &self.endpoint {
             builder = builder.with_endpoint(endpoint.clone());
+
+            let url = Url::parse(endpoint).context(error::InvalidEndpointUrlSnafu {
+                url: endpoint.clone(),
+            })?;
+            builder = builder.with_allow_http(url.scheme() == "http");
         }
 
         if let Some(credentials) = &self.credentials {


### PR DESCRIPTION
AWS S3 builder uses dedicated setting to allow http. Parse endpoint and enable if it isn't https.