### PR TITLE
issue 241 Return affected rows count

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,19 +44,19 @@ datafusion-physical-plan = { version = "45.0.0" }
 datafusion-doc = { version = "45.0.0" }
 datafusion-macros = { version = "45.0.0" }
 
-# do not change iceberg-rust, datafusion-functions-json hash commits unless datafusion version bumped
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "f2b9b88cd9b4282bc0286a970333e8c01cec177b" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "a9da1c26cf5b0e91aba33e6088dd02ff67c32928" }
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "a9da1c26cf5b0e91aba33e6088dd02ff67c32928" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "a9da1c26cf5b0e91aba33e6088dd02ff67c32928" }
+
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1d486d6127ba18dc2dced7ed5f4c403dd8a6a8b9" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1d486d6127ba18dc2dced7ed5f4c403dd8a6a8b9" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1d486d6127ba18dc2dced7ed5f4c403dd8a6a8b9" }
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
-datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
-datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
-datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
-datafusion-doc = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
-datafusion-macros = { git = "https://github.com/Embucket/datafusion.git", rev = "314a72634dc4f15242345fd17dc32df6c3ae04e8" }
+datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "eecc47ec20fec83158bd71611e799cb7d373646f" }
+datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "eecc47ec20fec83158bd71611e799cb7d373646f" }
+datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "eecc47ec20fec83158bd71611e799cb7d373646f" }
+datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "eecc47ec20fec83158bd71611e799cb7d373646f" }
+datafusion-doc = { git = "https://github.com/Embucket/datafusion.git", rev = "eecc47ec20fec83158bd71611e799cb7d373646f" }
+datafusion-macros = { git = "https://github.com/Embucket/datafusion.git", rev = "eecc47ec20fec83158bd71611e799cb7d373646f" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }


### PR DESCRIPTION
Partially resolve #241 
This PR must update hash-commits of updated rust-iceberg and datafusion. 

PR in Datafusion repo reverting commit, is merged: https://github.com/Embucket/datafusion/pull/18.
PR in Iceberg-rust repo adds actual support for insert rows count: https://github.com/Embucket/iceberg-rust/pull/18/commits
