### PR TITLE
Using preprocess_query as assosiated function

### DIFF
--- a/crates/control_plane/src/service.rs
+++ b/crates/control_plane/src/service.rs
@@ -284,7 +284,7 @@ impl ControlService for ControlServiceImpl {
                     id: session_id.to_string(),
                 })?;
 
-        let query = executor.preprocess_query(query);
+        let query = SqlExecutor::preprocess_query(query);
         let statement = executor
             .parse_query(&query)
             .context(error::DataFusionSnafu)?;


### PR DESCRIPTION
After recent changes preprocess_query become assosiated function instead of method. Fix usage of it in our service. 