### PR TITLE
`bucketd sql` subcommand

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,9 @@ repos:
       - id: cargo-check
         args: [ "--workspace" ]
       - id: fmt
-        args: [ "--", "--check" ]
+        args: [ "--", "--check"]
       - id: clippy
-        args: [ "--", "-D", "warnings" ]
+        args: [ "--workspace", "--tests" ]
   - repo: local
     # chmod +x check_license.sh
     hooks:

--- a/bin/bucketd/Cargo.toml
+++ b/bin/bucketd/Cargo.toml
@@ -10,6 +10,7 @@ dotenv = { version = "0.15.0" }
 icebucket_runtime = { path = "../../crates/runtime" }
 object_store = { workspace = true }
 snmalloc-rs = { workspace = true }
+strum = { version = "0.27.1", features = ["derive"] }
 tokio = { workspace = true }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/runtime/src/execution/dedicated_executor.rs
+++ b/crates/runtime/src/execution/dedicated_executor.rs
@@ -609,7 +609,7 @@ impl DedicatedExecutorBuilder {
                 // current thread RT)
                 DedicatedExecutor::register_io_runtime(io_handle.clone());
 
-                tracing::info!("Creating DedicatedExecutor",);
+                tracing::trace!("Creating DedicatedExecutor",);
 
                 let mut runtime_builder = runtime_builder;
                 let runtime = runtime_builder

--- a/crates/runtime/src/http/config.rs
+++ b/crates/runtime/src/http/config.rs
@@ -17,10 +17,12 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::execution::utils::DataSerializationFormat;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IceBucketWebConfig {
     pub host: String,
     pub port: u16,
     pub allow_origin: Option<String>,
-    pub data_format: String,
+    pub data_format: DataSerializationFormat,
 }

--- a/crates/runtime/src/http/error.rs
+++ b/crates/runtime/src/http/error.rs
@@ -47,7 +47,7 @@ impl IntoResponse for RuntimeHttpError {
 }
 
 //pub struct RuntimeHttpResult<T>(pub T);
-pub type RuntimeHttpResult<T> = Result<T, RuntimeHttpError>;
+pub type RuntimeResult<T> = Result<T, RuntimeHttpError>;
 
 #[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ErrorResponse {

--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -58,7 +58,9 @@ pub fn make_icebucket_app(
     metastore: Arc<dyn Metastore>,
     config: &IceBucketWebConfig,
 ) -> Result<Router, Box<dyn std::error::Error>> {
-    let execution_cfg = execution::utils::Config::new(&config.data_format)?;
+    let execution_cfg = execution::utils::Config {
+        dbt_serialization_format: config.data_format,
+    };
     let execution_svc = Arc::new(ExecutionService::new(metastore.clone(), execution_cfg));
 
     let session_memory = RequestSessionMemory::default();

--- a/crates/runtime/src/http/tests/common.rs
+++ b/crates/runtime/src/http/tests/common.rs
@@ -53,7 +53,7 @@ pub async fn create_server() -> SocketAddr {
             port: 3000,
             host: "0.0.0.0".to_string(),
             allow_origin: None,
-            data_format: "json".to_string(),
+            data_format: crate::execution::utils::DataSerializationFormat::Json,
         },
     )
     .unwrap();

--- a/crates/runtime/src/http/tests/query.rs
+++ b/crates/runtime/src/http/tests/query.rs
@@ -38,7 +38,7 @@ async fn test_parallel_queries() {
             port: 3000,
             host: "0.0.0.0".to_string(),
             allow_origin: None,
-            data_format: "json".to_string(),
+            data_format: crate::execution::utils::DataSerializationFormat::Json,
         },
     )
     .unwrap();

--- a/crates/runtime/src/http/tests/volumes.rs
+++ b/crates/runtime/src/http/tests/volumes.rs
@@ -47,7 +47,7 @@ async fn test_ui_volumes_file() {
 
     // memory volume with empty ident create Ok
     let expected = IceBucketVolume {
-        ident: "".to_string(),
+        ident: String::new(),
         volume: IceBucketVolumeType::File(IceBucketFileVolume {
             path: "/tmp/data".to_string(),
         }),
@@ -66,7 +66,7 @@ async fn test_ui_volumes_s3() {
 
     // memory volume with empty ident create Ok
     let expected = IceBucketVolume {
-        ident: "".to_string(),
+        ident: String::new(),
         volume: IceBucketVolumeType::S3(IceBucketS3Volume {
             region: Some("us-west-1".to_string()),
             bucket: Some("icebucket".to_string()),


### PR DESCRIPTION
To facilitate running SLT tests, we should support running one-off SQL commands from the command line. 

Supports both JSON and CSV:

```shell
cargo run -- sql -q "SHOW TABLES;"
```

```json
[{"table_catalog":"benchmark","table_schema":"public","table_name":"hits","table_type":"BASE TABLE"},{"table_catalog":"benchmark","table_schema":"information_schema","table_name":"tables","table_type":"VIEW"},{"table_catalog":"benchmark","table_schema":"information_schema","table_name":"views","table_type":"VIEW"},{"table_catalog":"benchmark","table_schema":"information_schema","table_name":"columns","table_type":"VIEW"},{"table_catalog":"benchmark","table_schema":"information_schema","table_name":"df_settings","table_type":"VIEW"},{"table_catalog":"benchmark","table_schema":"information_schema","table_name":"schemata","table_type":"VIEW"},{"table_catalog":"benchmark","table_schema":"information_schema","table_name":"routines","table_type":"VIEW"},{"table_catalog":"benchmark","table_schema":"information_schema","table_name":"parameters","table_type":"VIEW"}]
```


```shell
cargo run -- sql -q "SHOW TABLES;" --data-format=csv
```

```csv
table_catalog,table_schema,table_name,table_type
benchmark,public,hits,BASE TABLE
benchmark,information_schema,tables,VIEW
benchmark,information_schema,views,VIEW
benchmark,information_schema,columns,VIEW
benchmark,information_schema,df_settings,VIEW
benchmark,information_schema,schemata,VIEW
benchmark,information_schema,routines,VIEW
benchmark,information_schema,parameters,VIEW
```