### PR TITLE
Issue/373 openapi payloads schemas and other

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,6 @@ datafusion-macros = { git = "https://github.com/Embucket/datafusion.git", rev = 
 
 # issue #309
 chrono = { git = "https://github.com/chronotope/chrono.git", rev = "8b863490d88ba098038392c8aa930012ffd0c439" }
-# https://github.com/juhaku/utoipa/issues/1345
-utoipa = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }
-utoipa-swagger-ui = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }
 
 # https://github.com/juhaku/utoipa/issues/1345
 utoipa = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ datafusion-macros = { git = "https://github.com/Embucket/datafusion.git", rev = 
 
 # issue #309
 chrono = { git = "https://github.com/chronotope/chrono.git", rev = "8b863490d88ba098038392c8aa930012ffd0c439" }
+# https://github.com/juhaku/utoipa/issues/1345
+utoipa = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }
+utoipa-swagger-ui = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }
 
 # https://github.com/juhaku/utoipa/issues/1345
 utoipa = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }

--- a/crates/history/src/entities/query.rs
+++ b/crates/history/src/entities/query.rs
@@ -28,13 +28,13 @@ pub enum QueryStatus {
     Error,
 }
 
-pub type QueryHistoryId = i64;
+pub type QueryRecordId = i64;
 
-// QueryItem struct is used for storing Query History result and also used in http response
+// QueryRecord struct is used for storing QueryRecord History result and also used in http response
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct QueryItem {
-    pub id: QueryHistoryId,
+pub struct QueryRecord {
+    pub id: QueryRecordId,
     pub worksheet_id: WorksheetId,
     pub query: String,
     pub start_time: DateTime<Utc>,
@@ -46,9 +46,9 @@ pub struct QueryItem {
     pub error: Option<String>,
 }
 
-impl QueryItem {
+impl QueryRecord {
     #[must_use]
-    pub fn get_key(worksheet_id: WorksheetId, id: QueryHistoryId) -> Bytes {
+    pub fn get_key(worksheet_id: WorksheetId, id: QueryRecordId) -> Bytes {
         Bytes::from(format!("/qh/{worksheet_id}/{id}"))
     }
 
@@ -99,7 +99,7 @@ impl QueryItem {
     }
 }
 
-impl IterableEntity for QueryItem {
+impl IterableEntity for QueryRecord {
     type Cursor = i64;
 
     fn cursor(&self) -> Self::Cursor {

--- a/crates/history/src/entities/worksheet.rs
+++ b/crates/history/src/entities/worksheet.rs
@@ -28,10 +28,8 @@ pub type WorksheetId = i64;
 #[serde(rename_all = "camelCase")]
 pub struct Worksheet {
     pub id: WorksheetId,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
+    pub name: String,
+    pub content: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -43,13 +41,13 @@ impl Worksheet {
     }
 
     #[must_use]
-    pub fn new(content: Option<String>) -> Self {
+    pub fn new(name: String, content: String) -> Self {
         let created_at = Utc::now();
         let id = created_at.timestamp_millis();
         // id, start_time have the same value
         Self {
             id,
-            name: None,
+            name,
             content,
             created_at,
             updated_at: created_at,
@@ -57,11 +55,11 @@ impl Worksheet {
     }
 
     pub fn set_name(&mut self, name: String) {
-        self.name = Some(name);
+        self.name = name;
     }
 
     pub fn set_content(&mut self, content: String) {
-        self.content = Some(content);
+        self.content = content;
     }
 }
 
@@ -83,7 +81,7 @@ mod test {
 
     #[test]
     fn test_new_worksheet() {
-        let w1 = Worksheet::new(None);
+        let w1 = Worksheet::new(String::new(), String::new());
         assert_eq!(w1.id, w1.created_at.timestamp_millis());
     }
 }

--- a/crates/history/src/store.rs
+++ b/crates/history/src/store.rs
@@ -200,7 +200,7 @@ mod tests {
         let db = SlateDBWorksheetsStore::new_in_memory().await;
 
         // create worksheet first
-        let worksheet = Worksheet::new(Some(String::new()));
+        let worksheet = Worksheet::new(String::new(), String::new());
 
         let n: u16 = 2;
         let mut created: Vec<QueryItem> = vec![];

--- a/crates/history/src/store.rs
+++ b/crates/history/src/store.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{QueryHistoryId, QueryItem, Worksheet, WorksheetId};
+use crate::{QueryRecord, QueryRecordId, Worksheet, WorksheetId};
 use async_trait::async_trait;
 use icebucket_utils::iterable::{IterableCursor, IterableEntity};
 use icebucket_utils::Db;
@@ -43,11 +43,11 @@ pub enum WorksheetsStoreError {
     #[snafu(display("Error updating worksheet: {source}"))]
     WorksheetUpdate { source: icebucket_utils::Error },
 
-    #[snafu(display("Error adding query history: {source}"))]
-    HistoryAdd { source: icebucket_utils::Error },
+    #[snafu(display("Error adding query record: {source}"))]
+    QueryAdd { source: icebucket_utils::Error },
 
     #[snafu(display("Error getting query history: {source}"))]
-    HistoryGet { source: icebucket_utils::Error },
+    QueryGet { source: icebucket_utils::Error },
 
     #[snafu(display("Can't locate worksheet by key: {message}"))]
     WorksheetNotFound { message: String },
@@ -63,13 +63,13 @@ pub trait WorksheetsStore: std::fmt::Debug + Send + Sync {
     async fn update_worksheet(&self, worksheet: Worksheet) -> WorksheetsStoreResult<()>;
     async fn get_worksheets(&self) -> WorksheetsStoreResult<Vec<Worksheet>>;
 
-    async fn add_history_item(&self, item: QueryItem) -> WorksheetsStoreResult<()>;
+    async fn add_history_item(&self, item: QueryRecord) -> WorksheetsStoreResult<()>;
     async fn query_history(
         &self,
         worksheet_id: WorksheetId,
         cursor: Option<i64>,
         limit: Option<u16>,
-    ) -> WorksheetsStoreResult<Vec<QueryItem>>;
+    ) -> WorksheetsStoreResult<Vec<QueryRecord>>;
 }
 
 pub struct SlateDBWorksheetsStore {
@@ -158,12 +158,12 @@ impl WorksheetsStore for SlateDBWorksheetsStore {
             .context(WorksheetsListSnafu)?)
     }
 
-    async fn add_history_item(&self, item: QueryItem) -> WorksheetsStoreResult<()> {
+    async fn add_history_item(&self, item: QueryRecord) -> WorksheetsStoreResult<()> {
         Ok(self
             .db
             .put_iterable_entity(&item)
             .await
-            .context(HistoryAddSnafu)?)
+            .context(QueryAddSnafu)?)
     }
 
     async fn query_history(
@@ -171,19 +171,19 @@ impl WorksheetsStore for SlateDBWorksheetsStore {
         worksheet_id: WorksheetId,
         cursor: Option<i64>,
         limit: Option<u16>,
-    ) -> WorksheetsStoreResult<Vec<QueryItem>> {
+    ) -> WorksheetsStoreResult<Vec<QueryRecord>> {
         // TODO: add worksheet_id to key prefix
         let start_key = if let Some(cursor) = cursor {
-            QueryItem::get_key(worksheet_id, cursor)
+            QueryRecord::get_key(worksheet_id, cursor)
         } else {
-            QueryItem::get_key(worksheet_id, QueryHistoryId::CURSOR_MIN)
+            QueryRecord::get_key(worksheet_id, QueryRecordId::CURSOR_MIN)
         };
-        let end_key = QueryItem::get_key(worksheet_id, QueryHistoryId::CURSOR_MAX);
+        let end_key = QueryRecord::get_key(worksheet_id, QueryRecordId::CURSOR_MAX);
         Ok(self
             .db
             .items_from_range(start_key..end_key, limit)
             .await
-            .context(HistoryGetSnafu)?)
+            .context(QueryGetSnafu)?)
     }
 }
 
@@ -203,11 +203,11 @@ mod tests {
         let worksheet = Worksheet::new(String::new(), String::new());
 
         let n: u16 = 2;
-        let mut created: Vec<QueryItem> = vec![];
+        let mut created: Vec<QueryRecord> = vec![];
         for i in 0..n {
             let start_time = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap()
                 + Duration::milliseconds(i.into());
-            let mut item = QueryItem::query_start(
+            let mut item = QueryRecord::query_start(
                 worksheet.id,
                 format!("select {i}").as_str(),
                 Some(start_time),
@@ -226,7 +226,7 @@ mod tests {
             db.add_history_item(item).await.unwrap();
         }
 
-        let cursor = <QueryItem as IterableEntity>::Cursor::CURSOR_MIN;
+        let cursor = <QueryRecord as IterableEntity>::Cursor::CURSOR_MIN;
         eprintln!("cursor: {cursor}");
         let retrieved = db
             .query_history(worksheet.id, Some(cursor), Some(10))

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -99,5 +99,4 @@ workspace = true
 [dev-dependencies]
 insta = { version = "1.42.0", features = ["yaml"] }
 reqwest = "0.12.14"
-oas3 = { version = "0.15.0" }
-rand = { version = "0.8.5" }
+

--- a/crates/runtime/src/http/tests/databases_navigation.rs
+++ b/crates/runtime/src/http/tests/databases_navigation.rs
@@ -23,7 +23,7 @@ use crate::http::ui::queries::models::QueryPayload;
 use crate::http::ui::schemas::models::SchemaPayload;
 use crate::http::ui::tests::common::req;
 use crate::http::ui::tests::common::{ui_test_op, Entity, Op};
-use crate::http::ui::volumes::models::{VolumePayload, VolumeResponse};
+use crate::http::ui::volumes::models::{Volume, VolumePayload, VolumeResponse};
 use crate::http::ui::worksheets::models::{WorksheetPayload, WorksheetResponse};
 use crate::tests::run_icebucket_test_server;
 use http::Method;
@@ -49,10 +49,10 @@ async fn test_ui_databases_navigation() {
         Op::Create,
         None,
         &Entity::Volume(VolumePayload {
-            data: IceBucketVolume {
+            data: Volume::from(IceBucketVolume {
                 ident: String::new(),
                 volume: IceBucketVolumeType::Memory,
-            },
+            }),
         }),
     )
     .await;
@@ -63,14 +63,14 @@ async fn test_ui_databases_navigation() {
         data: IceBucketDatabase {
             ident: "test1".to_string(),
             properties: None,
-            volume: volume.data.ident.clone(),
+            volume: volume.data.name.clone(),
         },
     };
     let expected2 = DatabasePayload {
         data: IceBucketDatabase {
             ident: "test2".to_string(),
             properties: None,
-            volume: volume.data.ident.clone(),
+            volume: volume.data.name.clone(),
         },
     };
     //2 DBs
@@ -92,7 +92,8 @@ async fn test_ui_databases_navigation() {
                 database: expected1.data.ident.clone(),
             },
             properties: None,
-        },
+        }
+        .into(),
     };
     //1 SCHEMA
     let _res = ui_test_op(addr, Op::Create, None, &Entity::Schema(expected1.clone())).await;
@@ -134,8 +135,8 @@ async fn test_ui_databases_navigation() {
 	    DVCE_CREATED_TSTAMP TIMESTAMP_NTZ(9),
 	    EVENT TEXT,
 	    EVENT_ID TEXT);",
-        expected1.data.ident.database.clone(),
-        expected1.data.ident.schema.clone(),
+        expected1.data.database.clone(),
+        expected1.data.schema.clone(),
         "tested1"
     ));
 

--- a/crates/runtime/src/http/tests/databases_navigation.rs
+++ b/crates/runtime/src/http/tests/databases_navigation.rs
@@ -24,7 +24,7 @@ use crate::http::ui::schemas::models::SchemaPayload;
 use crate::http::ui::tests::common::req;
 use crate::http::ui::tests::common::{ui_test_op, Entity, Op};
 use crate::http::ui::volumes::models::{Volume, VolumePayload, VolumeResponse};
-use crate::http::ui::worksheets::models::{WorksheetPayload, WorksheetResponse};
+use crate::http::ui::worksheets::models::{WorksheetCreatePayload, WorksheetResponse};
 use crate::tests::run_icebucket_test_server;
 use http::Method;
 use icebucket_metastore::{IceBucketDatabase, IceBucketVolume};
@@ -111,9 +111,9 @@ async fn test_ui_databases_navigation() {
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets"),
-        json!(WorksheetPayload {
-            name: Some("test".to_string()),
-            content: None,
+        json!(WorksheetCreatePayload {
+            name: "test".to_string(),
+            content: String::new(),
         })
         .to_string(),
     )

--- a/crates/runtime/src/http/ui/databases/handlers.rs
+++ b/crates/runtime/src/http/ui/databases/handlers.rs
@@ -20,13 +20,17 @@ use crate::http::{
     error::ErrorResponse,
     metastore::handlers::QueryParameters,
     ui::databases::error::{DatabasesAPIError, DatabasesResult},
-    ui::databases::models::{DatabasePayload, DatabaseResponse, DatabasesResponse},
+    ui::databases::models::{
+        DatabaseCreatePayload, DatabaseCreateResponse, DatabaseResponse, DatabaseUpdatePayload,
+        DatabaseUpdateResponse, DatabasesResponse,
+    },
 };
 use axum::{
     extract::{Path, Query, State},
     Json,
 };
 use icebucket_metastore::error::MetastoreError;
+use icebucket_metastore::IceBucketDatabase;
 use utoipa::OpenApi;
 use validator::Validate;
 
@@ -41,7 +45,8 @@ use validator::Validate;
     ),
     components(
         schemas(
-            DatabasePayload,
+            DatabaseCreatePayload,
+            DatabaseCreateResponse,
             DatabaseResponse,
             DatabasesResponse,
             ErrorResponse,
@@ -58,9 +63,9 @@ pub struct ApiDoc;
     operation_id = "createDatabase",
     tags = ["databases"],
     path = "/ui/databases",
-    request_body = DatabasePayload,
+    request_body = DatabaseCreatePayload,
     responses(
-        (status = 200, description = "Successful Response", body = inline(DatabaseResponse)),
+        (status = 200, description = "Successful Response", body = DatabaseCreateResponse),
         (status = 409, description = "Already Exists", body = ErrorResponse),
         (status = 400, description = "Bad request", body = ErrorResponse),
     )
@@ -68,20 +73,22 @@ pub struct ApiDoc;
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
 pub async fn create_database(
     State(state): State<AppState>,
-    Json(database): Json<DatabasePayload>,
-) -> DatabasesResult<Json<DatabaseResponse>> {
-    database
-        .data
-        .validate()
-        .map_err(|e| DatabasesAPIError::Create {
-            source: MetastoreError::Validation { source: e },
-        })?;
+    Json(database): Json<DatabaseCreatePayload>,
+) -> DatabasesResult<Json<DatabaseCreateResponse>> {
+    let database: IceBucketDatabase = database.data.into();
+    database.validate().map_err(|e| DatabasesAPIError::Create {
+        source: MetastoreError::Validation { source: e },
+    })?;
     state
         .metastore
-        .create_database(&database.data.ident.clone(), database.data)
+        .create_database(&database.ident.clone(), database)
         .await
         .map_err(|e| DatabasesAPIError::Create { source: e })
-        .map(|o| Json(DatabaseResponse { data: o.data }))
+        .map(|o| {
+            Json(DatabaseCreateResponse {
+                data: o.data.into(),
+            })
+        })
 }
 
 #[utoipa::path(
@@ -103,7 +110,9 @@ pub async fn get_database(
     Path(database_name): Path<String>,
 ) -> DatabasesResult<Json<DatabaseResponse>> {
     match state.metastore.get_database(&database_name).await {
-        Ok(Some(db)) => Ok(Json(DatabaseResponse { data: db.data })),
+        Ok(Some(db)) => Ok(Json(DatabaseResponse {
+            data: db.data.into(),
+        })),
         Ok(None) => Err(DatabasesAPIError::Get {
             source: MetastoreError::DatabaseNotFound {
                 db: database_name.clone(),
@@ -144,12 +153,12 @@ pub async fn delete_database(
     operation_id = "updateDatabase",
     tags = ["databases"],
     path = "/ui/databases/{databaseName}",
-    request_body = DatabasePayload,
+    request_body = DatabaseUpdatePayload,
     params(
         ("databaseName" = String, Path, description = "Database name")
     ),
     responses(
-        (status = 200, description = "Successful Response", body = DatabaseResponse),
+        (status = 200, description = "Successful Response", body = DatabaseUpdateResponse),
         (status = 404, description = "Not found", body = ErrorResponse),
         (status = 400, description = "Invalid data", body = ErrorResponse)
     )
@@ -158,21 +167,23 @@ pub async fn delete_database(
 pub async fn update_database(
     State(state): State<AppState>,
     Path(database_name): Path<String>,
-    Json(database): Json<DatabasePayload>,
-) -> DatabasesResult<Json<DatabaseResponse>> {
-    database
-        .data
-        .validate()
-        .map_err(|e| DatabasesAPIError::Update {
-            source: MetastoreError::Validation { source: e },
-        })?;
+    Json(database): Json<DatabaseUpdatePayload>,
+) -> DatabasesResult<Json<DatabaseUpdateResponse>> {
+    let database: IceBucketDatabase = database.data.into();
+    database.validate().map_err(|e| DatabasesAPIError::Update {
+        source: MetastoreError::Validation { source: e },
+    })?;
     //TODO: Implement database renames
     state
         .metastore
-        .update_database(&database_name, database.data)
+        .update_database(&database_name, database)
         .await
         .map_err(|e| DatabasesAPIError::Update { source: e })
-        .map(|o| Json(DatabaseResponse { data: o.data }))
+        .map(|o| {
+            Json(DatabaseUpdateResponse {
+                data: o.data.into(),
+            })
+        })
 }
 
 #[utoipa::path(
@@ -196,7 +207,7 @@ pub async fn list_databases(
         .map_err(|e| DatabasesAPIError::List { source: e })
         .map(|o| {
             Json(DatabasesResponse {
-                items: o.into_iter().map(|x| x.data).collect(),
+                items: o.into_iter().map(|x| x.data.into()).collect(),
             })
         })
 }

--- a/crates/runtime/src/http/ui/databases/handlers.rs
+++ b/crates/runtime/src/http/ui/databases/handlers.rs
@@ -37,7 +37,7 @@ use validator::Validate;
         get_database,
         delete_database,
         list_databases,
-        update_database,
+        // update_database,
     ),
     components(
         schemas(

--- a/crates/runtime/src/http/ui/databases/models.rs
+++ b/crates/runtime/src/http/ui/databases/models.rs
@@ -20,9 +20,28 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Database {
+    pub database: String,
+    pub volume: String,
+}
+
+impl From<IceBucketDatabase> for Database {
+    fn from(db: IceBucketDatabase) -> Self {
+        Database {
+            database: db.ident,
+            volume: db.volume,
+        }
+    }
+}
+
+// do not actualy use Database instead of IceBucketDatabase as
+// it's just enough updating value_type in utoipa for non-nested struct
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabasePayload {
     #[serde(flatten)]
+    #[schema(value_type = Database)]
     pub data: IceBucketDatabase,
 }
 
@@ -30,11 +49,13 @@ pub struct DatabasePayload {
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseResponse {
     #[serde(flatten)]
+    #[schema(value_type = Database)]
     pub data: IceBucketDatabase,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabasesResponse {
+    #[schema(value_type = Vec<Database>)]
     pub items: Vec<IceBucketDatabase>,
 }

--- a/crates/runtime/src/http/ui/databases/models.rs
+++ b/crates/runtime/src/http/ui/databases/models.rs
@@ -19,43 +19,71 @@ use icebucket_metastore::models::IceBucketDatabase;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
 pub struct Database {
-    pub database: String,
+    pub name: String,
     pub volume: String,
 }
 
 impl From<IceBucketDatabase> for Database {
     fn from(db: IceBucketDatabase) -> Self {
         Self {
-            database: db.ident,
+            name: db.ident,
             volume: db.volume,
         }
     }
 }
 
-// do not actualy use Database instead of IceBucketDatabase as
-// it's just enough updating value_type in utoipa for non-nested struct
+// TODO: Remove it when found why it can't locate .into() if only From trait implemeted
+#[allow(clippy::from_over_into)]
+impl Into<IceBucketDatabase> for Database {
+    fn into(self) -> IceBucketDatabase {
+        IceBucketDatabase {
+            ident: self.name,
+            volume: self.volume,
+            properties: None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct DatabasePayload {
+pub struct DatabaseCreatePayload {
     #[serde(flatten)]
-    #[schema(value_type = Database)]
-    pub data: IceBucketDatabase,
+    pub data: Database,
+}
+
+// TODO: make Database fields optional in update payload, not used currently
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DatabaseUpdatePayload {
+    #[serde(flatten)]
+    pub data: Database,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DatabaseCreateResponse {
+    #[serde(flatten)]
+    pub data: Database,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DatabaseUpdateResponse {
+    #[serde(flatten)]
+    pub data: Database,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseResponse {
     #[serde(flatten)]
-    #[schema(value_type = Database)]
-    pub data: IceBucketDatabase,
+    pub data: Database,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabasesResponse {
-    #[schema(value_type = Vec<Database>)]
-    pub items: Vec<IceBucketDatabase>,
+    pub items: Vec<Database>,
 }

--- a/crates/runtime/src/http/ui/databases/models.rs
+++ b/crates/runtime/src/http/ui/databases/models.rs
@@ -27,7 +27,7 @@ pub struct Database {
 
 impl From<IceBucketDatabase> for Database {
     fn from(db: IceBucketDatabase) -> Self {
-        Database {
+        Self {
             database: db.ident,
             volume: db.volume,
         }

--- a/crates/runtime/src/http/ui/models/table.rs
+++ b/crates/runtime/src/http/ui/models/table.rs
@@ -363,12 +363,12 @@ impl Statistics {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct QueryPayload {
+pub struct QueryCreatePayload {
     pub query: String,
     pub context: Option<HashMap<String, String>>,
 }
 
-impl QueryPayload {
+impl QueryCreatePayload {
     #[allow(clippy::new_without_default)]
     #[must_use]
     pub const fn new(query: String) -> Self {

--- a/crates/runtime/src/http/ui/queries/error.rs
+++ b/crates/runtime/src/http/ui/queries/error.rs
@@ -58,7 +58,7 @@ impl IntoStatusCode for QueriesAPIError {
                 },
             },
             Self::Queries { source } => match &source {
-                WorksheetsStoreError::HistoryGet { .. }
+                WorksheetsStoreError::QueryGet { .. }
                 | WorksheetsStoreError::WorksheetNotFound { .. }
                 | WorksheetsStoreError::BadKey { .. } => StatusCode::NOT_FOUND,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/runtime/src/http/ui/queries/error.rs
+++ b/crates/runtime/src/http/ui/queries/error.rs
@@ -25,15 +25,21 @@ use snafu::prelude::*;
 
 pub type QueriesResult<T> = Result<T, QueriesAPIError>;
 
+// Query itself can have different kinds of errors
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum QueryError {
+    #[snafu(transparent)]
+    Execution { source: crate::execution::error::ExecutionError },
+    #[snafu(transparent)]
+    Store { source: WorksheetsStoreError },
+}
+
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum QueriesAPIError {
-    #[snafu(transparent)]
-    QueryExecution {
-        source: crate::execution::error::ExecutionError,
-    }, // query execution error
-    #[snafu(display("Query worksheet error: {source}"))]
-    QueryWorksheet { source: WorksheetsStoreError }, // query worksheet error
+    #[snafu(display("Query execution error: {source}"))]
+    Query { source: QueryError },
     #[snafu(display("Error getting queries: {source}"))]
     Queries { source: WorksheetsStoreError },
 }
@@ -42,19 +48,19 @@ pub enum QueriesAPIError {
 impl IntoStatusCode for QueriesAPIError {
     fn status_code(&self) -> StatusCode {
         match self {
-            // query handler error
-            Self::QueryExecution { .. } => StatusCode::UNPROCESSABLE_ENTITY,
-            // query handler error
-            Self::QueryWorksheet { source } => match &source {
-                WorksheetsStoreError::WorksheetNotFound { .. } => StatusCode::NOT_FOUND,
-                _ => StatusCode::BAD_REQUEST,
-            },
+            Self::Query{ source } => match &source {
+                QueryError::Execution { .. } => StatusCode::UNPROCESSABLE_ENTITY,
+                QueryError::Store { source } => match &source {
+                    WorksheetsStoreError::WorksheetNotFound { .. } => StatusCode::NOT_FOUND,
+                    _ => StatusCode::BAD_REQUEST,    
+                }
+            } ,
             Self::Queries { source } => match &source {
                 WorksheetsStoreError::HistoryGet { .. }
                 | WorksheetsStoreError::WorksheetNotFound { .. }
                 | WorksheetsStoreError::BadKey { .. } => StatusCode::NOT_FOUND,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
-            },
+            }
         }
     }
 }

--- a/crates/runtime/src/http/ui/queries/error.rs
+++ b/crates/runtime/src/http/ui/queries/error.rs
@@ -30,7 +30,9 @@ pub type QueriesResult<T> = Result<T, QueriesAPIError>;
 #[snafu(visibility(pub(crate)))]
 pub enum QueryError {
     #[snafu(transparent)]
-    Execution { source: crate::execution::error::ExecutionError },
+    Execution {
+        source: crate::execution::error::ExecutionError,
+    },
     #[snafu(transparent)]
     Store { source: WorksheetsStoreError },
 }
@@ -48,19 +50,19 @@ pub enum QueriesAPIError {
 impl IntoStatusCode for QueriesAPIError {
     fn status_code(&self) -> StatusCode {
         match self {
-            Self::Query{ source } => match &source {
+            Self::Query { source } => match &source {
                 QueryError::Execution { .. } => StatusCode::UNPROCESSABLE_ENTITY,
                 QueryError::Store { source } => match &source {
                     WorksheetsStoreError::WorksheetNotFound { .. } => StatusCode::NOT_FOUND,
-                    _ => StatusCode::BAD_REQUEST,    
-                }
-            } ,
+                    _ => StatusCode::BAD_REQUEST,
+                },
+            },
             Self::Queries { source } => match &source {
                 WorksheetsStoreError::HistoryGet { .. }
                 | WorksheetsStoreError::WorksheetNotFound { .. }
                 | WorksheetsStoreError::BadKey { .. } => StatusCode::NOT_FOUND,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
-            }
+            },
         }
     }
 }

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -24,7 +24,7 @@ use crate::{
     execution::query::IceBucketQueryContext,
     http::{
         error::ErrorResponse,
-        ui::queries::error::{QueriesAPIError, QueriesResult},
+        ui::queries::error::{QueryError, QueriesAPIError, QueriesResult},
     },
 };
 use axum::{
@@ -72,7 +72,7 @@ pub async fn query(
         .history
         .get_worksheet(worksheet_id)
         .await
-        .map_err(|e| QueriesAPIError::QueryWorksheet { source: e })?;
+        .map_err(|e| QueriesAPIError::Query {  source: QueryError::Store { source: e } })?;
 
     let query_context = IceBucketQueryContext {
         database: request
@@ -90,7 +90,7 @@ pub async fn query(
         .execution_svc
         .query_table(&session_id, worksheet, &request.query, query_context)
         .await
-        .map_err(|e| QueriesAPIError::QueryExecution { source: e })?;
+        .map_err(|e| QueriesAPIError::Query { source: QueryError::Execution { source:e } })?;
     let duration = start.elapsed();
     Ok(Json(QueryResponse {
         id,

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -18,7 +18,8 @@
 use crate::http::session::DFSessionId;
 use crate::http::state::AppState;
 use crate::http::ui::queries::models::{
-    ExecutionContext, GetHistoryItemsParams, QueriesResponse, QueryPayload, QueryResponse,
+    ExecutionContext, GetHistoryItemsParams, QueriesResponse, QueryCreatePayload,
+    QueryCreateResponse,
 };
 use crate::http::{
     error::ErrorResponse,
@@ -28,7 +29,7 @@ use axum::{
     extract::{Path, Query, State},
     Json,
 };
-use icebucket_history::{QueryHistoryId, QueryItem, WorksheetId};
+use icebucket_history::{QueryRecord, QueryRecordId, WorksheetId};
 use icebucket_utils::iterable::IterableEntity;
 use std::collections::HashMap;
 use std::time::Instant;
@@ -37,7 +38,7 @@ use utoipa::OpenApi;
 #[derive(OpenApi)]
 #[openapi(
     paths(query, history,),
-    components(schemas(QueriesResponse, QueryResponse, QueryPayload,))
+    components(schemas(QueriesResponse, QueryCreateResponse, QueryCreatePayload,))
 )]
 pub struct ApiDoc;
 
@@ -52,10 +53,10 @@ pub struct ApiDoc;
     request_body(
         content(
             (
-                QueryPayload = "application/json", 
+                QueryCreatePayload = "application/json", 
                 examples (
                     ("with context" = (
-                        value = json!(QueryPayload {
+                        value = json!(QueryCreatePayload {
                             query: "CREATE TABLE test(a INT);".to_string(),
                             context: Some(HashMap::from([
                                 ("database".to_string(), "my_database".to_string()),
@@ -68,7 +69,7 @@ pub struct ApiDoc;
         )
     ),
     responses(
-        (status = 200, description = "Returns result of the query", body = QueryResponse),
+        (status = 200, description = "Returns result of the query", body = QueryCreateResponse),
         (status = 404, description = "Worksheet not found", body = ErrorResponse),
         (status = 409, description = "Bad request", body = ErrorResponse),
         (status = 422, description = "Unprocessable entity", body = ErrorResponse),
@@ -76,13 +77,12 @@ pub struct ApiDoc;
     )
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
-// Add time sql took
 pub async fn query(
     DFSessionId(session_id): DFSessionId,
     State(state): State<AppState>,
     Path(worksheet_id): Path<WorksheetId>,
-    Json(request): Json<QueryPayload>,
-) -> QueriesResult<Json<QueryResponse>> {
+    Json(request): Json<QueryCreatePayload>,
+) -> QueriesResult<Json<QueryCreateResponse>> {
     let worksheet = state
         .history
         .get_worksheet(worksheet_id)
@@ -111,7 +111,7 @@ pub async fn query(
             source: QueryError::Execution { source: e },
         })?;
     let duration = start.elapsed();
-    Ok(Json(QueryResponse {
+    Ok(Json(QueryCreateResponse {
         id,
         worksheet_id,
         query: request.query.clone(),
@@ -127,7 +127,7 @@ pub async fn query(
     tags = ["queries"],
     params(
         ("worksheet_id" = WorksheetId, Path, description = "Worksheet id"),
-        ("cursor" = Option<QueryHistoryId>, Query, description = "Cursor"),
+        ("cursor" = Option<QueryRecordId>, Query, description = "Cursor"),
         ("limit" = Option<u16>, Query, description = "History items limit"),
     ),
     responses(
@@ -138,7 +138,6 @@ pub async fn query(
     )
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
-// Add time sql took
 pub async fn history(
     Query(params): Query<GetHistoryItemsParams>,
     State(state): State<AppState>,
@@ -159,7 +158,7 @@ pub async fn history(
     let next_cursor = if let Some(last_item) = items.last() {
         last_item.next_cursor()
     } else {
-        QueryItem::min_cursor() // no items in range -> go to beginning
+        QueryRecord::min_cursor() // no items in range -> go to beginning
     };
     Ok(Json(QueriesResponse {
         items,

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -32,6 +32,7 @@ use icebucket_history::{QueryHistoryId, QueryItem, WorksheetId};
 use icebucket_utils::iterable::IterableEntity;
 use std::time::Instant;
 use utoipa::OpenApi;
+use std::collections::HashMap;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -43,12 +44,29 @@ pub struct ApiDoc;
 #[utoipa::path(
     post,
     path = "/worksheets/{worksheet_id}/queries",
-    request_body = QueryPayload,
     operation_id = "createQuery",
     tags = ["queries"],
     params(
         ("worksheet_id" = WorksheetId, Path, description = "Worksheet id")
     ),
+    request_body(
+        content(
+            (
+                QueryPayload = "application/json", 
+                examples (
+                    ("with context" = (
+                        value = json!(QueryPayload {
+                            query: "CREATE TABLE test(a INT);".to_string(),
+                            context: Some(HashMap::from([
+                                ("database".to_string(), "my_database".to_string()),
+                                ("schema".to_string(), "public".to_string()),
+                            ])),
+                        })
+                    )),
+                )
+            ),
+        )
+    ),        
     responses(
         (status = 200, description = "Returns result of the query", body = QueryResponse),
         (status = 404, description = "Worksheet not found", body = ErrorResponse),

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -18,7 +18,7 @@
 use crate::http::session::DFSessionId;
 use crate::http::state::AppState;
 use crate::http::ui::queries::models::{
-    GetHistoryItemsParams, QueriesResponse, QueryPayload, QueryResponse,
+    ExecutionContext, GetHistoryItemsParams, QueriesResponse, QueryPayload, QueryResponse,
 };
 use crate::{
     execution::query::IceBucketQueryContext,
@@ -72,9 +72,11 @@ pub async fn query(
         .history
         .get_worksheet(worksheet_id)
         .await
-        .map_err(|e| QueriesAPIError::Query {  source: QueryError::Store { source: e } })?;
+        .map_err(|e| QueriesAPIError::Query {
+            source: QueryError::Store { source: e },
+        })?;
 
-    let query_context = IceBucketQueryContext {
+    let query_context = ExecutionContext {
         database: request
             .context
             .as_ref()
@@ -90,7 +92,9 @@ pub async fn query(
         .execution_svc
         .query_table(&session_id, worksheet, &request.query, query_context)
         .await
-        .map_err(|e| QueriesAPIError::Query { source: QueryError::Execution { source:e } })?;
+        .map_err(|e| QueriesAPIError::Query {
+            source: QueryError::Execution { source: e },
+        })?;
     let duration = start.elapsed();
     Ok(Json(QueryResponse {
         id,

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -30,9 +30,9 @@ use axum::{
 };
 use icebucket_history::{QueryHistoryId, QueryItem, WorksheetId};
 use icebucket_utils::iterable::IterableEntity;
+use std::collections::HashMap;
 use std::time::Instant;
 use utoipa::OpenApi;
-use std::collections::HashMap;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -66,7 +66,7 @@ pub struct ApiDoc;
                 )
             ),
         )
-    ),        
+    ),
     responses(
         (status = 200, description = "Returns result of the query", body = QueryResponse),
         (status = 404, description = "Worksheet not found", body = ErrorResponse),

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -20,12 +20,9 @@ use crate::http::state::AppState;
 use crate::http::ui::queries::models::{
     ExecutionContext, GetHistoryItemsParams, QueriesResponse, QueryPayload, QueryResponse,
 };
-use crate::{
-    execution::query::IceBucketQueryContext,
-    http::{
-        error::ErrorResponse,
-        ui::queries::error::{QueryError, QueriesAPIError, QueriesResult},
-    },
+use crate::http::{
+    error::ErrorResponse,
+    ui::queries::error::{QueriesAPIError, QueriesResult, QueryError},
 };
 use axum::{
     extract::{Path, Query, State},

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -108,8 +108,6 @@ pub async fn query(
 #[utoipa::path(
     get,
     path = "/worksheets/{worksheet_id}/queries",
-    // params(("cursor" = String, description = "Cursor")),
-    // params(("limit" = u16, description = "Limit")),
     operation_id = "getQueries",
     tags = ["queries"],
     params(

--- a/crates/runtime/src/http/ui/queries/models.rs
+++ b/crates/runtime/src/http/ui/queries/models.rs
@@ -21,6 +21,8 @@ use std::collections::HashMap;
 use utoipa::ToSchema;
 use validator::Validate;
 
+pub type ExecutionContext = crate::execution::query::IceBucketQueryContext;
+
 // Temporarily copied here
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/crates/runtime/src/http/ui/queries/models.rs
+++ b/crates/runtime/src/http/ui/queries/models.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use icebucket_history::{QueryHistoryId, QueryItem, WorksheetId};
+use icebucket_history::{QueryRecord, QueryRecordId, WorksheetId};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use utoipa::ToSchema;
@@ -26,62 +26,31 @@ pub type ExecutionContext = crate::execution::query::IceBucketQueryContext;
 // Temporarily copied here
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct QueryPayload {
+pub struct QueryCreatePayload {
     pub query: String,
     pub context: Option<HashMap<String, String>>,
 }
 
-impl QueryPayload {
-    #[allow(clippy::new_without_default)]
-    #[must_use]
-    pub const fn new(query: String) -> Self {
-        Self {
-            query,
-            context: None,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Validate, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct QueryResponse {
-    pub id: QueryHistoryId,
+pub struct QueryCreateResponse {
+    pub id: QueryRecordId,
     pub worksheet_id: WorksheetId,
     pub query: String,
     pub result: String,
     pub duration_seconds: f32,
 }
 
-impl QueryResponse {
-    #[allow(clippy::new_without_default)]
-    #[must_use]
-    pub const fn new(
-        id: QueryHistoryId,
-        worksheet_id: WorksheetId,
-        query: String,
-        result: String,
-        duration_seconds: f32,
-    ) -> Self {
-        Self {
-            id,
-            worksheet_id,
-            query,
-            result,
-            duration_seconds,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QueriesResponse {
-    pub items: Vec<QueryItem>,
-    pub current_cursor: Option<QueryHistoryId>,
-    pub next_cursor: QueryHistoryId,
+    pub items: Vec<QueryRecord>,
+    pub current_cursor: Option<QueryRecordId>,
+    pub next_cursor: QueryRecordId,
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema, utoipa::IntoParams)]
 pub struct GetHistoryItemsParams {
-    pub cursor: Option<QueryHistoryId>,
+    pub cursor: Option<QueryRecordId>,
     pub limit: Option<u16>,
 }

--- a/crates/runtime/src/http/ui/schemas/models.rs
+++ b/crates/runtime/src/http/ui/schemas/models.rs
@@ -15,26 +15,54 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use icebucket_metastore::models::IceBucketSchema;
+use icebucket_metastore::models::{IceBucketSchema, IceBucketSchemaIdent};
 use serde::{Deserialize, Serialize};
+use std::convert::From;
 use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Schema {
+    pub database: String,
+    pub schema: String,
+}
+
+impl From<IceBucketSchema> for Schema {
+    fn from(schema: IceBucketSchema) -> Self {
+        Schema {
+            schema: schema.ident.schema,
+            database: schema.ident.database,
+        }
+    }
+}
+
+impl Into<IceBucketSchema> for Schema {
+    fn into(self) -> IceBucketSchema {
+        IceBucketSchema {
+            ident: IceBucketSchemaIdent {
+                schema: self.schema,
+                database: self.database,
+            },
+            properties: None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaPayload {
     #[serde(flatten)]
-    pub data: IceBucketSchema,
+    pub data: Schema,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaResponse {
     #[serde(flatten)]
-    pub data: IceBucketSchema,
+    pub data: Schema,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemasResponse {
-    pub items: Vec<IceBucketSchema>,
+    pub items: Vec<Schema>,
 }

--- a/crates/runtime/src/http/ui/schemas/models.rs
+++ b/crates/runtime/src/http/ui/schemas/models.rs
@@ -35,6 +35,8 @@ impl From<IceBucketSchema> for Schema {
     }
 }
 
+// TODO: Remove it when found why it can't locate .into() if only From trait implemeted
+#[allow(clippy::from_over_into)]
 impl Into<IceBucketSchema> for Schema {
     fn into(self) -> IceBucketSchema {
         IceBucketSchema {

--- a/crates/runtime/src/http/ui/schemas/models.rs
+++ b/crates/runtime/src/http/ui/schemas/models.rs
@@ -23,13 +23,13 @@ use utoipa::ToSchema;
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Schema {
     pub database: String,
-    pub schema: String,
+    pub name: String,
 }
 
 impl From<IceBucketSchema> for Schema {
     fn from(schema: IceBucketSchema) -> Self {
         Self {
-            schema: schema.ident.schema,
+            name: schema.ident.schema,
             database: schema.ident.database,
         }
     }
@@ -41,7 +41,7 @@ impl Into<IceBucketSchema> for Schema {
     fn into(self) -> IceBucketSchema {
         IceBucketSchema {
             ident: IceBucketSchemaIdent {
-                schema: self.schema,
+                schema: self.name,
                 database: self.database,
             },
             properties: None,
@@ -51,7 +51,28 @@ impl Into<IceBucketSchema> for Schema {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SchemaPayload {
+pub struct SchemaCreatePayload {
+    #[serde(flatten)]
+    pub data: Schema,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaUpdatePayload {
+    #[serde(flatten)]
+    pub data: Schema,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaCreateResponse {
+    #[serde(flatten)]
+    pub data: Schema,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaUpdateResponse {
     #[serde(flatten)]
     pub data: Schema,
 }

--- a/crates/runtime/src/http/ui/schemas/models.rs
+++ b/crates/runtime/src/http/ui/schemas/models.rs
@@ -28,7 +28,7 @@ pub struct Schema {
 
 impl From<IceBucketSchema> for Schema {
     fn from(schema: IceBucketSchema) -> Self {
-        Schema {
+        Self {
             schema: schema.ident.schema,
             database: schema.ident.database,
         }

--- a/crates/runtime/src/http/ui/tests/common.rs
+++ b/crates/runtime/src/http/ui/tests/common.rs
@@ -55,18 +55,7 @@ pub async fn req(
         .send()
         .await;
 
-    if let Ok(res) = &res {
-        match res.error_for_status_ref() {
-            Ok(res) => {
-                eprintln!("res: {res:?}");
-            }
-            Err(err) => {
-                eprintln!("err: {err:?}");
-            }
-        }
-    } else if let Err(err) = &res {
-        eprintln!("req: {method} {url}, error: {err:?}");
-    }
+    eprintln!("req: {method} {url}, {res:?}");
 
     res
 }

--- a/crates/runtime/src/http/ui/tests/common.rs
+++ b/crates/runtime/src/http/ui/tests/common.rs
@@ -17,9 +17,9 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use crate::http::ui::databases::models::DatabasePayload;
-use crate::http::ui::schemas::models::SchemaPayload;
-use crate::http::ui::volumes::models::VolumePayload;
+use crate::http::ui::databases::models::DatabaseCreatePayload;
+use crate::http::ui::schemas::models::SchemaCreatePayload;
+use crate::http::ui::volumes::models::VolumeCreatePayload;
 use http::Method;
 use reqwest::Response;
 use serde_json::json;
@@ -28,9 +28,9 @@ use std::net::SocketAddr;
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum Entity {
-    Volume(VolumePayload),
-    Database(DatabasePayload),
-    Schema(SchemaPayload),
+    Volume(VolumeCreatePayload),
+    Database(DatabaseCreatePayload),
+    Schema(SchemaCreatePayload),
 }
 
 #[derive(Debug)]
@@ -71,7 +71,7 @@ fn ui_op_endpoint(addr: SocketAddr, t: &Entity, op: &Op) -> String {
         Entity::Database(db) => match op {
             Op::Create | Op::List => format!("http://{addr}/ui/databases"),
             Op::Delete | Op::Get | Op::Update => {
-                format!("http://{addr}/ui/databases/{}", db.data.ident)
+                format!("http://{addr}/ui/databases/{}", db.data.name)
             }
         },
         Entity::Schema(sc) => match op {
@@ -80,7 +80,7 @@ fn ui_op_endpoint(addr: SocketAddr, t: &Entity, op: &Op) -> String {
             }
             Op::Delete | Op::Get | Op::Update => format!(
                 "http://{addr}/ui/databases/{}/schemas/{}",
-                sc.data.database, sc.data.schema
+                sc.data.database, sc.data.name
             ),
         },
     }

--- a/crates/runtime/src/http/ui/tests/common.rs
+++ b/crates/runtime/src/http/ui/tests/common.rs
@@ -76,7 +76,7 @@ fn ui_op_endpoint(addr: SocketAddr, t: &Entity, op: &Op) -> String {
         Entity::Volume(vol) => match op {
             Op::Create | Op::List => format!("http://{addr}/ui/volumes"),
             Op::Delete | Op::Get | Op::Update => {
-                format!("http://{addr}/ui/volumes/{}", vol.data.ident)
+                format!("http://{addr}/ui/volumes/{}", vol.data.name)
             }
         },
         Entity::Database(db) => match op {
@@ -87,14 +87,11 @@ fn ui_op_endpoint(addr: SocketAddr, t: &Entity, op: &Op) -> String {
         },
         Entity::Schema(sc) => match op {
             Op::Create | Op::List => {
-                format!(
-                    "http://{addr}/ui/databases/{}/schemas",
-                    sc.data.ident.database
-                )
+                format!("http://{addr}/ui/databases/{}/schemas", sc.data.database)
             }
             Op::Delete | Op::Get | Op::Update => format!(
                 "http://{addr}/ui/databases/{}/schemas/{}",
-                sc.data.ident.database, sc.data.ident.schema
+                sc.data.database, sc.data.schema
             ),
         },
     }

--- a/crates/runtime/src/http/ui/tests/databases.rs
+++ b/crates/runtime/src/http/ui/tests/databases.rs
@@ -20,7 +20,7 @@
 use crate::http::error::ErrorResponse;
 use crate::http::ui::databases::models::{DatabasePayload, DatabaseResponse, DatabasesResponse};
 use crate::http::ui::tests::common::{ui_test_op, Entity, Op};
-use crate::http::ui::volumes::models::{VolumePayload, VolumeResponse};
+use crate::http::ui::volumes::models::{Volume, VolumePayload, VolumeResponse};
 use crate::tests::run_icebucket_test_server;
 use icebucket_metastore::IceBucketVolumeType;
 use icebucket_metastore::{IceBucketDatabase, IceBucketVolume};
@@ -36,10 +36,10 @@ async fn test_ui_databases_metastore_update_bug() {
         Op::Create,
         None,
         &Entity::Volume(VolumePayload {
-            data: IceBucketVolume {
+            data: Volume::from(IceBucketVolume {
                 ident: String::new(),
                 volume: IceBucketVolumeType::Memory,
-            },
+            }),
         }),
     )
     .await;
@@ -121,10 +121,10 @@ async fn test_ui_databases() {
         Op::Create,
         None,
         &Entity::Volume(VolumePayload {
-            data: IceBucketVolume {
+            data: Volume::from(IceBucketVolume {
                 ident: String::new(),
                 volume: IceBucketVolumeType::Memory,
-            },
+            }),
         }),
     )
     .await;
@@ -135,7 +135,7 @@ async fn test_ui_databases() {
         data: IceBucketDatabase {
             ident: String::new(),
             properties: None,
-            volume: volume.data.ident.clone(),
+            volume: volume.data.name.clone(),
         },
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected.clone())).await;
@@ -156,7 +156,7 @@ async fn test_ui_databases() {
         data: IceBucketDatabase {
             ident: "test".to_string(),
             properties: None,
-            volume: volume.data.ident.clone(),
+            volume: volume.data.name.clone(),
         },
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected.clone())).await;

--- a/crates/runtime/src/http/ui/tests/databases.rs
+++ b/crates/runtime/src/http/ui/tests/databases.rs
@@ -18,9 +18,11 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use crate::http::error::ErrorResponse;
-use crate::http::ui::databases::models::{DatabasePayload, DatabaseResponse, DatabasesResponse};
+use crate::http::ui::databases::models::{
+    DatabaseCreatePayload, DatabaseResponse, DatabasesResponse,
+};
 use crate::http::ui::tests::common::{ui_test_op, Entity, Op};
-use crate::http::ui::volumes::models::{Volume, VolumePayload, VolumeResponse};
+use crate::http::ui::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse};
 use crate::tests::run_icebucket_test_server;
 use icebucket_metastore::IceBucketVolumeType;
 use icebucket_metastore::{IceBucketDatabase, IceBucketVolume};
@@ -35,7 +37,7 @@ async fn test_ui_databases_metastore_update_bug() {
         addr,
         Op::Create,
         None,
-        &Entity::Volume(VolumePayload {
+        &Entity::Volume(VolumeCreatePayload {
             data: Volume::from(IceBucketVolume {
                 ident: String::from("t"),
                 volume: IceBucketVolumeType::Memory,
@@ -43,15 +45,16 @@ async fn test_ui_databases_metastore_update_bug() {
         }),
     )
     .await;
-    let volume = res.json::<VolumeResponse>().await.unwrap();
+    let volume = res.json::<VolumeCreateResponse>().await.unwrap();
 
     // Create database, Ok
-    let expected = DatabasePayload {
+    let expected = DatabaseCreatePayload {
         data: IceBucketDatabase {
             ident: "test".to_string(),
             properties: None,
             volume: volume.data.name.clone(),
-        },
+        }
+        .into(),
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected.clone())).await;
     assert_eq!(http::StatusCode::OK, res.status());
@@ -59,17 +62,18 @@ async fn test_ui_databases_metastore_update_bug() {
     assert_eq!(expected.data, created_database.data);
 
     // Update database test -> new-test, Ok
-    let new_database = DatabasePayload {
+    let new_database = DatabaseCreatePayload {
         data: IceBucketDatabase {
             ident: "new-test".to_string(),
             properties: None,
             volume: volume.data.name.clone(),
-        },
+        }
+        .into(),
     };
     let res = ui_test_op(
         addr,
         Op::Update,
-        Some(&Entity::Database(DatabasePayload {
+        Some(&Entity::Database(DatabaseCreatePayload {
             data: created_database.data.clone(),
         })),
         &Entity::Database(new_database.clone()),
@@ -86,7 +90,7 @@ async fn test_ui_databases_metastore_update_bug() {
         addr,
         Op::Get,
         None,
-        &Entity::Database(DatabasePayload {
+        &Entity::Database(DatabaseCreatePayload {
             data: created_database.data.clone(),
         }),
     )
@@ -100,7 +104,7 @@ async fn test_ui_databases_metastore_update_bug() {
         addr,
         Op::Get,
         None,
-        &Entity::Database(DatabasePayload {
+        &Entity::Database(DatabaseCreatePayload {
             data: renamed_database.data.clone(),
         }),
     )
@@ -120,7 +124,7 @@ async fn test_ui_databases() {
         addr,
         Op::Create,
         None,
-        &Entity::Volume(VolumePayload {
+        &Entity::Volume(VolumeCreatePayload {
             data: Volume::from(IceBucketVolume {
                 ident: String::new(),
                 volume: IceBucketVolumeType::Memory,
@@ -128,15 +132,16 @@ async fn test_ui_databases() {
         }),
     )
     .await;
-    let volume = res.json::<VolumeResponse>().await.unwrap();
+    let volume = res.json::<VolumeCreateResponse>().await.unwrap();
 
     // Create database with empty name, error 400
-    let expected = DatabasePayload {
+    let expected = DatabaseCreatePayload {
         data: IceBucketDatabase {
             ident: String::new(),
             properties: None,
             volume: volume.data.name.clone(),
-        },
+        }
+        .into(),
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected.clone())).await;
     assert_eq!(http::StatusCode::BAD_REQUEST, res.status());
@@ -152,12 +157,13 @@ async fn test_ui_databases() {
     assert_eq!(0, databases.items.len());
 
     // Create database, Ok
-    let expected = DatabasePayload {
+    let expected = DatabaseCreatePayload {
         data: IceBucketDatabase {
             ident: "test".to_string(),
             properties: None,
             volume: volume.data.name.clone(),
-        },
+        }
+        .into(),
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected.clone())).await;
     assert_eq!(http::StatusCode::OK, res.status());
@@ -174,7 +180,7 @@ async fn test_ui_databases() {
     let res = ui_test_op(
         addr,
         Op::Delete,
-        Some(&Entity::Database(DatabasePayload {
+        Some(&Entity::Database(DatabaseCreatePayload {
             data: created_database.data.clone(),
         })),
         &stub,

--- a/crates/runtime/src/http/ui/tests/databases.rs
+++ b/crates/runtime/src/http/ui/tests/databases.rs
@@ -37,20 +37,20 @@ async fn test_ui_databases_metastore_update_bug() {
         None,
         &Entity::Volume(VolumePayload {
             data: Volume::from(IceBucketVolume {
-                ident: String::new(),
+                ident: String::from("t"),
                 volume: IceBucketVolumeType::Memory,
             }),
         }),
     )
     .await;
-    let volume = res.json::<DatabaseResponse>().await.unwrap();
+    let volume = res.json::<VolumeResponse>().await.unwrap();
 
     // Create database, Ok
     let expected = DatabasePayload {
         data: IceBucketDatabase {
             ident: "test".to_string(),
             properties: None,
-            volume: volume.data.ident.clone(),
+            volume: volume.data.name.clone(),
         },
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected.clone())).await;
@@ -63,7 +63,7 @@ async fn test_ui_databases_metastore_update_bug() {
         data: IceBucketDatabase {
             ident: "new-test".to_string(),
             properties: None,
-            volume: volume.data.ident.clone(),
+            volume: volume.data.name.clone(),
         },
     };
     let res = ui_test_op(

--- a/crates/runtime/src/http/ui/tests/queries.rs
+++ b/crates/runtime/src/http/ui/tests/queries.rs
@@ -20,7 +20,7 @@
 use crate::http::error::ErrorResponse;
 use crate::http::ui::queries::models::{QueriesResponse, QueryPayload, QueryResponse};
 use crate::http::ui::tests::common::req;
-use crate::http::ui::worksheets::models::{WorksheetPayload, WorksheetResponse};
+use crate::http::ui::worksheets::models::{WorksheetCreatePayload, WorksheetResponse};
 use crate::tests::run_icebucket_test_server;
 use http::Method;
 use icebucket_history::QueryStatus;
@@ -36,9 +36,9 @@ async fn test_ui_queries() {
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets"),
-        json!(WorksheetPayload {
-            name: None,
-            content: None,
+        json!(WorksheetCreatePayload {
+            name: String::new(),
+            content: String::new(),
         })
         .to_string(),
     )

--- a/crates/runtime/src/http/ui/tests/queries.rs
+++ b/crates/runtime/src/http/ui/tests/queries.rs
@@ -18,7 +18,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use crate::http::error::ErrorResponse;
-use crate::http::ui::queries::models::{QueriesResponse, QueryPayload, QueryResponse};
+use crate::http::ui::queries::models::{QueriesResponse, QueryCreatePayload, QueryCreateResponse};
 use crate::http::ui::tests::common::req;
 use crate::http::ui::worksheets::models::{WorksheetCreatePayload, WorksheetResponse};
 use crate::tests::run_icebucket_test_server;
@@ -73,7 +73,7 @@ async fn test_ui_queries() {
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets/{}/queries", worksheet.id),
-        json!(QueryPayload {
+        json!(QueryCreatePayload {
             query: "SELECT 1".to_string(),
             context: None,
         })
@@ -83,14 +83,14 @@ async fn test_ui_queries() {
     .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     // println!("{:?}", res.bytes().await);
-    let query_run_resp = res.json::<QueryResponse>().await.unwrap();
+    let query_run_resp = res.json::<QueryCreateResponse>().await.unwrap();
     assert_eq!(query_run_resp.result, "[{\"Int64(1)\":1}]");
 
     let res = req(
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets/{}/queries", worksheet.id),
-        json!(QueryPayload {
+        json!(QueryCreatePayload {
             query: "SELECT 2".to_string(),
             context: None,
         })
@@ -100,14 +100,14 @@ async fn test_ui_queries() {
     .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     // println!("{:?}", res.bytes().await);
-    let query_run_resp2 = res.json::<QueryResponse>().await.unwrap();
+    let query_run_resp2 = res.json::<QueryCreateResponse>().await.unwrap();
     assert_eq!(query_run_resp2.result, "[{\"Int64(2)\":2}]");
 
     let res = req(
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets/{}/queries", worksheet.id),
-        json!(QueryPayload {
+        json!(QueryCreatePayload {
             query: "SELECT foo".to_string(),
             context: None,
         })
@@ -124,7 +124,7 @@ async fn test_ui_queries() {
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets/{}/queries", worksheet.id),
-        json!(QueryPayload {
+        json!(QueryCreatePayload {
             query: "SELECT foo".to_string(),
             context: None,
         })

--- a/crates/runtime/src/http/ui/tests/tables.rs
+++ b/crates/runtime/src/http/ui/tests/tables.rs
@@ -23,8 +23,8 @@ use crate::http::ui::queries::models::QueryPayload;
 use crate::http::ui::schemas::models::SchemaPayload;
 use crate::http::ui::tables::models::TableResponse;
 use crate::http::ui::tests::common::{req, ui_test_op, Entity, Op};
-use crate::http::ui::volumes::models::VolumePayload;
-use crate::http::ui::worksheets::{WorksheetPayload, WorksheetResponse};
+use crate::http::ui::volumes::models::{VolumePayload, VolumeResponse};
+use crate::http::ui::worksheets::{WorksheetCreatePayload, WorksheetResponse};
 use crate::tests::run_icebucket_test_server;
 use http::Method;
 use icebucket_metastore::{IceBucketDatabase, IceBucketVolume};
@@ -47,18 +47,19 @@ async fn test_ui_tables() {
             data: IceBucketVolume {
                 ident: String::new(),
                 volume: IceBucketVolumeType::Memory,
-            },
+            }
+            .into(),
         }),
     )
     .await;
-    let volume: IceBucketVolume = res.json().await.unwrap();
+    let volume: VolumeResponse = res.json().await.unwrap();
 
     let database_name = "test1".to_string();
     // Create database, Ok
     let expected1 = IceBucketDatabase {
         ident: database_name.clone(),
         properties: None,
-        volume: volume.ident.clone(),
+        volume: volume.data.name.clone(),
     };
     let _res = ui_test_op(
         addr,
@@ -81,7 +82,7 @@ async fn test_ui_tables() {
     };
 
     let payload = SchemaPayload {
-        data: schema_expected1.clone(),
+        data: schema_expected1.clone().into(),
     };
 
     //Create schema
@@ -103,9 +104,9 @@ async fn test_ui_tables() {
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets"),
-        json!(WorksheetPayload {
-            name: Some("test".to_string()),
-            content: None,
+        json!(WorksheetCreatePayload {
+            name: "test".to_string(),
+            content: String::new(),
         })
         .to_string(),
     )

--- a/crates/runtime/src/http/ui/tests/volumes.rs
+++ b/crates/runtime/src/http/ui/tests/volumes.rs
@@ -17,7 +17,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use crate::http::ui::tests::common::{ui_test_op, Entity, Op};
-use crate::http::ui::volumes::models::{VolumePayload, VolumeResponse};
+use crate::http::ui::volumes::models::{Volume, VolumePayload, VolumeResponse};
 use crate::tests::run_icebucket_test_server;
 use icebucket_metastore::IceBucketVolume;
 use icebucket_metastore::{
@@ -32,10 +32,10 @@ async fn test_ui_volumes_memory() {
 
     // memory volume with empty ident create Ok
     let expected = VolumePayload {
-        data: IceBucketVolume {
+        data: Volume::from(IceBucketVolume {
             ident: String::new(),
             volume: IceBucketVolumeType::Memory,
-        },
+        }),
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     assert_eq!(200, res.status());
@@ -50,12 +50,12 @@ async fn test_ui_volumes_file() {
 
     // memory volume with empty ident create Ok
     let expected = VolumePayload {
-        data: IceBucketVolume {
+        data: Volume::from(IceBucketVolume {
             ident: String::new(),
             volume: IceBucketVolumeType::File(IceBucketFileVolume {
                 path: "/tmp/data".to_string(),
             }),
-        },
+        }),
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     // let res = create_test_volume(addr, &expected).await;
@@ -71,7 +71,7 @@ async fn test_ui_volumes_s3() {
 
     // memory volume with empty ident create Ok
     let expected = VolumePayload {
-        data: IceBucketVolume {
+        data: Volume::from(IceBucketVolume {
             ident: String::new(),
             volume: IceBucketVolumeType::S3(IceBucketS3Volume {
                 region: Some("us-west-1".to_string()),
@@ -84,7 +84,7 @@ async fn test_ui_volumes_s3() {
                     aws_secret_access_key: "********".to_string(),
                 })),
             }),
-        },
+        }),
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     // let res = create_test_volume(addr, &expected).await;

--- a/crates/runtime/src/http/ui/tests/volumes.rs
+++ b/crates/runtime/src/http/ui/tests/volumes.rs
@@ -17,7 +17,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use crate::http::ui::tests::common::{ui_test_op, Entity, Op};
-use crate::http::ui::volumes::models::{Volume, VolumePayload, VolumeResponse};
+use crate::http::ui::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse};
 use crate::tests::run_icebucket_test_server;
 use icebucket_metastore::IceBucketVolume;
 use icebucket_metastore::{
@@ -31,7 +31,7 @@ async fn test_ui_volumes_memory() {
     let addr = run_icebucket_test_server().await;
 
     // memory volume with empty ident create Ok
-    let expected = VolumePayload {
+    let expected = VolumeCreatePayload {
         data: Volume::from(IceBucketVolume {
             ident: String::new(),
             volume: IceBucketVolumeType::Memory,
@@ -39,7 +39,7 @@ async fn test_ui_volumes_memory() {
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     assert_eq!(200, res.status());
-    let created = res.json::<VolumeResponse>().await.unwrap();
+    let created = res.json::<VolumeCreateResponse>().await.unwrap();
     assert_eq!(expected.data, created.data);
 }
 
@@ -49,7 +49,7 @@ async fn test_ui_volumes_file() {
     let addr = run_icebucket_test_server().await;
 
     // memory volume with empty ident create Ok
-    let expected = VolumePayload {
+    let expected = VolumeCreatePayload {
         data: Volume::from(IceBucketVolume {
             ident: String::new(),
             volume: IceBucketVolumeType::File(IceBucketFileVolume {
@@ -60,7 +60,7 @@ async fn test_ui_volumes_file() {
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     // let res = create_test_volume(addr, &expected).await;
     assert_eq!(200, res.status());
-    let created = res.json::<VolumeResponse>().await.unwrap();
+    let created = res.json::<VolumeCreateResponse>().await.unwrap();
     assert_eq!(expected.data, created.data);
 }
 
@@ -70,7 +70,7 @@ async fn test_ui_volumes_s3() {
     let addr = run_icebucket_test_server().await;
 
     // memory volume with empty ident create Ok
-    let expected = VolumePayload {
+    let expected = VolumeCreatePayload {
         data: Volume::from(IceBucketVolume {
             ident: String::new(),
             volume: IceBucketVolumeType::S3(IceBucketS3Volume {
@@ -89,6 +89,6 @@ async fn test_ui_volumes_s3() {
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     // let res = create_test_volume(addr, &expected).await;
     assert_eq!(200, res.status());
-    let created = res.json::<VolumeResponse>().await.unwrap();
+    let created = res.json::<VolumeCreateResponse>().await.unwrap();
     assert_eq!(expected.data, created.data);
 }

--- a/crates/runtime/src/http/ui/tests/worksheets.rs
+++ b/crates/runtime/src/http/ui/tests/worksheets.rs
@@ -19,7 +19,7 @@
 
 use crate::http::error::ErrorResponse;
 use crate::http::ui::tests::common::req;
-use crate::http::ui::worksheets::{WorksheetPayload, WorksheetResponse, WorksheetsResponse};
+use crate::http::ui::worksheets::{WorksheetCreatePayload, WorksheetUpdatePayload, WorksheetResponse, WorksheetsResponse};
 use crate::tests::run_icebucket_test_server;
 use http::Method;
 use serde_json::json;
@@ -44,9 +44,9 @@ async fn test_ui_worksheets() {
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets"),
-        json!(WorksheetPayload {
-            name: None,
-            content: None,
+        json!(WorksheetCreatePayload {
+            name: String::new(),
+            content: String::new(),
         })
         .to_string(),
     )
@@ -55,17 +55,18 @@ async fn test_ui_worksheets() {
     assert_eq!(http::StatusCode::OK, res.status());
     let worksheet1 = res.json::<WorksheetResponse>().await.unwrap().data;
     assert!(worksheet1.id > 0);
-    assert!(worksheet1.name.is_none());
-    assert!(worksheet1.content.is_none());
+    assert!(!worksheet.name.is_empty()); // test behavior: name based on time
+
+    let create_payload = WorksheetCreatePayload {
+        name: "test".to_string(),
+        content: "select 1;".to_string(),
+    };
 
     let res = req(
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets"),
-        json!(WorksheetPayload {
-            name: None,
-            content: Some("select 1;".to_string()),
-        })
+        json!(create_payload)
         .to_string(),
     )
     .await
@@ -74,8 +75,8 @@ async fn test_ui_worksheets() {
     // println!("{:?}", res.bytes().await);
     let worksheet2 = res.json::<WorksheetResponse>().await.unwrap().data;
     assert!(worksheet2.id > 0);
-    assert!(worksheet2.name.is_none());
-    assert!(worksheet2.content.is_some());
+    assert_eq!(worksheet2.name, create_payload.name);
+    assert_eq!(worksheet2.content, create_payload.content);
 
     let res = req(
         &client,
@@ -97,11 +98,12 @@ async fn test_ui_worksheets_ops() {
     let addr = run_icebucket_test_server().await;
     let client = reqwest::Client::new();
 
+    // bad payload, None instead of string
     let res = req(
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets"),
-        json!(WorksheetPayload {
+        json!(WorksheetUpdatePayload {
             name: None,
             content: None,
         })
@@ -109,8 +111,23 @@ async fn test_ui_worksheets_ops() {
     )
     .await
     .unwrap();
+    assert_eq!(http::StatusCode::UNPROCESSABLE_ENTITY, res.status());
+
+    let res = req(
+        &client,
+        Method::POST,
+        &format!("http://{addr}/ui/worksheets"),
+        json!(WorksheetCreatePayload {
+            name: String::new(),
+            content: String::new(),
+        })
+        .to_string(),
+    )
+    .await
+    .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     let worksheet = res.json::<WorksheetResponse>().await.unwrap().data;
+    assert!(!worksheet.name.is_empty());
 
     let res = req(
         &client,
@@ -134,7 +151,7 @@ async fn test_ui_worksheets_ops() {
     .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
 
-    let patch_payload = WorksheetPayload {
+    let patch_payload = WorksheetUpdatePayload {
         name: Some("test".to_string()),
         content: Some("select 1".to_string()),
     };
@@ -168,8 +185,8 @@ async fn test_ui_worksheets_ops() {
     .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     let worksheet_2 = res.json::<WorksheetResponse>().await.unwrap().data;
-    assert_eq!(worksheet_2.name, patch_payload.name);
-    assert_eq!(worksheet_2.content, patch_payload.content);
+    assert_eq!(Some(worksheet_2.name), patch_payload.name);
+    assert_eq!(Some(worksheet_2.content), patch_payload.content);
 
     let res = req(
         &client,

--- a/crates/runtime/src/http/ui/tests/worksheets.rs
+++ b/crates/runtime/src/http/ui/tests/worksheets.rs
@@ -19,7 +19,9 @@
 
 use crate::http::error::ErrorResponse;
 use crate::http::ui::tests::common::req;
-use crate::http::ui::worksheets::{WorksheetCreatePayload, WorksheetUpdatePayload, WorksheetResponse, WorksheetsResponse};
+use crate::http::ui::worksheets::{
+    WorksheetCreatePayload, WorksheetResponse, WorksheetUpdatePayload, WorksheetsResponse,
+};
 use crate::tests::run_icebucket_test_server;
 use http::Method;
 use serde_json::json;
@@ -55,7 +57,7 @@ async fn test_ui_worksheets() {
     assert_eq!(http::StatusCode::OK, res.status());
     let worksheet1 = res.json::<WorksheetResponse>().await.unwrap().data;
     assert!(worksheet1.id > 0);
-    assert!(!worksheet.name.is_empty()); // test behavior: name based on time
+    assert!(!worksheet1.name.is_empty()); // test behavior: name based on time
 
     let create_payload = WorksheetCreatePayload {
         name: "test".to_string(),
@@ -66,8 +68,7 @@ async fn test_ui_worksheets() {
         &client,
         Method::POST,
         &format!("http://{addr}/ui/worksheets"),
-        json!(create_payload)
-        .to_string(),
+        json!(create_payload).to_string(),
     )
     .await
     .unwrap();

--- a/crates/runtime/src/http/ui/volumes/handlers.rs
+++ b/crates/runtime/src/http/ui/volumes/handlers.rs
@@ -27,17 +27,18 @@ use axum::{
     Json,
 };
 use icebucket_metastore::error::MetastoreError;
+use icebucket_metastore::models::IceBucketVolume;
 use utoipa::OpenApi;
 use validator::Validate;
 
 #[derive(OpenApi)]
 #[openapi(
     paths(
-        create_volume,
+        // create_volume,
         get_volume,
-        delete_volume,
+        // delete_volume,
         list_volumes,
-        update_volume,
+        // update_volume,
     ),
     components(
         schemas(
@@ -71,18 +72,22 @@ pub async fn create_volume(
     State(state): State<AppState>,
     Json(volume): Json<VolumePayload>,
 ) -> VolumesResult<Json<VolumeResponse>> {
-    volume
-        .data
+    let icebucket_volume: IceBucketVolume = volume.data.into();
+    icebucket_volume
         .validate()
         .map_err(|e| VolumesAPIError::Create {
             source: MetastoreError::Validation { source: e },
         })?;
     state
         .metastore
-        .create_volume(&volume.data.ident.clone(), volume.data)
+        .create_volume(&icebucket_volume.ident.clone(), icebucket_volume)
         .await
         .map_err(|e| VolumesAPIError::Create { source: e })
-        .map(|o| Json(VolumeResponse { data: o.data }))
+        .map(|o| {
+            Json(VolumeResponse {
+                data: o.data.into(),
+            })
+        })
 }
 
 #[utoipa::path(
@@ -105,7 +110,9 @@ pub async fn get_volume(
     Path(volume_name): Path<String>,
 ) -> VolumesResult<Json<VolumeResponse>> {
     match state.metastore.get_volume(&volume_name).await {
-        Ok(Some(volume)) => Ok(Json(VolumeResponse { data: volume.data })),
+        Ok(Some(volume)) => Ok(Json(VolumeResponse {
+            data: volume.data.into(),
+        })),
         Ok(None) => Err(VolumesAPIError::Get {
             source: MetastoreError::VolumeNotFound {
                 volume: volume_name.clone(),
@@ -163,18 +170,20 @@ pub async fn update_volume(
     Path(volume_name): Path<String>,
     Json(volume): Json<VolumePayload>,
 ) -> VolumesResult<Json<VolumeResponse>> {
-    volume
-        .data
-        .validate()
-        .map_err(|e| VolumesAPIError::Update {
-            source: MetastoreError::Validation { source: e },
-        })?;
+    let volume: IceBucketVolume = volume.data.into();
+    volume.validate().map_err(|e| VolumesAPIError::Update {
+        source: MetastoreError::Validation { source: e },
+    })?;
     state
         .metastore
-        .update_volume(&volume_name, volume.data)
+        .update_volume(&volume_name, volume)
         .await
         .map_err(|e| VolumesAPIError::Update { source: e })
-        .map(|o| Json(VolumeResponse { data: o.data }))
+        .map(|o| {
+            Json(VolumeResponse {
+                data: o.data.into(),
+            })
+        })
 }
 
 #[utoipa::path(
@@ -194,10 +203,9 @@ pub async fn list_volumes(State(state): State<AppState>) -> VolumesResult<Json<V
         .list_volumes()
         .await
         .map_err(|e| VolumesAPIError::List { source: e })
-        // TODO: use deref
         .map(|o| {
             Json(VolumesResponse {
-                items: o.iter().map(|x| x.data.clone()).collect(),
+                items: o.into_iter().map(|x| x.data.into()).collect(),
             })
         })
 }

--- a/crates/runtime/src/http/ui/volumes/models.rs
+++ b/crates/runtime/src/http/ui/volumes/models.rs
@@ -52,7 +52,7 @@ pub struct Volume {
 
 impl From<IceBucketVolume> for Volume {
     fn from(volume: IceBucketVolume) -> Self {
-        Volume {
+        Self {
             name: volume.ident,
             volume: match volume.volume {
                 IceBucketVolumeType::S3(volume) => VolumeType::S3(S3Volume { 

--- a/crates/runtime/src/http/ui/volumes/models.rs
+++ b/crates/runtime/src/http/ui/volumes/models.rs
@@ -15,26 +15,99 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use icebucket_metastore::models::IceBucketVolume;
+use icebucket_metastore::models::{
+    IceBucketFileVolume, IceBucketS3Volume, IceBucketVolume, IceBucketVolumeType, AwsCredentials,
+};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
+pub struct S3Volume {
+    pub region: Option<String>,
+    pub bucket: Option<String>,
+    pub endpoint: Option<String>,
+    pub skip_signature: Option<bool>,
+    pub metadata_endpoint: Option<String>,
+    pub credentials: Option<AwsCredentials>,    
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
+pub struct FileVolume {
+    path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
+pub enum VolumeType {
+    S3(S3Volume),
+    File(FileVolume),
+    Memory,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
+pub struct Volume {
+    pub name: String,
+    #[serde(flatten)]
+    pub volume: VolumeType,
+}
+
+impl From<IceBucketVolume> for Volume {
+    fn from(volume: IceBucketVolume) -> Self {
+        Volume {
+            name: volume.ident,
+            volume: match volume.volume {
+                IceBucketVolumeType::S3(volume) => VolumeType::S3(S3Volume { 
+                    region: volume.region,
+                    bucket: volume.bucket,
+                    endpoint: volume.endpoint,
+                    skip_signature: volume.skip_signature,
+                    metadata_endpoint: volume.metadata_endpoint,
+                    credentials: volume.credentials,
+                }),
+                IceBucketVolumeType::File(file) => VolumeType::File(FileVolume { path: file.path }),
+                IceBucketVolumeType::Memory => VolumeType::Memory,
+            },
+        }
+    }
+}
+
+impl Into<IceBucketVolume> for Volume {
+    fn into(self) -> IceBucketVolume {
+        IceBucketVolume {
+            ident: self.name,
+            volume: match self.volume {
+                VolumeType::S3(volume) => IceBucketVolumeType::S3(IceBucketS3Volume {
+                    region: volume.region,
+                    bucket: volume.bucket,
+                    endpoint: volume.endpoint,
+                    skip_signature: volume.skip_signature,
+                    metadata_endpoint: volume.metadata_endpoint,
+                    credentials: volume.credentials,
+                }),
+                VolumeType::File(volume) => {
+                    IceBucketVolumeType::File(IceBucketFileVolume { path: volume.path })
+                }
+                VolumeType::Memory => IceBucketVolumeType::Memory,
+            },
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumePayload {
     #[serde(flatten)]
-    pub data: IceBucketVolume,
+    pub data: Volume,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumeResponse {
     #[serde(flatten)]
-    pub data: IceBucketVolume,
+    pub data: Volume,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumesResponse {
-    pub items: Vec<IceBucketVolume>,
+    pub items: Vec<Volume>,
 }

--- a/crates/runtime/src/http/ui/volumes/models.rs
+++ b/crates/runtime/src/http/ui/volumes/models.rs
@@ -70,6 +70,8 @@ impl From<IceBucketVolume> for Volume {
     }
 }
 
+// TODO: Remove it when found why it can't locate .into() if only From trait implemeted
+#[allow(clippy::from_over_into)]
 impl Into<IceBucketVolume> for Volume {
     fn into(self) -> IceBucketVolume {
         IceBucketVolume {

--- a/crates/runtime/src/http/ui/volumes/models.rs
+++ b/crates/runtime/src/http/ui/volumes/models.rs
@@ -96,7 +96,28 @@ impl Into<IceBucketVolume> for Volume {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct VolumePayload {
+pub struct VolumeCreatePayload {
+    #[serde(flatten)]
+    pub data: Volume,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VolumeUpdatePayload {
+    #[serde(flatten)]
+    pub data: Volume,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VolumeCreateResponse {
+    #[serde(flatten)]
+    pub data: Volume,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VolumeUpdateResponse {
     #[serde(flatten)]
     pub data: Volume,
 }

--- a/crates/runtime/src/http/ui/volumes/models.rs
+++ b/crates/runtime/src/http/ui/volumes/models.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use icebucket_metastore::models::{
-    IceBucketFileVolume, IceBucketS3Volume, IceBucketVolume, IceBucketVolumeType, AwsCredentials,
+    AwsCredentials, IceBucketFileVolume, IceBucketS3Volume, IceBucketVolume, IceBucketVolumeType,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -28,7 +28,7 @@ pub struct S3Volume {
     pub endpoint: Option<String>,
     pub skip_signature: Option<bool>,
     pub metadata_endpoint: Option<String>,
-    pub credentials: Option<AwsCredentials>,    
+    pub credentials: Option<AwsCredentials>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
@@ -55,7 +55,7 @@ impl From<IceBucketVolume> for Volume {
         Self {
             name: volume.ident,
             volume: match volume.volume {
-                IceBucketVolumeType::S3(volume) => VolumeType::S3(S3Volume { 
+                IceBucketVolumeType::S3(volume) => VolumeType::S3(S3Volume {
                     region: volume.region,
                     bucket: volume.bucket,
                     endpoint: volume.endpoint,

--- a/crates/runtime/src/http/ui/worksheets/error.rs
+++ b/crates/runtime/src/http/ui/worksheets/error.rs
@@ -72,9 +72,8 @@ impl IntoStatusCode for WorksheetsAPIError {
                     WorksheetsStoreError::BadKey { .. }
                     | WorksheetsStoreError::WorksheetUpdate { .. } => StatusCode::BAD_REQUEST,
                     WorksheetsStoreError::WorksheetNotFound { .. } => StatusCode::NOT_FOUND,
-                    _ => StatusCode::INTERNAL_SERVER_ERROR,                    
-                }
-
+                    _ => StatusCode::INTERNAL_SERVER_ERROR,
+                },
             },
             Self::List { source } => match &source {
                 WorksheetsStoreError::WorksheetsList { .. } => StatusCode::BAD_REQUEST,

--- a/crates/runtime/src/http/ui/worksheets/error.rs
+++ b/crates/runtime/src/http/ui/worksheets/error.rs
@@ -27,6 +27,15 @@ pub type WorksheetsResult<T> = Result<T, WorksheetsAPIError>;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
+pub enum WorksheetUpdateError {
+    #[snafu(transparent)]
+    Store { source: WorksheetsStoreError },
+    #[snafu(display("No fields to update"))]
+    NothingToUpdate,
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
 pub enum WorksheetsAPIError {
     #[snafu(display("Create worksheet error: {source}"))]
     Create { source: WorksheetsStoreError },
@@ -35,7 +44,7 @@ pub enum WorksheetsAPIError {
     #[snafu(display("Delete worksheet error: {source}"))]
     Delete { source: WorksheetsStoreError },
     #[snafu(display("Update worksheet error: {source}"))]
-    Update { source: WorksheetsStoreError },
+    Update { source: WorksheetUpdateError },
     #[snafu(display("Get worksheets error: {source}"))]
     List { source: WorksheetsStoreError },
 }
@@ -58,10 +67,14 @@ impl IntoStatusCode for WorksheetsAPIError {
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             },
             Self::Update { source } => match &source {
-                WorksheetsStoreError::BadKey { .. }
-                | WorksheetsStoreError::WorksheetUpdate { .. } => StatusCode::BAD_REQUEST,
-                WorksheetsStoreError::WorksheetNotFound { .. } => StatusCode::NOT_FOUND,
-                _ => StatusCode::INTERNAL_SERVER_ERROR,
+                WorksheetUpdateError::NothingToUpdate => StatusCode::BAD_REQUEST,
+                WorksheetUpdateError::Store { source } => match &source {
+                    WorksheetsStoreError::BadKey { .. }
+                    | WorksheetsStoreError::WorksheetUpdate { .. } => StatusCode::BAD_REQUEST,
+                    WorksheetsStoreError::WorksheetNotFound { .. } => StatusCode::NOT_FOUND,
+                    _ => StatusCode::INTERNAL_SERVER_ERROR,                    
+                }
+
             },
             Self::List { source } => match &source {
                 WorksheetsStoreError::WorksheetsList { .. } => StatusCode::BAD_REQUEST,

--- a/crates/runtime/src/http/ui/worksheets/handlers.rs
+++ b/crates/runtime/src/http/ui/worksheets/handlers.rs
@@ -19,7 +19,8 @@ use crate::http::error::ErrorResponse;
 use crate::http::state::AppState;
 use crate::http::ui::worksheets::{
     error::{WorksheetUpdateError, WorksheetsAPIError, WorksheetsResult},
-    WorksheetCreatePayload, WorksheetResponse, WorksheetUpdatePayload, WorksheetsResponse,
+    WorksheetCreatePayload, WorksheetCreateResponse, WorksheetResponse, WorksheetUpdatePayload,
+    WorksheetsResponse,
 };
 use axum::{
     extract::{Path, State},
@@ -43,6 +44,7 @@ use utoipa::OpenApi;
         ErrorResponse,
         WorksheetCreatePayload,
         WorksheetUpdatePayload,
+        WorksheetCreateResponse,
         WorksheetResponse,
         WorksheetsResponse,
     ))
@@ -61,7 +63,6 @@ pub struct ApiDoc;
     )
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
-// Add time sql took
 pub async fn worksheets(
     State(state): State<AppState>,
 ) -> WorksheetsResult<Json<WorksheetsResponse>> {
@@ -100,18 +101,17 @@ pub async fn worksheets(
         )
     ),
     responses(
-        (status = 200, description = "Created worksheet", body = WorksheetResponse),
+        (status = 200, description = "Created worksheet", body = WorksheetCreateResponse),
         (status = 409, description = "Already Exists", body = ErrorResponse),
         (status = 422, description = "Unprocessable Entity"), // Failed to deserialize payload
         (status = 500, description = "Internal server error", body = ErrorResponse),
     )
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
-// Add time sql took
 pub async fn create_worksheet(
     State(state): State<AppState>,
     Json(payload): Json<WorksheetCreatePayload>,
-) -> WorksheetsResult<Json<WorksheetResponse>> {
+) -> WorksheetsResult<Json<WorksheetCreateResponse>> {
     let name = if payload.name.is_empty() {
         Utc::now().to_string()
     } else {
@@ -123,7 +123,7 @@ pub async fn create_worksheet(
         .add_worksheet(request)
         .await
         .map_err(|e| WorksheetsAPIError::Create { source: e })?;
-    Ok(Json(WorksheetResponse { data: worksheet }))
+    Ok(Json(WorksheetCreateResponse { data: worksheet }))
 }
 
 #[utoipa::path(
@@ -142,7 +142,6 @@ pub async fn create_worksheet(
     )
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
-// Add time sql took
 pub async fn worksheet(
     State(state): State<AppState>,
     Path(worksheet_id): Path<WorksheetId>,
@@ -170,7 +169,6 @@ pub async fn worksheet(
     )
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
-// Add time sql took
 pub async fn delete_worksheet(
     State(state): State<AppState>,
     Path(worksheet_id): Path<WorksheetId>,
@@ -212,14 +210,13 @@ pub async fn delete_worksheet(
         )
     ),
     responses(
-        (status = 200, description = "Worksheet updated", body = WorksheetResponse),
+        (status = 200, description = "Worksheet updated"),
         (status = 400, description = "Bad request", body = ErrorResponse),
         (status = 404, description = "Worksheet not found", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse),
     )
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
-// Add time sql took
 pub async fn update_worksheet(
     State(state): State<AppState>,
     Path(worksheet_id): Path<WorksheetId>,

--- a/crates/runtime/src/http/ui/worksheets/handlers.rs
+++ b/crates/runtime/src/http/ui/worksheets/handlers.rs
@@ -18,17 +18,17 @@
 use crate::http::error::ErrorResponse;
 use crate::http::state::AppState;
 use crate::http::ui::worksheets::{
-    error::{WorksheetsAPIError, WorksheetUpdateError, WorksheetsResult},
-    WorksheetCreatePayload, WorksheetUpdatePayload, WorksheetResponse, WorksheetsResponse,
+    error::{WorksheetUpdateError, WorksheetsAPIError, WorksheetsResult},
+    WorksheetCreatePayload, WorksheetResponse, WorksheetUpdatePayload, WorksheetsResponse,
 };
 use axum::{
     extract::{Path, State},
     Json,
 };
+use chrono::Utc;
 use icebucket_history::{Worksheet, WorksheetId};
 use tracing;
 use utoipa::OpenApi;
-use chrono::Utc;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -39,7 +39,13 @@ use chrono::Utc;
         delete_worksheet,
         update_worksheet,
     ),
-    components(schemas(ErrorResponse, WorksheetCreatePayload, WorksheetUpdatePayload, WorksheetResponse, WorksheetsResponse,))
+    components(schemas(
+        ErrorResponse,
+        WorksheetCreatePayload,
+        WorksheetUpdatePayload,
+        WorksheetResponse,
+        WorksheetsResponse,
+    ))
 )]
 pub struct ApiDoc;
 
@@ -117,7 +123,7 @@ pub async fn create_worksheet(
         .add_worksheet(request)
         .await
         .map_err(|e| WorksheetsAPIError::Create { source: e })?;
-    Ok(Json(WorksheetResponse { data: worksheet } ))
+    Ok(Json(WorksheetResponse { data: worksheet }))
 }
 
 #[utoipa::path(
@@ -199,7 +205,9 @@ pub async fn update_worksheet(
     Json(payload): Json<WorksheetUpdatePayload>,
 ) -> WorksheetsResult<()> {
     if payload.name.is_none() && payload.content.is_none() {
-        return Err(WorksheetsAPIError::Update { source: WorksheetUpdateError::NothingToUpdate })
+        return Err(WorksheetsAPIError::Update {
+            source: WorksheetUpdateError::NothingToUpdate,
+        });
     }
 
     let mut worksheet = state
@@ -207,7 +215,7 @@ pub async fn update_worksheet(
         .get_worksheet(worksheet_id)
         .await
         .map_err(|e| WorksheetsAPIError::Update {
-            source: WorksheetUpdateError::Store { source: e }
+            source: WorksheetUpdateError::Store { source: e },
         })?;
 
     if let Some(name) = payload.name {
@@ -223,6 +231,6 @@ pub async fn update_worksheet(
         .update_worksheet(worksheet)
         .await
         .map_err(|e| WorksheetsAPIError::Update {
-            source: WorksheetUpdateError::Store { source: e }
+            source: WorksheetUpdateError::Store { source: e },
         })
 }

--- a/crates/runtime/src/http/ui/worksheets/handlers.rs
+++ b/crates/runtime/src/http/ui/worksheets/handlers.rs
@@ -206,11 +206,11 @@ pub async fn delete_worksheet(
                             name: None,
                             content: Some("SELECT * from test;".into()),
                         })
-                    )),                    
+                    )),
                 )
             ),
         )
-    ),    
+    ),
     responses(
         (status = 200, description = "Worksheet updated", body = WorksheetResponse),
         (status = 400, description = "Bad request", body = ErrorResponse),

--- a/crates/runtime/src/http/ui/worksheets/handlers.rs
+++ b/crates/runtime/src/http/ui/worksheets/handlers.rs
@@ -190,6 +190,27 @@ pub async fn delete_worksheet(
     params(
         ("worksheet_id" = WorksheetId, Path, description = "Worksheet id")
     ),
+    request_body(
+        content(
+            (
+                WorksheetUpdatePayload = "application/json", 
+                examples (
+                    ("rename" = (
+                        value = json!(WorksheetUpdatePayload {
+                            name: Some("new-worksheet".into()),
+                            content: None,
+                        })
+                    )),
+                    ("update content" = (
+                        value = json!(WorksheetUpdatePayload {
+                            name: None,
+                            content: Some("SELECT * from test;".into()),
+                        })
+                    )),                    
+                )
+            ),
+        )
+    ),    
     responses(
         (status = 200, description = "Worksheet updated", body = WorksheetResponse),
         (status = 400, description = "Bad request", body = ErrorResponse),

--- a/crates/runtime/src/http/ui/worksheets/models.rs
+++ b/crates/runtime/src/http/ui/worksheets/models.rs
@@ -37,6 +37,13 @@ pub struct WorksheetUpdatePayload {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct WorksheetCreateResponse {
+    #[serde(flatten)]
+    pub data: Worksheet,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct WorksheetResponse {
     #[serde(flatten)]
     pub data: Worksheet,

--- a/crates/runtime/src/http/ui/worksheets/models.rs
+++ b/crates/runtime/src/http/ui/worksheets/models.rs
@@ -19,7 +19,6 @@ use icebucket_history::Worksheet;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct WorksheetCreatePayload {

--- a/crates/runtime/src/http/ui/worksheets/models.rs
+++ b/crates/runtime/src/http/ui/worksheets/models.rs
@@ -19,10 +19,20 @@ use icebucket_history::Worksheet;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct WorksheetPayload {
+pub struct WorksheetCreatePayload {
+    pub name: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorksheetUpdatePayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
 }
 


### PR DESCRIPTION
closes #375
not yet #373

- [x] Get rid of IceBucket prefix in schema name of openapi spec.
- [x] Do logical separation on open api spec level if possible, Or create separate schemas  and use in implementation.
- [ ] Add schema for query result, instead of `result: "string"`
- [x] Separate Worksheet payloads for update, create
- [x] Fix deploy error