### PR TITLE
Issue/388 query result real type instead string

### DIFF
--- a/crates/history/src/store.rs
+++ b/crates/history/src/store.rs
@@ -63,7 +63,7 @@ pub trait WorksheetsStore: std::fmt::Debug + Send + Sync {
     async fn update_worksheet(&self, worksheet: Worksheet) -> WorksheetsStoreResult<()>;
     async fn get_worksheets(&self) -> WorksheetsStoreResult<Vec<Worksheet>>;
 
-    async fn add_query(&self, item: QueryRecord) -> WorksheetsStoreResult<()>;
+    async fn add_query(&self, item: &QueryRecord) -> WorksheetsStoreResult<()>;
     async fn get_queries(
         &self,
         worksheet_id: WorksheetId,
@@ -158,10 +158,10 @@ impl WorksheetsStore for SlateDBWorksheetsStore {
             .context(WorksheetsListSnafu)?)
     }
 
-    async fn add_query(&self, item: QueryRecord) -> WorksheetsStoreResult<()> {
+    async fn add_query(&self, item: &QueryRecord) -> WorksheetsStoreResult<()> {
         Ok(self
             .db
-            .put_iterable_entity(&item)
+            .put_iterable_entity(item)
             .await
             .context(QueryAddSnafu)?)
     }
@@ -223,7 +223,7 @@ mod tests {
             }
             created.push(item.clone());
             eprintln!("added {:?}", item.key());
-            db.add_query(item).await.unwrap();
+            db.add_query(&item).await.unwrap();
         }
 
         let cursor = <QueryRecord as IterableEntity>::Cursor::CURSOR_MIN;

--- a/crates/history/src/store.rs
+++ b/crates/history/src/store.rs
@@ -63,8 +63,8 @@ pub trait WorksheetsStore: std::fmt::Debug + Send + Sync {
     async fn update_worksheet(&self, worksheet: Worksheet) -> WorksheetsStoreResult<()>;
     async fn get_worksheets(&self) -> WorksheetsStoreResult<Vec<Worksheet>>;
 
-    async fn add_history_item(&self, item: QueryRecord) -> WorksheetsStoreResult<()>;
-    async fn query_history(
+    async fn add_query(&self, item: QueryRecord) -> WorksheetsStoreResult<()>;
+    async fn get_queries(
         &self,
         worksheet_id: WorksheetId,
         cursor: Option<i64>,
@@ -158,7 +158,7 @@ impl WorksheetsStore for SlateDBWorksheetsStore {
             .context(WorksheetsListSnafu)?)
     }
 
-    async fn add_history_item(&self, item: QueryRecord) -> WorksheetsStoreResult<()> {
+    async fn add_query(&self, item: QueryRecord) -> WorksheetsStoreResult<()> {
         Ok(self
             .db
             .put_iterable_entity(&item)
@@ -166,7 +166,7 @@ impl WorksheetsStore for SlateDBWorksheetsStore {
             .context(QueryAddSnafu)?)
     }
 
-    async fn query_history(
+    async fn get_queries(
         &self,
         worksheet_id: WorksheetId,
         cursor: Option<i64>,
@@ -223,13 +223,13 @@ mod tests {
             }
             created.push(item.clone());
             eprintln!("added {:?}", item.key());
-            db.add_history_item(item).await.unwrap();
+            db.add_query(item).await.unwrap();
         }
 
         let cursor = <QueryRecord as IterableEntity>::Cursor::CURSOR_MIN;
         eprintln!("cursor: {cursor}");
         let retrieved = db
-            .query_history(worksheet.id, Some(cursor), Some(10))
+            .get_queries(worksheet.id, Some(cursor), Some(10))
             .await
             .unwrap();
         for item in &retrieved {

--- a/crates/runtime/src/execution/service.rs
+++ b/crates/runtime/src/execution/service.rs
@@ -113,13 +113,12 @@ impl ExecutionService {
         worksheet: Worksheet,
         query: &str,
         query_context: IceBucketQueryContext,
-    ) -> ExecutionResult<(QueryRecordId, String)> {
+    ) -> ExecutionResult<QueryRecord> {
         let mut query_record = QueryRecord::query_start(worksheet.id, query, None);
-        let id: QueryRecordId = query_record.id;
 
         // let (records, _) = self.query(session_id, query, query_context).await?;
         let records_batch = self.query(session_id, query, query_context).await;
-        let res = match records_batch {
+        match records_batch {
             Ok((records, _)) => {
                 let buf = Vec::new();
                 let write_builder = WriterBuilder::new().with_explicit_nulls(true);
@@ -134,39 +133,27 @@ impl ExecutionService {
                 // Get the underlying buffer back,
                 let buf = writer.into_inner();
 
-                let res = String::from_utf8(buf)
-                    .map(|res| (id, res))
-                    .context(ex_error::Utf8Snafu);
+                let res = String::from_utf8(buf).context(ex_error::Utf8Snafu);
 
-                match &res {
-                    Ok(id_res_tuple) => {
+                match res {
+                    Ok(encoded_res) => {
                         let result_count = i64::try_from(records.len()).unwrap_or(0);
-                        query_record.query_finished(
-                            result_count,
-                            Some(id_res_tuple.1.clone()),
-                            None,
-                        );
+                        query_record.query_finished(result_count, Some(encoded_res), None);
                     }
                     Err(err) => {
+                        // utf8 convert error
                         query_record.query_finished_with_error(err.to_string());
                     }
                 };
-
-                Ok(res)
+                Ok(query_record)
             }
             Err(err) => {
+                // query execution error
                 query_record.query_finished_with_error(err.to_string());
 
                 Err(err)
             }
-        };
-
-        if let Err(err) = self.history.add_history_item(query_record.clone()).await {
-            // do not raise error, just log ?
-            tracing::error!("{err}");
         }
-
-        res?
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -65,7 +65,6 @@ pub fn make_icebucket_app(
     let execution_cfg = execution::utils::Config::new(&config.data_format)?;
     let execution_svc = Arc::new(ExecutionService::new(
         metastore.clone(),
-        history.clone(),
         execution_cfg,
     ));
 

--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -63,10 +63,7 @@ pub fn make_icebucket_app(
     config: &IceBucketWebConfig,
 ) -> Result<Router, Box<dyn std::error::Error>> {
     let execution_cfg = execution::utils::Config::new(&config.data_format)?;
-    let execution_svc = Arc::new(ExecutionService::new(
-        metastore.clone(),
-        execution_cfg,
-    ));
+    let execution_svc = Arc::new(ExecutionService::new(metastore.clone(), execution_cfg));
 
     let session_memory = RequestSessionMemory::default();
     let session_store = RequestSessionStore::new(session_memory, execution_svc.clone());

--- a/crates/runtime/src/http/ui/databases/error.rs
+++ b/crates/runtime/src/http/ui/databases/error.rs
@@ -66,7 +66,7 @@ impl IntoStatusCode for DatabasesAPIError {
     }
 }
 
-// generic
+// TODO: make it reusable by other *APIError
 impl IntoResponse for DatabasesAPIError {
     fn into_response(self) -> axum::response::Response {
         let code = self.status_code();

--- a/crates/runtime/src/http/ui/databases/handlers.rs
+++ b/crates/runtime/src/http/ui/databases/handlers.rs
@@ -53,7 +53,7 @@ use validator::Validate;
         )
     ),
     tags(
-        (name = "databases", description = "Databases management endpoints.")
+        (name = "databases", description = "Databases endpoints")
     )
 )]
 pub struct ApiDoc;

--- a/crates/runtime/src/http/ui/queries/error.rs
+++ b/crates/runtime/src/http/ui/queries/error.rs
@@ -39,6 +39,10 @@ pub enum QueryError {
     Store { source: WorksheetsStoreError },
     #[snafu(display("Failed to parse row JSON: {source}"))]
     ResultParse { source: serde_json::Error },
+    #[snafu(display("ResultSet create error: {source}"))]
+    CreateResultSet { source: arrow::error::ArrowError },
+    #[snafu(display("Error encoding UTF8 string: {source}"))]
+    Utf8 { source: std::string::FromUtf8Error },
 }
 
 #[derive(Debug, Snafu)]
@@ -62,7 +66,9 @@ impl IntoStatusCode for QueriesAPIError {
                     WorksheetsStoreError::WorksheetNotFound { .. } => StatusCode::NOT_FOUND,
                     _ => StatusCode::BAD_REQUEST,
                 },
-                QueryError::ResultParse { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+                QueryError::ResultParse { .. }
+                | QueryError::Utf8 { .. }
+                | QueryError::CreateResultSet { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             },
             Self::Queries { source } => match &source {
                 QueryError::Store { source } => match &source {

--- a/crates/runtime/src/http/ui/queries/error.rs
+++ b/crates/runtime/src/http/ui/queries/error.rs
@@ -52,6 +52,8 @@ pub enum QueriesAPIError {
 
 // Select which status code to return.
 impl IntoStatusCode for QueriesAPIError {
+    #[allow(clippy::match_wildcard_for_single_variants)]
+    #[allow(clippy::collapsible_match)]
     fn status_code(&self) -> StatusCode {
         match self {
             Self::Query { source } => match &source {

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -37,8 +37,11 @@ use utoipa::OpenApi;
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(query, history,),
-    components(schemas(QueriesResponse, QueryCreateResponse, QueryCreatePayload,))
+    paths(query, history),
+    components(schemas(QueriesResponse, QueryCreateResponse, QueryCreatePayload,)),
+    tags(
+      (name = "queries", description = "Queries endpoints"),
+    )
 )]
 pub struct ApiDoc;
 

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -19,7 +19,7 @@ use crate::http::session::DFSessionId;
 use crate::http::state::AppState;
 use crate::http::ui::queries::models::{
     ExecutionContext, GetHistoryItemsParams, QueriesResponse, QueryCreatePayload,
-    QueryCreateResponse, QueryRecord,
+    QueryCreateResponse, QueryRecord, ResultSet,
 };
 use crate::http::{
     error::ErrorResponse,
@@ -85,6 +85,11 @@ pub async fn query(
     Path(worksheet_id): Path<WorksheetId>,
     Json(request): Json<QueryCreatePayload>,
 ) -> QueriesResult<Json<QueryCreateResponse>> {
+    //
+    // Note: This handler allowed to return error from a designated place only,
+    // after query record successfull saved result or error.
+    //
+    // TODO: make worksheet optional and if it's not defined it should run query anyway
     let worksheet = state
         .history
         .get_worksheet(worksheet_id)
@@ -104,26 +109,58 @@ pub async fn query(
             .and_then(|c| c.get("schema").cloned()),
     };
 
-    let (query_record, err) = state
+    // TODO: save query record even if no related worksheet
+    let mut query_record = QueryRecordItem::query_start(worksheet.id, &request.query, None);
+
+    let query_res = state
         .execution_svc
-        .query_table(&session_id, worksheet, &request.query, query_context)
+        .query(&session_id, &request.query, query_context)
         .await;
 
-    // save query record even if error occured
-    if let Err(err) = state.history.add_query(query_record.clone()).await {
+    match query_res {
+        Ok((ref records, ref columns)) => {
+            let result_set = ResultSet::query_result_to_result_set(records, columns);
+            match result_set {
+                Ok(result_set) => {
+                    let encoded_res = serde_json::to_string(&result_set);
+
+                    if let Ok(encoded_res) = encoded_res {
+                        let result_count = i64::try_from(records.len()).unwrap_or(0);
+                        query_record.query_finished(result_count, Some(encoded_res), None);
+                    }
+                    // failed to wrap query results
+                    else if let Err(err) = encoded_res {
+                        query_record.query_finished_with_error(err.to_string());
+                    }
+                }
+                // error getting result_set
+                Err(err) => {
+                    query_record.query_finished_with_error(err.to_string());
+                }
+            }
+        }
+        // query error
+        Err(ref err) => {
+            // query execution error
+            query_record.query_finished_with_error(err.to_string());
+        }
+    };
+
+    // add query record
+    if let Err(err) = state.history.add_query(&query_record).await {
         // do not raise error, just log ?
         tracing::error!("{err}");
     }
 
-    if let Some(err) = err {
+    if let Err(err) = query_res {
         Err(QueriesAPIError::Query {
             source: QueryError::Execution { source: err },
         })
     } else {
-        Ok(Json(
-            QueryCreateResponse::try_from(query_record)
+        Ok(Json(QueryCreateResponse {
+            data: QueryRecord::try_from(query_record)
                 .map_err(|e| QueriesAPIError::Query { source: e })?,
-        ))   
+        }))
     }
 }
 
@@ -135,7 +172,7 @@ pub async fn query(
     params(
         ("worksheet_id" = WorksheetId, Path, description = "Worksheet id"),
         ("cursor" = Option<QueryRecordId>, Query, description = "Cursor"),
-        ("limit" = Option<u16>, Query, description = "History items limit"),
+        ("limit" = Option<u16>, Query, description = "Queries limit"),
     ),
     responses(
         (status = 200, description = "Returns queries history", body = QueriesResponse),
@@ -172,10 +209,22 @@ pub async fn queries(
                 QueryRecordItem::min_cursor() // no items in range -> go to beginning
             };
             let queries: Vec<QueryRecord> = recs
+                .clone()
                 .into_iter()
                 .map(QueryRecord::try_from)
                 .filter_map(Result::ok)
                 .collect();
+
+            let queries_failed_to_load: Vec<QueryError> = recs
+                .into_iter()
+                .map(QueryRecord::try_from)
+                .filter_map(Result::err)
+                .collect();
+            if !queries_failed_to_load.is_empty() {
+                // TODO: fix tracing output
+                tracing::error!("Queries: failed to load queries: {queries_failed_to_load:?}");
+            }
+
             Ok(Json(QueriesResponse {
                 items: queries,
                 current_cursor: params.cursor,

--- a/crates/runtime/src/http/ui/queries/models.rs
+++ b/crates/runtime/src/http/ui/queries/models.rs
@@ -15,7 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::error::{QueryError, QueryRecordResult, ResultParseSnafu};
+use super::error::{
+    CreateResultSetSnafu, QueryError, QueryRecordResult, ResultParseSnafu, Utf8Snafu,
+};
+use crate::execution::models::ColumnInfo;
+use arrow::array::RecordBatch;
+use arrow_json::{writer::JsonArray, WriterBuilder};
 use chrono::{DateTime, Utc};
 use icebucket_history::{QueryRecord as QueryRecordItem, QueryRecordId, QueryStatus, WorksheetId};
 use indexmap::IndexMap;
@@ -29,6 +34,68 @@ pub type ExecutionContext = crate::execution::query::IceBucketQueryContext;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct Column {
+    pub name: String,
+    pub r#type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResultSet {
+    pub columns: Vec<Column>,
+    pub rows: Vec<Vec<Value>>,
+}
+
+impl ResultSet {
+    pub fn query_result_to_result_set(
+        records: &[RecordBatch],
+        columns: &[ColumnInfo],
+    ) -> std::result::Result<Self, QueryError> {
+        let buf = Vec::new();
+        let write_builder = WriterBuilder::new().with_explicit_nulls(true);
+        let mut writer = write_builder.build::<_, JsonArray>(buf);
+
+        // serialize records to str
+        let records: Vec<&RecordBatch> = records.iter().collect();
+        writer
+            .write_batches(&records)
+            .context(CreateResultSetSnafu)?;
+        writer.finish().context(CreateResultSetSnafu)?;
+
+        // Get the underlying buffer back,
+        let buf = writer.into_inner();
+        let record_batch_str = String::from_utf8(buf).context(Utf8Snafu)?;
+
+        // convert to array, leaving only values
+        let rows: Vec<IndexMap<String, Value>> =
+            serde_json::from_str(record_batch_str.as_str()).context(ResultParseSnafu)?;
+        let rows: Vec<Vec<Value>> = rows
+            .into_iter()
+            .map(|obj| obj.values().cloned().collect())
+            .collect();
+
+        let columns = columns
+            .iter()
+            .map(|ci| Column {
+                name: ci.name.clone(),
+                r#type: ci.r#type.clone(),
+            })
+            .collect();
+
+        Ok(Self { columns, rows })
+    }
+}
+
+impl TryFrom<&str> for ResultSet {
+    type Error = QueryError;
+
+    fn try_from(result: &str) -> QueryRecordResult<Self> {
+        serde_json::from_str(result).context(ResultParseSnafu)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct QueryCreatePayload {
     pub query: String,
     pub context: Option<HashMap<String, String>>,
@@ -37,6 +104,13 @@ pub struct QueryCreatePayload {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryCreateResponse {
+    #[serde(flatten)]
+    pub data: QueryRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryRecord {
     pub id: QueryRecordId,
     pub worksheet_id: WorksheetId,
     pub query: String,
@@ -44,54 +118,36 @@ pub struct QueryCreateResponse {
     pub end_time: DateTime<Utc>,
     pub duration_ms: i64,
     pub result_count: i64,
-    pub result: Vec<Vec<serde_json::Value>>,
+    pub result: ResultSet,
     pub status: QueryStatus,
-}
-
-impl TryFrom<QueryRecordItem> for QueryCreateResponse {
-    type Error = QueryError;
-
-    fn try_from(query: QueryRecordItem) -> QueryRecordResult<Self> {
-        match str_to_result(query.result.unwrap_or_default().as_str()) {
-            Ok(result) => Ok(Self {
-                id: query.id,
-                worksheet_id: query.worksheet_id,
-                query: query.query,
-                start_time: query.start_time,
-                end_time: query.end_time,
-                duration_ms: query.duration_ms,
-                result_count: query.result_count,
-                status: query.status,
-                result,
-            }),
-            Err(err) => Err(err),
-        }
-    }
-}
-
-pub(crate) fn str_to_result(result_str: &str) -> QueryRecordResult<Vec<Vec<Value>>> {
-    let json_array: Vec<IndexMap<String, Value>> = serde_json::from_str(result_str).context(ResultParseSnafu)?;
-    Ok(json_array
-        .into_iter()
-        .map(|obj| { println!("keys: {:?}", obj.keys()); obj.values().cloned().collect() })
-        .collect())
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct QueryRecord {
-    #[serde(flatten)]
-    pub data: QueryCreateResponse,
-    pub error: Option<String>,
+    pub error: String, // empty error - ok
 }
 
 impl TryFrom<QueryRecordItem> for QueryRecord {
     type Error = QueryError;
 
     fn try_from(query: QueryRecordItem) -> QueryRecordResult<Self> {
+        let query_result = query.result.unwrap_or_default();
+        let query_error = query.error.unwrap_or_default();
+        let result_set = if query_result.is_empty() {
+            ResultSet {
+                rows: vec![],
+                columns: vec![],
+            }
+        } else {
+            ResultSet::try_from(query_result.as_str())?
+        };
         Ok(Self {
-            error: query.error.clone(),
-            data: QueryCreateResponse::try_from(query)?,
+            id: query.id,
+            worksheet_id: query.worksheet_id,
+            query: query.query,
+            start_time: query.start_time,
+            end_time: query.end_time,
+            duration_ms: query.duration_ms,
+            result_count: query.result_count,
+            status: query.status,
+            result: result_set,
+            error: query_error,
         })
     }
 }

--- a/crates/runtime/src/http/ui/queries/models.rs
+++ b/crates/runtime/src/http/ui/queries/models.rs
@@ -15,30 +15,86 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use icebucket_history::{QueryRecord, QueryRecordId, WorksheetId};
+use super::error::{QueryError, QueryRecordResult, ResultParseSnafu};
+use chrono::{DateTime, Utc};
+use icebucket_history::{QueryRecord as QueryRecordItem, QueryRecordId, QueryStatus, WorksheetId};
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use serde_json::{Error, Value};
+use snafu::ResultExt;
 use std::collections::HashMap;
 use utoipa::ToSchema;
 use validator::Validate;
 
 pub type ExecutionContext = crate::execution::query::IceBucketQueryContext;
 
-// Temporarily copied here
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryCreatePayload {
     pub query: String,
     pub context: Option<HashMap<String, String>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryCreateResponse {
     pub id: QueryRecordId,
     pub worksheet_id: WorksheetId,
     pub query: String,
-    pub result: String,
-    pub duration_seconds: f32,
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub duration_ms: i64,
+    pub result_count: i64,
+    pub result: Vec<Vec<serde_json::Value>>,
+    pub status: QueryStatus,
+}
+
+impl TryFrom<QueryRecordItem> for QueryCreateResponse {
+    type Error = QueryError;
+
+    fn try_from(query: QueryRecordItem) -> QueryRecordResult<Self> {
+        match str_to_result(query.result.unwrap_or(String::new()).as_str()) {
+            Ok(result) => Ok(Self {
+                id: query.id,
+                worksheet_id: query.worksheet_id,
+                query: query.query,
+                start_time: query.start_time,
+                end_time: query.end_time,
+                duration_ms: query.duration_ms,
+                result_count: query.result_count,
+                status: query.status,
+                result,
+            }),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+pub(crate) fn str_to_result(result_str: &str) -> QueryRecordResult<Vec<Vec<Value>>> {
+    let json_array: Vec<IndexMap<String, Value>> = serde_json::from_str(result_str).context(ResultParseSnafu)?;
+    Ok(json_array
+        .into_iter()
+        .map(|obj| obj.values().cloned().collect())
+        .collect())
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryRecord {
+    #[serde(flatten)]
+    pub data: QueryCreateResponse,
+    pub error: Option<String>,
+}
+
+impl TryFrom<QueryRecordItem> for QueryRecord {
+    type Error = QueryError;
+
+    fn try_from(query: QueryRecordItem) -> QueryRecordResult<Self> {
+        Ok(Self {
+            error: query.error.clone(),
+            data: QueryCreateResponse::try_from(query)?,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/runtime/src/http/ui/router.rs
+++ b/crates/runtime/src/http/ui/router.rs
@@ -27,7 +27,7 @@ use crate::http::ui::worksheets::handlers::{
     create_worksheet, delete_worksheet, update_worksheet, worksheet, worksheets,
 };
 
-use crate::http::ui::queries::handlers::{history, query};
+use crate::http::ui::queries::handlers::{queries, query};
 // use crate::http::ui::old_handlers::tables::{
 //     create_table, delete_table, get_settings, get_snapshots, get_table, register_table,
 //     update_table_properties, upload_data_to_table,
@@ -52,18 +52,20 @@ use tower_http::sensitive_headers::SetSensitiveHeadersLayer;
 use utoipa::OpenApi;
 
 #[derive(OpenApi)]
-#[openapi(info(
-    title = "UI Router API",
-    description = "API documentation for the UI endpoints.",
-    version = "1.0.2",
-    license(
-        name = "Apache 2.0",
-        url = "https://www.apache.org/licenses/LICENSE-2.0.html"
+#[openapi(
+    info(
+        title = "UI Router API",
+        description = "API documentation for the UI endpoints.",
+        version = "1.0.2",
+        license(
+            name = "Apache 2.0",
+            url = "https://www.apache.org/licenses/LICENSE-2.0.html"
+        ),
+        contact(name = "Embucket, Inc.", url = "https://embucket.com"),
+        description = "Defines the specification for the UI Catalog API",
     ),
-    contact(name = "Embucket, Inc.", url = "https://embucket.com"),
-    description = "Defines the specification for the UI Catalog API",
-), tags(
-))]
+    tags()
+)]
 pub struct ApiDoc;
 
 #[must_use]
@@ -115,7 +117,7 @@ pub fn create_router() -> Router<AppState> {
         )
         .route(
             "/worksheets/{worksheet_id}/queries",
-            post(query).get(history),
+            post(query).get(queries),
         )
         // .route(
         //     "/warehouses/{warehouseId}/databases/{databaseName}/tables/{tableName}/settings",

--- a/crates/runtime/src/http/ui/router.rs
+++ b/crates/runtime/src/http/ui/router.rs
@@ -63,11 +63,6 @@ use utoipa::OpenApi;
     contact(name = "Embucket, Inc.", url = "https://embucket.com"),
     description = "Defines the specification for the UI Catalog API",
 ), tags(
-    (name = "volumes", description = "Volumes endpoints"),
-    (name = "databases", description = "Databases endpoints"),
-    (name = "schemas", description = "Schemas endpoints"),
-    (name = "worksheets", description = "Worksheets endpoints"),
-    (name = "queries", description = "Queries endpoints"),
 ))]
 pub struct ApiDoc;
 

--- a/crates/runtime/src/http/ui/schemas/error.rs
+++ b/crates/runtime/src/http/ui/schemas/error.rs
@@ -66,7 +66,7 @@ impl IntoStatusCode for SchemasAPIError {
     }
 }
 
-// generic
+// TODO: make it reusable by other *APIError
 impl IntoResponse for SchemasAPIError {
     fn into_response(self) -> axum::response::Response {
         let code = self.status_code();

--- a/crates/runtime/src/http/ui/schemas/handlers.rs
+++ b/crates/runtime/src/http/ui/schemas/handlers.rs
@@ -54,7 +54,7 @@ use utoipa::OpenApi;
         )
     ),
     tags(
-        (name = "schemas", description = "Schemas management endpoints.")
+        (name = "schemas", description = "Schemas endpoints")
     )
 )]
 pub struct ApiDoc;

--- a/crates/runtime/src/http/ui/tests/queries.rs
+++ b/crates/runtime/src/http/ui/tests/queries.rs
@@ -81,10 +81,12 @@ async fn test_ui_queries() {
     )
     .await
     .unwrap();
-    assert_eq!(http::StatusCode::OK, res.status());
-    // println!("{:?}", res.bytes().await);
+    //println!("{:?}", res.bytes().await);
+
     let query_run_resp = res.json::<QueryCreateResponse>().await.unwrap();
-    assert_eq!(query_run_resp.result, "[{\"Int64(1)\":1}]");
+    println!("query_run_resp: {query_run_resp:?}");
+    assert_eq!(query_run_resp.result, [[i64::from(1)]]);
+    // assert_eq!(query_run_resp.result, "[{\"Int64(1)\":1}]");
 
     let res = req(
         &client,
@@ -101,7 +103,8 @@ async fn test_ui_queries() {
     assert_eq!(http::StatusCode::OK, res.status());
     // println!("{:?}", res.bytes().await);
     let query_run_resp2 = res.json::<QueryCreateResponse>().await.unwrap();
-    assert_eq!(query_run_resp2.result, "[{\"Int64(2)\":2}]");
+    assert_eq!(query_run_resp2.result, [[i64::from(2)]] );
+    // assert_eq!(query_run_resp2.result, "[{\"Int64(2)\":2}]");
 
     let res = req(
         &client,
@@ -152,10 +155,10 @@ async fn test_ui_queries() {
     // println!("{:?}", res.bytes().await);
     let history_resp = res.json::<QueriesResponse>().await.unwrap();
     assert_eq!(history_resp.items.len(), 2);
-    assert_eq!(history_resp.items[0].status, QueryStatus::Ok);
-    assert_eq!(history_resp.items[0].result, Some(query_run_resp.result));
-    assert_eq!(history_resp.items[1].status, QueryStatus::Ok);
-    assert_eq!(history_resp.items[1].result, Some(query_run_resp2.result));
+    assert_eq!(history_resp.items[0].data.status, QueryStatus::Ok);
+    assert_eq!(history_resp.items[0].data.result, query_run_resp.result);
+    assert_eq!(history_resp.items[1].data.status, QueryStatus::Ok);
+    assert_eq!(history_resp.items[1].data.result, query_run_resp2.result);
 
     // get rest
     let res = req(
@@ -173,6 +176,7 @@ async fn test_ui_queries() {
     // println!("{:?}", res.bytes().await);
     let history_resp = res.json::<QueriesResponse>().await.unwrap();
     assert_eq!(history_resp.items.len(), 2);
-    assert_eq!(history_resp.items[0].status, QueryStatus::Error);
-    assert_eq!(history_resp.items[1].status, QueryStatus::Error);
+    assert_eq!(history_resp.items[0].data.status, QueryStatus::Error);
+    assert_eq!(history_resp.items[1].data.status, QueryStatus::Error);
+    assert!(false);
 }

--- a/crates/runtime/src/http/ui/tests/queries.rs
+++ b/crates/runtime/src/http/ui/tests/queries.rs
@@ -84,7 +84,7 @@ async fn test_ui_queries() {
     //println!("{:?}", res.bytes().await);
 
     let query_run_resp = res.json::<QueryCreateResponse>().await.unwrap();
-    println!("query_run_resp: {query_run_resp:?}");
+    // println!("query_run_resp: {query_run_resp:?}");
     assert_eq!(query_run_resp.result, [[i64::from(1)]]);
     // assert_eq!(query_run_resp.result, "[{\"Int64(1)\":1}]");
 
@@ -178,5 +178,4 @@ async fn test_ui_queries() {
     assert_eq!(history_resp.items.len(), 2);
     assert_eq!(history_resp.items[0].data.status, QueryStatus::Error);
     assert_eq!(history_resp.items[1].data.status, QueryStatus::Error);
-    assert!(false);
 }

--- a/crates/runtime/src/http/ui/tests/volumes.rs
+++ b/crates/runtime/src/http/ui/tests/volumes.rs
@@ -24,6 +24,7 @@ use icebucket_metastore::{
     AwsAccessKeyCredentials, AwsCredentials, IceBucketFileVolume, IceBucketS3Volume,
     IceBucketVolumeType,
 };
+use serde_json;
 
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
@@ -49,6 +50,14 @@ async fn test_ui_volumes_file() {
     let addr = run_icebucket_test_server().await;
 
     // memory volume with empty ident create Ok
+    let payload = r#"{"name":"","file":{"path":"/tmp/data"}}"#;
+    let expected: VolumeCreatePayload = serde_json::from_str(payload).unwrap();
+    let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
+    // let res = create_test_volume(addr, &expected).await;
+    assert_eq!(200, res.status());
+    let created = res.json::<VolumeCreateResponse>().await.unwrap();
+    assert_eq!(expected.data, created.data);
+
     let expected = VolumeCreatePayload {
         data: Volume::from(IceBucketVolume {
             ident: String::new(),
@@ -59,9 +68,7 @@ async fn test_ui_volumes_file() {
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     // let res = create_test_volume(addr, &expected).await;
-    assert_eq!(200, res.status());
-    let created = res.json::<VolumeCreateResponse>().await.unwrap();
-    assert_eq!(expected.data, created.data);
+    assert_eq!(409, res.status());
 }
 
 #[tokio::test]

--- a/crates/runtime/src/http/ui/tests/volumes.rs
+++ b/crates/runtime/src/http/ui/tests/volumes.rs
@@ -50,7 +50,7 @@ async fn test_ui_volumes_file() {
     let addr = run_icebucket_test_server().await;
 
     // memory volume with empty ident create Ok
-    let payload = r#"{"name":"","file":{"path":"/tmp/data"}}"#;
+    let payload = r#"{"name":"","type": "file", "path":"/tmp/data"}"#;
     let expected: VolumeCreatePayload = serde_json::from_str(payload).unwrap();
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     // let res = create_test_volume(addr, &expected).await;

--- a/crates/runtime/src/http/ui/volumes/error.rs
+++ b/crates/runtime/src/http/ui/volumes/error.rs
@@ -67,7 +67,7 @@ impl IntoStatusCode for VolumesAPIError {
     }
 }
 
-// generic
+// TODO: make it reusable by other *APIError
 impl IntoResponse for VolumesAPIError {
     fn into_response(self) -> axum::response::Response {
         let code = self.status_code();

--- a/crates/runtime/src/http/ui/volumes/handlers.rs
+++ b/crates/runtime/src/http/ui/volumes/handlers.rs
@@ -52,7 +52,7 @@ use validator::Validate;
         )
     ),
     tags(
-        (name = "volumes", description = "Volumes management endpoints.")
+        (name = "volumes", description = "Volumes endpoints")
     )
 )]
 pub struct ApiDoc;

--- a/crates/runtime/src/http/ui/volumes/models.rs
+++ b/crates/runtime/src/http/ui/volumes/models.rs
@@ -37,7 +37,7 @@ pub struct FileVolume {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum VolumeType {
     S3(S3Volume),
     File(FileVolume),

--- a/crates/runtime/src/http/ui/volumes/models.rs
+++ b/crates/runtime/src/http/ui/volumes/models.rs
@@ -37,6 +37,7 @@ pub struct FileVolume {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub enum VolumeType {
     S3(S3Volume),
     File(FileVolume),

--- a/crates/runtime/src/http/ui/worksheets/handlers.rs
+++ b/crates/runtime/src/http/ui/worksheets/handlers.rs
@@ -47,7 +47,10 @@ use utoipa::OpenApi;
         WorksheetCreateResponse,
         WorksheetResponse,
         WorksheetsResponse,
-    ))
+    )),
+    tags(
+        (name = "worksheets", description = "Worksheets endpoints"),
+    )
 )]
 pub struct ApiDoc;
 


### PR DESCRIPTION
Closes #388 

* Removes duplicate tags
* Rename history item to QueryRecord and related functions
* Use QueryRecord flattened in CreateResponse 
* Query response with results type instead of string, result includes {columns, rows}