### PR TITLE
UI Get List Pagination + refactor full scan in slatedb

### DIFF
--- a/crates/metastore/src/metastore.rs
+++ b/crates/metastore/src/metastore.rs
@@ -36,7 +36,7 @@ use crate::models::*;
 
 #[async_trait]
 pub trait Metastore: std::fmt::Debug + Send + Sync {
-    async fn list_volumes(&self) -> MetastoreResult<Vec<RwObject<IceBucketVolume>>>;
+    async fn list_volumes(&self, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<IceBucketVolume>>>;
     async fn create_volume(
         &self,
         name: &IceBucketVolumeIdent,
@@ -61,7 +61,7 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
         name: &IceBucketVolumeIdent,
     ) -> MetastoreResult<Option<Arc<dyn ObjectStore>>>;
 
-    async fn list_databases(&self) -> MetastoreResult<Vec<RwObject<IceBucketDatabase>>>;
+    async fn list_databases(&self, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<IceBucketDatabase>>>;
     async fn create_database(
         &self,
         name: &IceBucketDatabaseIdent,
@@ -85,6 +85,8 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
     async fn list_schemas(
         &self,
         database: &IceBucketDatabaseIdent,
+        cursor: Option<String>,
+        limit: Option<usize>
     ) -> MetastoreResult<Vec<RwObject<IceBucketSchema>>>;
     async fn create_schema(
         &self,
@@ -109,6 +111,8 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
     async fn list_tables(
         &self,
         schema: &IceBucketSchemaIdent,
+        cursor: Option<String>,
+        limit: Option<usize>
     ) -> MetastoreResult<Vec<RwObject<IceBucketTable>>>;
     async fn create_table(
         &self,
@@ -185,13 +189,13 @@ impl SlateDBMetastore {
         &self.db
     }
 
-    async fn list_objects<T>(&self, list_key: &str) -> MetastoreResult<Vec<RwObject<T>>>
+    async fn list_objects<T>(&self, list_key: &str, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<T>>>
     where
         T: serde::Serialize + DeserializeOwned + Eq + PartialEq + Send + Sync,
     {
         let entities = self
             .db
-            .list_objects(list_key)
+            .list_objects(list_key, cursor, limit)
             .await
             .context(metastore_error::UtilSlateDBSnafu)?;
         Ok(entities)
@@ -275,8 +279,8 @@ impl SlateDBMetastore {
 
 #[async_trait]
 impl Metastore for SlateDBMetastore {
-    async fn list_volumes(&self) -> MetastoreResult<Vec<RwObject<IceBucketVolume>>> {
-        self.list_objects(KEY_VOLUME).await
+    async fn list_volumes(&self, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<IceBucketVolume>>> {
+        self.list_objects(KEY_VOLUME, cursor, limit).await
     }
 
     async fn create_volume(
@@ -336,7 +340,7 @@ impl Metastore for SlateDBMetastore {
     ) -> MetastoreResult<()> {
         let key = format!("{KEY_VOLUME}/{name}");
         let databases_using = self
-            .list_databases()
+            .list_databases(None, None)
             .await?
             .into_iter()
             .filter(|db| db.volume == *name)
@@ -379,8 +383,8 @@ impl Metastore for SlateDBMetastore {
         }
     }
 
-    async fn list_databases(&self) -> MetastoreResult<Vec<RwObject<IceBucketDatabase>>> {
-        self.list_objects(KEY_DATABASE).await
+    async fn list_databases(&self, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<IceBucketDatabase>>> {
+        self.list_objects(KEY_DATABASE, cursor, limit).await
     }
 
     async fn create_database(
@@ -422,7 +426,7 @@ impl Metastore for SlateDBMetastore {
         name: &IceBucketDatabaseIdent,
         cascade: bool,
     ) -> MetastoreResult<()> {
-        let schemas = self.list_schemas(name).await?;
+        let schemas = self.list_schemas(name, None, None).await?;
         if cascade {
             let futures = schemas
                 .iter()
@@ -437,9 +441,11 @@ impl Metastore for SlateDBMetastore {
     async fn list_schemas(
         &self,
         database: &IceBucketDatabaseIdent,
+        cursor: Option<String>,
+        limit: Option<usize>
     ) -> MetastoreResult<Vec<RwObject<IceBucketSchema>>> {
         let key = format!("{KEY_SCHEMA}/{database}");
-        self.list_objects(&key).await
+        self.list_objects(&key, cursor, limit).await
     }
 
     async fn create_schema(
@@ -482,7 +488,7 @@ impl Metastore for SlateDBMetastore {
         ident: &IceBucketSchemaIdent,
         cascade: bool,
     ) -> MetastoreResult<()> {
-        let tables = self.list_tables(ident).await?;
+        let tables = self.list_tables(ident, None, None).await?;
 
         if cascade {
             let futures = tables
@@ -498,9 +504,11 @@ impl Metastore for SlateDBMetastore {
     async fn list_tables(
         &self,
         schema: &IceBucketSchemaIdent,
+        cursor: Option<String>,
+        limit: Option<usize>
     ) -> MetastoreResult<Vec<RwObject<IceBucketTable>>> {
         let key = format!("{KEY_TABLE}/{}/{}", schema.database, schema.schema);
-        self.list_objects(&key).await
+        self.list_objects(&key, cursor, limit).await
     }
 
     #[allow(clippy::too_many_lines)]
@@ -894,7 +902,7 @@ mod tests {
         ms.create_volume(&"test".to_string(), volume)
             .await
             .expect("create volume failed");
-        let all_volumes = ms.list_volumes().await.expect("list volumes failed");
+        let all_volumes = ms.list_volumes(None, None).await.expect("list volumes failed");
 
         let test_volume = ms
             .db()
@@ -935,7 +943,7 @@ mod tests {
         ms.create_volume(&"test".to_string(), volume)
             .await
             .expect("create volume failed");
-        let all_volumes = ms.list_volumes().await.expect("list volumes failed");
+        let all_volumes = ms.list_volumes(None, None).await.expect("list volumes failed");
         let get_volume = ms
             .get_volume(&"test".to_owned())
             .await
@@ -943,7 +951,7 @@ mod tests {
         ms.delete_volume(&"test".to_string(), false)
             .await
             .expect("delete volume failed");
-        let all_volumes_after = ms.list_volumes().await.expect("list volumes failed");
+        let all_volumes_after = ms.list_volumes(None, None).await.expect("list volumes failed");
 
         insta::with_settings!({
             filters => insta_filters(),
@@ -1006,7 +1014,7 @@ mod tests {
         ms.create_database(&"testdb".to_owned(), database.clone())
             .await
             .expect("create database failed");
-        let all_databases = ms.list_databases().await.expect("list databases failed");
+        let all_databases = ms.list_databases(None, None).await.expect("list databases failed");
 
         database.volume = "testv2".to_owned();
         ms.update_database(&"testdb".to_owned(), database)
@@ -1020,7 +1028,7 @@ mod tests {
         ms.delete_database(&"testdb".to_string(), false)
             .await
             .expect("delete database failed");
-        let all_dbs_after = ms.list_databases().await.expect("list databases failed");
+        let all_dbs_after = ms.list_databases(None, None).await.expect("list databases failed");
 
         insta::with_settings!({
             filters => insta_filters(),
@@ -1064,7 +1072,7 @@ mod tests {
             .expect("create schema failed");
 
         let schema_list = ms
-            .list_schemas(&schema.ident.database)
+            .list_schemas(&schema.ident.database, None, None)
             .await
             .expect("list schemas failed");
         let schema_get = ms
@@ -1075,7 +1083,7 @@ mod tests {
             .await
             .expect("delete schema failed");
         let schema_list_after = ms
-            .list_schemas(&schema.ident.database)
+            .list_schemas(&schema.ident.database, None, None)
             .await
             .expect("list schemas failed");
 
@@ -1182,7 +1190,7 @@ mod tests {
             .collect();
 
         let table_list = ms
-            .list_tables(&table.ident.clone().into())
+            .list_tables(&table.ident.clone().into(), None, None)
             .await
             .expect("list tables failed");
         let table_get = ms.get_table(&table.ident).await.expect("get table failed");
@@ -1190,7 +1198,7 @@ mod tests {
             .await
             .expect("delete table failed");
         let table_list_after = ms
-            .list_tables(&table.ident.into())
+            .list_tables(&table.ident.into(), None, None)
             .await
             .expect("list tables failed");
 

--- a/crates/metastore/src/metastore.rs
+++ b/crates/metastore/src/metastore.rs
@@ -36,7 +36,11 @@ use crate::models::*;
 
 #[async_trait]
 pub trait Metastore: std::fmt::Debug + Send + Sync {
-    async fn list_volumes(&self, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<IceBucketVolume>>>;
+    async fn list_volumes(
+        &self,
+        cursor: Option<String>,
+        limit: Option<usize>,
+    ) -> MetastoreResult<Vec<RwObject<IceBucketVolume>>>;
     async fn create_volume(
         &self,
         name: &IceBucketVolumeIdent,
@@ -61,7 +65,11 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
         name: &IceBucketVolumeIdent,
     ) -> MetastoreResult<Option<Arc<dyn ObjectStore>>>;
 
-    async fn list_databases(&self, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<IceBucketDatabase>>>;
+    async fn list_databases(
+        &self,
+        cursor: Option<String>,
+        limit: Option<usize>,
+    ) -> MetastoreResult<Vec<RwObject<IceBucketDatabase>>>;
     async fn create_database(
         &self,
         name: &IceBucketDatabaseIdent,
@@ -86,7 +94,7 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
         &self,
         database: &IceBucketDatabaseIdent,
         cursor: Option<String>,
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> MetastoreResult<Vec<RwObject<IceBucketSchema>>>;
     async fn create_schema(
         &self,
@@ -112,7 +120,7 @@ pub trait Metastore: std::fmt::Debug + Send + Sync {
         &self,
         schema: &IceBucketSchemaIdent,
         cursor: Option<String>,
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> MetastoreResult<Vec<RwObject<IceBucketTable>>>;
     async fn create_table(
         &self,
@@ -189,7 +197,12 @@ impl SlateDBMetastore {
         &self.db
     }
 
-    async fn list_objects<T>(&self, list_key: &str, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<T>>>
+    async fn list_objects<T>(
+        &self,
+        list_key: &str,
+        cursor: Option<String>,
+        limit: Option<usize>,
+    ) -> MetastoreResult<Vec<RwObject<T>>>
     where
         T: serde::Serialize + DeserializeOwned + Eq + PartialEq + Send + Sync,
     {
@@ -279,7 +292,11 @@ impl SlateDBMetastore {
 
 #[async_trait]
 impl Metastore for SlateDBMetastore {
-    async fn list_volumes(&self, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<IceBucketVolume>>> {
+    async fn list_volumes(
+        &self,
+        cursor: Option<String>,
+        limit: Option<usize>,
+    ) -> MetastoreResult<Vec<RwObject<IceBucketVolume>>> {
         self.list_objects(KEY_VOLUME, cursor, limit).await
     }
 
@@ -383,7 +400,11 @@ impl Metastore for SlateDBMetastore {
         }
     }
 
-    async fn list_databases(&self, cursor: Option<String>, limit: Option<usize>) -> MetastoreResult<Vec<RwObject<IceBucketDatabase>>> {
+    async fn list_databases(
+        &self,
+        cursor: Option<String>,
+        limit: Option<usize>,
+    ) -> MetastoreResult<Vec<RwObject<IceBucketDatabase>>> {
         self.list_objects(KEY_DATABASE, cursor, limit).await
     }
 
@@ -442,7 +463,7 @@ impl Metastore for SlateDBMetastore {
         &self,
         database: &IceBucketDatabaseIdent,
         cursor: Option<String>,
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> MetastoreResult<Vec<RwObject<IceBucketSchema>>> {
         let key = format!("{KEY_SCHEMA}/{database}");
         self.list_objects(&key, cursor, limit).await
@@ -505,7 +526,7 @@ impl Metastore for SlateDBMetastore {
         &self,
         schema: &IceBucketSchemaIdent,
         cursor: Option<String>,
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> MetastoreResult<Vec<RwObject<IceBucketTable>>> {
         let key = format!("{KEY_TABLE}/{}/{}", schema.database, schema.schema);
         self.list_objects(&key, cursor, limit).await
@@ -902,7 +923,10 @@ mod tests {
         ms.create_volume(&"test".to_string(), volume)
             .await
             .expect("create volume failed");
-        let all_volumes = ms.list_volumes(None, None).await.expect("list volumes failed");
+        let all_volumes = ms
+            .list_volumes(None, None)
+            .await
+            .expect("list volumes failed");
 
         let test_volume = ms
             .db()
@@ -943,7 +967,10 @@ mod tests {
         ms.create_volume(&"test".to_string(), volume)
             .await
             .expect("create volume failed");
-        let all_volumes = ms.list_volumes(None, None).await.expect("list volumes failed");
+        let all_volumes = ms
+            .list_volumes(None, None)
+            .await
+            .expect("list volumes failed");
         let get_volume = ms
             .get_volume(&"test".to_owned())
             .await
@@ -951,7 +978,10 @@ mod tests {
         ms.delete_volume(&"test".to_string(), false)
             .await
             .expect("delete volume failed");
-        let all_volumes_after = ms.list_volumes(None, None).await.expect("list volumes failed");
+        let all_volumes_after = ms
+            .list_volumes(None, None)
+            .await
+            .expect("list volumes failed");
 
         insta::with_settings!({
             filters => insta_filters(),
@@ -1014,7 +1044,10 @@ mod tests {
         ms.create_database(&"testdb".to_owned(), database.clone())
             .await
             .expect("create database failed");
-        let all_databases = ms.list_databases(None, None).await.expect("list databases failed");
+        let all_databases = ms
+            .list_databases(None, None)
+            .await
+            .expect("list databases failed");
 
         database.volume = "testv2".to_owned();
         ms.update_database(&"testdb".to_owned(), database)
@@ -1028,7 +1061,10 @@ mod tests {
         ms.delete_database(&"testdb".to_string(), false)
             .await
             .expect("delete database failed");
-        let all_dbs_after = ms.list_databases(None, None).await.expect("list databases failed");
+        let all_dbs_after = ms
+            .list_databases(None, None)
+            .await
+            .expect("list databases failed");
 
         insta::with_settings!({
             filters => insta_filters(),

--- a/crates/runtime/src/execution/catalog/mod.rs
+++ b/crates/runtime/src/execution/catalog/mod.rs
@@ -89,7 +89,7 @@ impl IceBucketDFMetastore {
 
         let databases = self
             .metastore
-            .list_databases()
+            .list_databases(None, None)
             .await
             .context(ex_error::MetastoreSnafu)?;
         for database in databases {
@@ -100,7 +100,7 @@ impl IceBucketDFMetastore {
             let db_seen_entry = seen.entry(database.ident.clone()).or_default();
             let schemas = self
                 .metastore
-                .list_schemas(&database.ident)
+                .list_schemas(&database.ident, None, None)
                 .await
                 .context(ex_error::MetastoreSnafu)?;
             for schema in schemas {
@@ -112,7 +112,7 @@ impl IceBucketDFMetastore {
                     .or_default();
                 let tables = self
                     .metastore
-                    .list_tables(&schema.ident)
+                    .list_tables(&schema.ident, None, None)
                     .await
                     .context(ex_error::MetastoreSnafu)?;
                 for table in tables {
@@ -586,7 +586,7 @@ impl IcebergCatalog for IceBucketIcebergBridge {
         };
         Ok(self
             .metastore
-            .list_tables(&schema_ident)
+            .list_tables(&schema_ident, None, None)
             .await
             .map_err(|e| IcebergError::External(Box::new(e)))?
             .iter()
@@ -607,13 +607,13 @@ impl IcebergCatalog for IceBucketIcebergBridge {
         let mut namespaces = Vec::new();
         let databases = self
             .metastore
-            .list_databases()
+            .list_databases(None, None)
             .await
             .map_err(|e| IcebergError::External(Box::new(e)))?;
         for database in databases {
             let schemas = self
                 .metastore
-                .list_schemas(&database.ident)
+                .list_schemas(&database.ident, None, None)
                 .await
                 .map_err(|e| IcebergError::External(Box::new(e)))?;
             for schema in schemas {

--- a/crates/runtime/src/http/catalog/handlers.rs
+++ b/crates/runtime/src/http/catalog/handlers.rs
@@ -95,7 +95,7 @@ pub async fn list_namespaces(
 ) -> MetastoreAPIResult<Json<ListNamespacesResponse>> {
     let schemas = state
         .metastore
-        .list_schemas(&database_name)
+        .list_schemas(&database_name, None, None)
         .await
         .map_err(MetastoreAPIError)?;
     Ok(Json(from_schemas_list(schemas)))
@@ -218,7 +218,7 @@ pub async fn list_tables(
     let schema_ident = IceBucketSchemaIdent::new(database_name, schema_name);
     let tables = state
         .metastore
-        .list_tables(&schema_ident)
+        .list_tables(&schema_ident, None, None)
         .await
         .map_err(MetastoreAPIError)?;
     Ok(Json(from_tables_list(tables)))

--- a/crates/runtime/src/http/metastore/handlers.rs
+++ b/crates/runtime/src/http/metastore/handlers.rs
@@ -69,7 +69,7 @@ pub async fn list_volumes(
 ) -> MetastoreAPIResult<Json<RwObjectVec<IceBucketVolume>>> {
     let volumes = state
         .metastore
-        .list_volumes()
+        .list_volumes(None, None)
         .await
         .map_err(MetastoreAPIError)?
         .iter()
@@ -191,7 +191,7 @@ pub async fn list_databases(
 ) -> MetastoreAPIResult<Json<Vec<RwObject<IceBucketDatabase>>>> {
     state
         .metastore
-        .list_databases()
+        .list_databases(None, None)
         .await
         .map_err(MetastoreAPIError)
         .map(Json)
@@ -308,7 +308,7 @@ pub async fn list_schemas(
 ) -> MetastoreAPIResult<Json<Vec<RwObject<IceBucketSchema>>>> {
     state
         .metastore
-        .list_schemas(&database_name)
+        .list_schemas(&database_name, None, None)
         .await
         .map_err(MetastoreAPIError)
         .map(Json)
@@ -437,7 +437,7 @@ pub async fn list_tables(
     let schema_ident = IceBucketSchemaIdent::new(database_name, schema_name);
     state
         .metastore
-        .list_tables(&schema_ident)
+        .list_tables(&schema_ident, None, None)
         .await
         .map_err(MetastoreAPIError)
         .map(Json)

--- a/crates/runtime/src/http/ui/databases/handlers.rs
+++ b/crates/runtime/src/http/ui/databases/handlers.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::http::state::AppState;
+use crate::http::ui::databases::models::DatabasesParameters;
 use crate::http::{
     error::ErrorResponse,
     metastore::handlers::QueryParameters,
@@ -33,7 +34,6 @@ use icebucket_metastore::error::MetastoreError;
 use icebucket_metastore::IceBucketDatabase;
 use utoipa::OpenApi;
 use validator::Validate;
-use crate::http::ui::databases::models::DatabasesParameters;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -213,7 +213,10 @@ pub async fn list_databases(
         .await
         .map_err(|e| DatabasesAPIError::List { source: e })
         .map(|o| {
-            let next_cursor = o.iter().last().map_or(String::new(), |rw_object| rw_object.ident.clone());
+            let next_cursor = o
+                .iter()
+                .last()
+                .map_or(String::new(), |rw_object| rw_object.ident.clone());
             Json(DatabasesResponse {
                 items: o.into_iter().map(|x| x.data.into()).collect(),
                 current_cursor: parameters.cursor,

--- a/crates/runtime/src/http/ui/databases/handlers.rs
+++ b/crates/runtime/src/http/ui/databases/handlers.rs
@@ -33,6 +33,7 @@ use icebucket_metastore::error::MetastoreError;
 use icebucket_metastore::IceBucketDatabase;
 use utoipa::OpenApi;
 use validator::Validate;
+use crate::http::ui::databases::models::DatabasesParameters;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -190,6 +191,10 @@ pub async fn update_database(
 #[utoipa::path(
     get,
     operation_id = "getDatabases",
+    params(
+        ("cursor" = Option<String>, Query, description = "Databases cursor"),
+        ("limit" = Option<usize>, Query, description = "Databases limit"),
+    ),
     tags = ["databases"],
     path = "/ui/databases",
     responses(
@@ -199,16 +204,20 @@ pub async fn update_database(
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
 pub async fn list_databases(
+    Query(parameters): Query<DatabasesParameters>,
     State(state): State<AppState>,
 ) -> DatabasesResult<Json<DatabasesResponse>> {
     state
         .metastore
-        .list_databases()
+        .list_databases(parameters.cursor.clone(), parameters.limit)
         .await
         .map_err(|e| DatabasesAPIError::List { source: e })
         .map(|o| {
+            let next_cursor = o.iter().last().map_or(String::new(), |rw_object| rw_object.ident.clone());
             Json(DatabasesResponse {
                 items: o.into_iter().map(|x| x.data.into()).collect(),
+                current_cursor: parameters.cursor,
+                next_cursor,
             })
         })
 }

--- a/crates/runtime/src/http/ui/databases/models.rs
+++ b/crates/runtime/src/http/ui/databases/models.rs
@@ -17,7 +17,7 @@
 
 use icebucket_metastore::models::IceBucketDatabase;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
 pub struct Database {
@@ -86,4 +86,12 @@ pub struct DatabaseResponse {
 #[serde(rename_all = "camelCase")]
 pub struct DatabasesResponse {
     pub items: Vec<Database>,
+    pub current_cursor: Option<String>,
+    pub next_cursor: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema, IntoParams)]
+pub(crate) struct DatabasesParameters {
+    pub(crate) cursor: Option<String>,
+    pub(crate) limit: Option<usize>,
 }

--- a/crates/runtime/src/http/ui/navigation_trees/handlers.rs
+++ b/crates/runtime/src/http/ui/navigation_trees/handlers.rs
@@ -18,9 +18,12 @@
 use crate::http::error::ErrorResponse;
 use crate::http::state::AppState;
 use crate::http::ui::navigation_trees::error::{NavigationTreesAPIError, NavigationTreesResult};
-use crate::http::ui::navigation_trees::models::{NavigationTreeDatabase, NavigationTreeSchema, NavigationTreeTable, NavigationTreesParameters, NavigationTreesResponse};
-use axum::{extract::State, Json};
+use crate::http::ui::navigation_trees::models::{
+    NavigationTreeDatabase, NavigationTreeSchema, NavigationTreeTable, NavigationTreesParameters,
+    NavigationTreesResponse,
+};
 use axum::extract::Query;
+use axum::{extract::State, Json};
 use utoipa::OpenApi;
 
 #[derive(OpenApi)]
@@ -68,7 +71,10 @@ pub async fn get_navigation_trees(
         .await
         .map_err(|e| NavigationTreesAPIError::Get { source: e })?;
 
-    let next_cursor = rw_databases.iter().last().map_or(String::new(), |rw_object| rw_object.ident.clone());
+    let next_cursor = rw_databases
+        .iter()
+        .last()
+        .map_or(String::new(), |rw_object| rw_object.ident.clone());
 
     let mut databases: Vec<NavigationTreeDatabase> = vec![];
     for rw_database in rw_databases {

--- a/crates/runtime/src/http/ui/navigation_trees/handlers.rs
+++ b/crates/runtime/src/http/ui/navigation_trees/handlers.rs
@@ -18,10 +18,9 @@
 use crate::http::error::ErrorResponse;
 use crate::http::state::AppState;
 use crate::http::ui::navigation_trees::error::{NavigationTreesAPIError, NavigationTreesResult};
-use crate::http::ui::navigation_trees::models::{
-    NavigationTreeDatabase, NavigationTreeSchema, NavigationTreeTable, NavigationTreesResponse,
-};
+use crate::http::ui::navigation_trees::models::{NavigationTreeDatabase, NavigationTreeSchema, NavigationTreeTable, NavigationTreesParameters, NavigationTreesResponse};
 use axum::{extract::State, Json};
+use axum::extract::Query;
 use utoipa::OpenApi;
 
 #[derive(OpenApi)]
@@ -39,7 +38,7 @@ use utoipa::OpenApi;
         )
     ),
     tags(
-        (name = "navigation_trees-trees", description = "Navigation trees endpoints.")
+        (name = "navigation-trees", description = "Navigation trees endpoints.")
     )
 )]
 pub struct ApiDoc;
@@ -47,6 +46,10 @@ pub struct ApiDoc;
 #[utoipa::path(
     get,
     operation_id = "getNavigationTrees",
+    params(
+        ("cursor" = Option<String>, Query, description = "Navigation trees cursor"),
+        ("limit" = Option<usize>, Query, description = "Navigation trees limit"),
+    ),
     tags = ["navigation-trees"],
     path = "/ui/navigation-trees",
     responses(
@@ -56,19 +59,22 @@ pub struct ApiDoc;
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
 pub async fn get_navigation_trees(
+    Query(parameters): Query<NavigationTreesParameters>,
     State(state): State<AppState>,
 ) -> NavigationTreesResult<Json<NavigationTreesResponse>> {
     let rw_databases = state
         .metastore
-        .list_databases()
+        .list_databases(parameters.cursor.clone(), parameters.limit)
         .await
         .map_err(|e| NavigationTreesAPIError::Get { source: e })?;
+
+    let next_cursor = rw_databases.iter().last().map_or(String::new(), |rw_object| rw_object.ident.clone());
 
     let mut databases: Vec<NavigationTreeDatabase> = vec![];
     for rw_database in rw_databases {
         let rw_schemas = state
             .metastore
-            .list_schemas(&rw_database.ident)
+            .list_schemas(&rw_database.ident.clone(), None, None)
             .await
             .map_err(|e| NavigationTreesAPIError::Get { source: e })?;
 
@@ -76,7 +82,7 @@ pub async fn get_navigation_trees(
         for rw_schema in rw_schemas {
             let rw_tables = state
                 .metastore
-                .list_tables(&rw_schema.ident)
+                .list_tables(&rw_schema.ident, None, None)
                 .await
                 .map_err(|e| NavigationTreesAPIError::Get { source: e })?;
 
@@ -97,5 +103,9 @@ pub async fn get_navigation_trees(
         });
     }
 
-    Ok(Json(NavigationTreesResponse { items: databases }))
+    Ok(Json(NavigationTreesResponse {
+        items: databases,
+        current_cursor: parameters.cursor,
+        next_cursor,
+    }))
 }

--- a/crates/runtime/src/http/ui/navigation_trees/models.rs
+++ b/crates/runtime/src/http/ui/navigation_trees/models.rs
@@ -16,13 +16,15 @@
 // under the License.
 
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 use validator::Validate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NavigationTreesResponse {
     pub items: Vec<NavigationTreeDatabase>,
+    pub current_cursor: Option<String>,
+    pub next_cursor: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, ToSchema)]
@@ -43,4 +45,10 @@ pub struct NavigationTreeSchema {
 #[serde(rename_all = "camelCase")]
 pub struct NavigationTreeTable {
     pub(crate) name: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema, IntoParams)]
+pub(crate) struct NavigationTreesParameters {
+    pub(crate) cursor: Option<String>,
+    pub(crate) limit: Option<usize>,
 }

--- a/crates/runtime/src/http/ui/schemas/handlers.rs
+++ b/crates/runtime/src/http/ui/schemas/handlers.rs
@@ -37,6 +37,7 @@ use std::collections::HashMap;
 use std::convert::From;
 use std::convert::Into;
 use utoipa::OpenApi;
+use crate::http::ui::databases::models::DatabasesResponse;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -211,6 +212,8 @@ pub async fn update_schema(
     tags = ["schemas"],
     params(
         ("databaseName" = String, description = "Database Name"),
+        ("cursor" = Option<String>, Query, description = "Schemas cursor"),
+        ("limit" = Option<usize>, Query, description = "Schemas limit"),
     ),
     responses(
         (status = 200, body = SchemasResponse),
@@ -225,19 +228,18 @@ pub async fn list_schemas(
 ) -> SchemasResult<Json<SchemasResponse>> {
     state
         .metastore
-        .list_schemas(&database_name)
+        .list_schemas(&database_name, parameters.cursor.clone(), parameters.limit)
         .await
         .map_err(|e| SchemasAPIError::List { source: e })
         .map(|rw_objects| {
-            let cursor = parameters.cursor.unwrap_or(0);
-            let limit = parameters.limit.unwrap_or(rw_objects.len());
+            let next_cursor = rw_objects.iter().last().map_or(String::new(), |rw_object| rw_object.ident.schema.clone());
             Json(SchemasResponse {
                 items: rw_objects
                     .into_iter()
-                    .skip(cursor)
-                    .take(limit)
-                    .map(Schema::from)
-                    .collect::<Vec<Schema>>(),
+                    .map(|rw_object| Schema::from(rw_object))
+                    .collect(),
+                current_cursor: parameters.cursor,
+                next_cursor,
             })
         })
 }

--- a/crates/runtime/src/http/ui/schemas/handlers.rs
+++ b/crates/runtime/src/http/ui/schemas/handlers.rs
@@ -37,7 +37,6 @@ use std::collections::HashMap;
 use std::convert::From;
 use std::convert::Into;
 use utoipa::OpenApi;
-use crate::http::ui::databases::models::DatabasesResponse;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -232,12 +231,12 @@ pub async fn list_schemas(
         .await
         .map_err(|e| SchemasAPIError::List { source: e })
         .map(|rw_objects| {
-            let next_cursor = rw_objects.iter().last().map_or(String::new(), |rw_object| rw_object.ident.schema.clone());
+            let next_cursor = rw_objects
+                .iter()
+                .last()
+                .map_or(String::new(), |rw_object| rw_object.ident.schema.clone());
             Json(SchemasResponse {
-                items: rw_objects
-                    .into_iter()
-                    .map(|rw_object| Schema::from(rw_object))
-                    .collect(),
+                items: rw_objects.into_iter().map(Schema::from).collect(),
                 current_cursor: parameters.cursor,
                 next_cursor,
             })

--- a/crates/runtime/src/http/ui/schemas/models.rs
+++ b/crates/runtime/src/http/ui/schemas/models.rs
@@ -93,10 +93,12 @@ pub struct SchemaResponse {
 #[serde(rename_all = "camelCase")]
 pub struct SchemasResponse {
     pub items: Vec<Schema>,
+    pub current_cursor: Option<String>,
+    pub next_cursor: String,
 }
 
 #[derive(Debug, Deserialize, ToSchema, IntoParams)]
 pub struct SchemasParameters {
-    pub cursor: Option<usize>,
+    pub cursor: Option<String>,
     pub limit: Option<usize>,
 }

--- a/crates/runtime/src/http/ui/tests/schemas.rs
+++ b/crates/runtime/src/http/ui/tests/schemas.rs
@@ -158,20 +158,20 @@ async fn test_ui_schemas() {
         "testing1".to_string(),
         schemas_response.items.first().unwrap().name
     );
-
+    let cursor = schemas_response.next_cursor;
     //Get list schemas with parameters
     let res = req(
         &client,
         Method::GET,
         &format!(
-            "http://{addr}/ui/databases/{}/schemas?cursor=testing1",
+            "http://{addr}/ui/databases/{}/schemas?cursor={cursor}",
             database_name.clone()
         )
-            .to_string(),
+        .to_string(),
         String::new(),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     let schemas_response: SchemasResponse = res.json().await.unwrap();
     assert_eq!(2, schemas_response.items.len());

--- a/crates/runtime/src/http/ui/tests/schemas.rs
+++ b/crates/runtime/src/http/ui/tests/schemas.rs
@@ -143,7 +143,7 @@ async fn test_ui_schemas() {
         &client,
         Method::GET,
         &format!(
-            "http://{addr}/ui/databases/{}/schemas?cursor=1&limit=1",
+            "http://{addr}/ui/databases/{}/schemas?limit=1",
             database_name.clone()
         )
         .to_string(),
@@ -154,6 +154,27 @@ async fn test_ui_schemas() {
     assert_eq!(http::StatusCode::OK, res.status());
     let schemas_response: SchemasResponse = res.json().await.unwrap();
     assert_eq!(1, schemas_response.items.len());
+    assert_eq!(
+        "testing1".to_string(),
+        schemas_response.items.first().unwrap().name
+    );
+
+    //Get list schemas with parameters
+    let res = req(
+        &client,
+        Method::GET,
+        &format!(
+            "http://{addr}/ui/databases/{}/schemas?cursor=testing1",
+            database_name.clone()
+        )
+            .to_string(),
+        String::new(),
+    )
+        .await
+        .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let schemas_response: SchemasResponse = res.json().await.unwrap();
+    assert_eq!(2, schemas_response.items.len());
     assert_eq!(
         "testing2".to_string(),
         schemas_response.items.first().unwrap().name

--- a/crates/runtime/src/http/ui/volumes/models.rs
+++ b/crates/runtime/src/http/ui/volumes/models.rs
@@ -19,7 +19,7 @@ use icebucket_metastore::models::{
     AwsCredentials, IceBucketFileVolume, IceBucketS3Volume, IceBucketVolume, IceBucketVolumeType,
 };
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
 pub struct S3Volume {
@@ -134,4 +134,12 @@ pub struct VolumeResponse {
 #[serde(rename_all = "camelCase")]
 pub struct VolumesResponse {
     pub items: Vec<Volume>,
+    pub current_cursor: Option<String>,
+    pub next_cursor: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema, IntoParams)]
+pub struct VolumesParameters {
+    pub cursor: Option<String>,
+    pub limit: Option<usize>,
 }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -30,6 +30,7 @@ use snafu::prelude::*;
 use std::ops::RangeBounds;
 use std::string::ToString;
 use std::sync::Arc;
+use futures::stream_select;
 use uuid::Uuid;
 
 #[derive(Snafu, Debug)]
@@ -149,15 +150,21 @@ impl Db {
     pub async fn list_objects<T: Send + for<'de> serde::de::Deserialize<'de>>(
         &self,
         key: &str,
+        cursor: Option<String>,
+        limit: Option<usize>,
     ) -> Result<Vec<T>> {
-        let start = format!("{key}/");
+        let start = cursor.map_or(format!("{key}/"), |cursor| format!("{key}/{cursor}\x00"));
         let end = format!("{key}/\x7F");
         let range = Bytes::from(start)..Bytes::from(end);
+        let limit = limit.unwrap_or(usize::MAX);
         let mut iter = self.0.scan(range).await.context(ScanFailedSnafu)?;
         let mut objects: Vec<T> = vec![];
         while let Ok(Some(value)) = iter.next().await {
             let value = de::from_slice(&value.value).context(DeserializeValueSnafu)?;
             objects.push(value);
+            if objects.len() >= limit {
+                break;
+            }
         }
         Ok(objects)
     }
@@ -257,7 +264,7 @@ pub trait Repository {
     }
 
     async fn _list(&self) -> Result<Vec<Self::Entity>> {
-        let entities = self.db().list_objects(Self::collection_key()).await?;
+        let entities = self.db().list_objects(Self::collection_key(), None, None).await?;
         Ok(entities)
     }
 
@@ -295,12 +302,12 @@ mod test {
             .await
             .expect("Failed to put entity");
         let get_after_put = db.get::<TestEntity>("test/abc").await;
-        let list_after_append = db.list_objects::<TestEntity>("test").await;
+        let list_after_append = db.list_objects::<TestEntity>("test", None, None).await;
         db.delete("test/abc")
             .await
             .expect("Failed to delete entity");
         let get_after_delete = db.get::<TestEntity>("test/abc").await;
-        let list_after_remove = db.list_objects::<TestEntity>("test").await;
+        let list_after_remove = db.list_objects::<TestEntity>("test", None, None).await;
 
         insta::assert_debug_snapshot!((
             get_empty,


### PR DESCRIPTION
Closes #401 +

- In utils crate now we have the ability to use a cursor and limit.
- next_cursor is name of the last object + `\x00` - Nul ASCII char.
- Example: `tbl.{...}.aa < tbl.{...}.aa\x00 < tbl.{...}.ab`

