### PR TITLE
UI Decouple Tables Handlers (Info & Columns) + TableDataPreview "fix"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ iceberg = { git = "https://github.com/hansetag/iceberg-rust.git", branch = "ct/b
 tempfile = { version = "3" }
 utoipa = { version = "5.3.1", features = ["uuid", "chrono"] }
 utoipa-axum = { version = "0.2.0" }
-utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }
+utoipa-swagger-ui = { version = "9.0.1", features = ["axum"] }
 lazy_static = { version = "1.5" }
 snafu = { version = "0.8.5", features = ["futures"] }
 tracing = { version = "0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ datafusion-macros = { git = "https://github.com/Embucket/datafusion.git", rev = 
 chrono = { git = "https://github.com/chronotope/chrono.git", rev = "8b863490d88ba098038392c8aa930012ffd0c439" }
 
 # https://github.com/juhaku/utoipa/issues/1345
-utoipa = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }
-utoipa-swagger-ui = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }
+# utoipa = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }
+# utoipa-swagger-ui = { git = "https://github.com/juhaku/utoipa.git", rev = "1d32f0524a8680d79537ae92aa9ced6ba9d2b630" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/crates/runtime/src/http/ui/router.rs
+++ b/crates/runtime/src/http/ui/router.rs
@@ -39,9 +39,7 @@ use crate::http::ui::navigation_trees::handlers::{
 };
 use crate::http::ui::queries::handlers::ApiDoc as QueryApiDoc;
 use crate::http::ui::schemas::handlers::ApiDoc as SchemasApiDoc;
-use crate::http::ui::tables::handlers::{
-    get_table_info, get_table_preview_data, ApiDoc as TableApiDoc,
-};
+use crate::http::ui::tables::handlers::{get_table_columns_info, get_table_info, get_table_preview_data, ApiDoc as TableApiDoc};
 use crate::http::ui::volumes::handlers::ApiDoc as VolumesApiDoc;
 use crate::http::ui::worksheets::handlers::ApiDoc as WorksheetsApiDoc;
 
@@ -111,6 +109,10 @@ pub fn create_router() -> Router<AppState> {
         .route(
             "/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/info",
             get(get_table_info),
+        )
+        .route(
+            "/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/columns",
+            get(get_table_columns_info),
         )
         .route(
             "/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/preview",

--- a/crates/runtime/src/http/ui/router.rs
+++ b/crates/runtime/src/http/ui/router.rs
@@ -39,7 +39,9 @@ use crate::http::ui::navigation_trees::handlers::{
 };
 use crate::http::ui::queries::handlers::ApiDoc as QueryApiDoc;
 use crate::http::ui::schemas::handlers::ApiDoc as SchemasApiDoc;
-use crate::http::ui::tables::handlers::{get_table_columns_info, get_table_info, get_table_preview_data, ApiDoc as TableApiDoc};
+use crate::http::ui::tables::handlers::{
+    get_table_columns_info, get_table_preview_data, get_table_statistics, ApiDoc as TableApiDoc,
+};
 use crate::http::ui::volumes::handlers::ApiDoc as VolumesApiDoc;
 use crate::http::ui::worksheets::handlers::ApiDoc as WorksheetsApiDoc;
 
@@ -107,8 +109,8 @@ pub fn create_router() -> Router<AppState> {
         //     post(create_table),
         // )
         .route(
-            "/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/info",
-            get(get_table_info),
+            "/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/statistics",
+            get(get_table_statistics),
         )
         .route(
             "/databases/{databaseName}/schemas/{schemaName}/tables/{tableName}/columns",

--- a/crates/runtime/src/http/ui/tables/error.rs
+++ b/crates/runtime/src/http/ui/tables/error.rs
@@ -38,8 +38,8 @@ use crate::http::ui::error::IntoStatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use http::StatusCode;
-use snafu::prelude::*;
 use icebucket_metastore::error::MetastoreError;
+use snafu::prelude::*;
 
 pub type TablesResult<T> = Result<T, TablesAPIError>;
 
@@ -79,17 +79,16 @@ impl IntoStatusCode for TablesAPIError {
             Self::GetMetastore { source } => match &source {
                 MetastoreError::TableNotFound { .. } => StatusCode::NOT_FOUND,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
-            }
-            // Self::Delete { source } => match &source {
-            //     MetastoreError::SchemaNotFound { .. } => StatusCode::NOT_FOUND,
-            //     _ => StatusCode::INTERNAL_SERVER_ERROR,
-            // },
-            // Self::Update { source } => match &source {
-            //     MetastoreError::SchemaNotFound { .. } => StatusCode::NOT_FOUND,
-            //     MetastoreError::Validation { .. } => StatusCode::BAD_REQUEST,
-            //     _ => StatusCode::INTERNAL_SERVER_ERROR,
-            // },
-            // Self::List { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            }, // Self::Delete { source } => match &source {
+               //     MetastoreError::SchemaNotFound { .. } => StatusCode::NOT_FOUND,
+               //     _ => StatusCode::INTERNAL_SERVER_ERROR,
+               // },
+               // Self::Update { source } => match &source {
+               //     MetastoreError::SchemaNotFound { .. } => StatusCode::NOT_FOUND,
+               //     MetastoreError::Validation { .. } => StatusCode::BAD_REQUEST,
+               //     _ => StatusCode::INTERNAL_SERVER_ERROR,
+               // },
+               // Self::List { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/crates/runtime/src/http/ui/tables/handlers.rs
+++ b/crates/runtime/src/http/ui/tables/handlers.rs
@@ -147,9 +147,7 @@ pub async fn get_table_columns_info(
         database: Some(database_name.clone()),
         schema: Some(schema_name.clone()),
     };
-    let sql_string = format!(
-        "SELECT * FROM {database_name}.{schema_name}.{table_name} LIMIT 0"
-    );
+    let sql_string = format!("SELECT * FROM {database_name}.{schema_name}.{table_name} LIMIT 0");
     let (_, column_infos) = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)
@@ -160,14 +158,20 @@ pub async fn get_table_columns_info(
         items.push(TableColumnInfo {
             name: column_info.name.clone(),
             r#type: column_info.r#type.clone(),
-            description: "".to_string(),
-            nullable: if column_info.nullable { "Y".to_string() } else { "N".to_string() },
-            default: if column_info.nullable { "NULL".to_string() } else { "".to_string() },
-        })
+            description: String::new(),
+            nullable: if column_info.nullable {
+                "Y".to_string()
+            } else {
+                "N".to_string()
+            },
+            default: if column_info.nullable {
+                "NULL".to_string()
+            } else {
+                String::new()
+            },
+        });
     }
-    Ok(Json(TableColumnsInfoResponse {
-        items,
-    }))
+    Ok(Json(TableColumnsInfoResponse { items }))
 }
 #[utoipa::path(
     get,

--- a/crates/runtime/src/http/ui/tables/handlers.rs
+++ b/crates/runtime/src/http/ui/tables/handlers.rs
@@ -21,7 +21,7 @@ use crate::http::session::DFSessionId;
 use crate::http::state::AppState;
 use crate::http::ui::tables::error::{TablesAPIError, TablesResult};
 use crate::http::ui::tables::models::{
-    TableInfo, TableInfoColumn, TableInfoResponse, TablePreviewDataColumn,
+    TableInfo, TableColumnsInfoResponse, TableColumnInfo, TableInfoResponse, TablePreviewDataColumn,
     TablePreviewDataParameters, TablePreviewDataResponse, TablePreviewDataRow,
 };
 use arrow_array::{Array, StringArray};
@@ -31,6 +31,8 @@ use axum::{
     Json,
 };
 use utoipa::OpenApi;
+use icebucket_metastore::error::MetastoreError;
+use icebucket_metastore::IceBucketTableIdent;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -42,7 +44,8 @@ use utoipa::OpenApi;
         schemas(
             TableInfoResponse,
             TableInfo,
-            TableInfoColumn,
+            TableColumnsInfoResponse,
+            TableColumnInfo,
             TablePreviewDataResponse,
             TablePreviewDataColumn,
             TablePreviewDataRow,
@@ -96,6 +99,85 @@ pub struct ApiDoc;
 //
 // }
 
+// #[utoipa::path(
+//     get,
+//     path = "/ui/databases/{databaseName}/schemas/{schemaName}/{tableName}/info",
+//     params(
+//         ("databaseName" = String, description = "Database Name"),
+//         ("schemaName" = String, description = "Schema Name"),
+//         ("tableName" = String, description = "Table Name")
+//     ),
+//     operation_id = "getTableInfo",
+//     tags = ["tables"],
+//     responses(
+//         (status = 200, description = "Successful Response", body = TableInfoResponse),
+//         (status = 404, description = "Table not found", body = ErrorResponse),
+//         (status = 422, description = "Unprocessable entity", body = ErrorResponse),
+//     )
+// )]
+// #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
+// #[allow(clippy::unwrap_used)]
+// pub async fn get_table_info(
+//     DFSessionId(session_id): DFSessionId,
+//     State(state): State<AppState>,
+//     Path((database_name, schema_name, table_name)): Path<(String, String, String)>,
+// ) -> TablesResult<Json<TableInfoResponse>> {
+//     let context = IceBucketQueryContext {
+//         database: Some(database_name.clone()),
+//         schema: Some(schema_name.clone()),
+//     };
+//     let sql_string = format!("SELECT column_name, data_type FROM datafusion.information_schema.columns WHERE table_name = '{table_name}'");
+//     let (batches, _) = state
+//         .execution_svc
+//         .query(&session_id, sql_string.as_str(), context.clone())
+//         .await
+//         .map_err(|e| TablesAPIError::Get { source: e })?;
+//     let mut columns: Vec<TableInfoColumn> = vec![];
+//     for batch in batches {
+//         let column_name_array = batch
+//             .column(0)
+//             .as_any()
+//             .downcast_ref::<StringArray>()
+//             .unwrap();
+//         let data_type_array = batch
+//             .column(1)
+//             .as_any()
+//             .downcast_ref::<StringArray>()
+//             .unwrap();
+//
+//         // Iterate over each record
+//         for i in 0..batch.num_rows() {
+//             columns.push(TableInfoColumn {
+//                 name: column_name_array.value(i).to_string(),
+//                 r#type: data_type_array.value(i).to_string(),
+//             });
+//         }
+//     }
+//     let sql_string = format!(
+//         "SELECT COUNT(*) AS total_rows FROM {database_name}.{schema_name}.{}",
+//         table_name.clone()
+//     );
+//     let (batches, _) = state
+//         .execution_svc
+//         .query(&session_id, sql_string.as_str(), context)
+//         .await
+//         .map_err(|e| TablesAPIError::Get { source: e })?;
+//     let total_rows = batches.first().map_or(0, |batch| {
+//         batch
+//             .column(0)
+//             .as_any()
+//             .downcast_ref::<arrow::array::Int64Array>()
+//             .map_or(0, |array| array.value(0))
+//     });
+//     Ok(Json(TableInfoResponse {
+//         data: TableInfo {
+//             name: table_name,
+//             columns,
+//             total_rows,
+//         },
+//     }))
+// }
+
 #[utoipa::path(
     get,
     path = "/ui/databases/{databaseName}/schemas/{schemaName}/{tableName}/info",
@@ -115,66 +197,102 @@ pub struct ApiDoc;
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
 #[allow(clippy::unwrap_used)]
 pub async fn get_table_info(
-    DFSessionId(session_id): DFSessionId,
     State(state): State<AppState>,
     Path((database_name, schema_name, table_name)): Path<(String, String, String)>,
 ) -> TablesResult<Json<TableInfoResponse>> {
-    let context = IceBucketQueryContext {
-        database: Some(database_name.clone()),
-        schema: Some(schema_name.clone()),
-    };
-    let sql_string = format!("SELECT column_name, data_type FROM datafusion.information_schema.columns WHERE table_name = '{table_name}'");
-    let (batches, _) = state
-        .execution_svc
-        .query(&session_id, sql_string.as_str(), context.clone())
-        .await
-        .map_err(|e| TablesAPIError::Get { source: e })?;
-    let mut columns: Vec<TableInfoColumn> = vec![];
-    for batch in batches {
-        let column_name_array = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-        let data_type_array = batch
-            .column(1)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
-
-        // Iterate over each record
-        for i in 0..batch.num_rows() {
-            columns.push(TableInfoColumn {
-                name: column_name_array.value(i).to_string(),
-                r#type: data_type_array.value(i).to_string(),
-            });
-        }
-    }
-    let sql_string = format!(
-        "SELECT COUNT(*) AS total_rows FROM {database_name}.{schema_name}.{}",
-        table_name.clone()
-    );
-    let (batches, _) = state
-        .execution_svc
-        .query(&session_id, sql_string.as_str(), context)
-        .await
-        .map_err(|e| TablesAPIError::Get { source: e })?;
-    let total_rows = batches.first().map_or(0, |batch| {
-        batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<arrow::array::Int64Array>()
-            .map_or(0, |array| array.value(0))
-    });
-    Ok(Json(TableInfoResponse {
-        data: TableInfo {
-            name: table_name,
-            columns,
-            total_rows,
+    let ident = IceBucketTableIdent::new(&database_name, &schema_name, &table_name);
+    match state.metastore.get_table(&ident).await {
+        Ok(Some(rw_object)) => {
+            let mut total_bytes = 0;
+            let mut total_rows = 0;
+            if let Ok(Some(latest_snapshot)) = rw_object.metadata.current_snapshot(None) {
+                dbg!("latest snapshot");
+                dbg!(&latest_snapshot.summary().other);
+                total_bytes = latest_snapshot
+                    .summary()
+                    .other
+                    .get("total-files-size")
+                    .and_then(|value| {dbg!("total-files-size"); value.parse::<i64>().ok()})
+                    .unwrap_or(0);
+                total_rows = latest_snapshot
+                    .summary()
+                    .other
+                    .get("total-records")
+                    .and_then(|value| {dbg!("total-records"); value.parse::<i64>().ok()})
+                    .unwrap_or(0);
+            }
+            Ok(Json(
+                TableInfoResponse {
+                    data: TableInfo {
+                        name: rw_object.ident.table.clone(),
+                        total_rows,
+                        total_bytes,
+                        created_at: rw_object.created_at,
+                        updated_at: rw_object.updated_at,
+                    }
+                }
+            ))
         },
-    }))
+        Ok(None) => Err(TablesAPIError::GetMetastore {
+            source: MetastoreError::TableNotFound {
+                table: database_name,
+                schema: schema_name,
+                db: table_name,
+            },
+        }),
+        Err(e) => Err(TablesAPIError::GetMetastore { source: e }),
+    }
 }
-
+#[utoipa::path(
+    get,
+    path = "/ui/databases/{databaseName}/schemas/{schemaName}/{tableName}/columns",
+    params(
+        ("databaseName" = String, description = "Database Name"),
+        ("schemaName" = String, description = "Schema Name"),
+        ("tableName" = String, description = "Table Name")
+    ),
+    operation_id = "getTableColumnsInfo",
+    tags = ["tables"],
+    responses(
+        (status = 200, description = "Successful Response", body = TableColumnsInfoResponse),
+        (status = 404, description = "Table not found", body = ErrorResponse),
+        (status = 422, description = "Unprocessable entity", body = ErrorResponse),
+    )
+)]
+#[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
+#[allow(clippy::unwrap_used)]
+pub async fn get_table_columns_info(
+    State(state): State<AppState>,
+    Path((database_name, schema_name, table_name)): Path<(String, String, String)>,
+) -> TablesResult<Json<TableColumnsInfoResponse>> {
+    let ident = IceBucketTableIdent::new(&database_name, &schema_name, &table_name);
+    match state.metastore.get_table(&ident).await {
+        Ok(Some(rw_object)) => {
+            let mut items: Vec<TableColumnInfo> = vec![];
+            if let Ok(schema) = rw_object.metadata.current_schema(None) {
+                for field in schema.iter() {
+                    items.push(TableColumnInfo {
+                        name: field.name.clone(),
+                        r#type: field.field_type.to_string()
+                    })
+                }
+            }
+            Ok(Json(
+                TableColumnsInfoResponse {
+                    items,
+                }
+            ))
+        },
+        Ok(None) => Err(TablesAPIError::GetMetastore {
+            source: MetastoreError::TableNotFound {
+                table: database_name,
+                schema: schema_name,
+                db: table_name,
+            },
+        }),
+        Err(e) => Err(TablesAPIError::GetMetastore { source: e }),
+    }
+}
 #[utoipa::path(
     get,
     path = "/ui/databases/{databaseName}/schemas/{schemaName}/{tableName}/preview",
@@ -213,7 +331,7 @@ pub async fn get_table_preview_data(
         .execution_svc
         .query(&session_id, sql_string.as_str(), context.clone())
         .await
-        .map_err(|e| TablesAPIError::Get { source: e })?;
+        .map_err(|e| TablesAPIError::GetExecution { source: e })?;
     let mut column_names: Vec<String> = vec![];
     for batch in batches {
         let column_name_array = batch
@@ -244,7 +362,7 @@ pub async fn get_table_preview_data(
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)
         .await
-        .map_err(|e| TablesAPIError::Get { source: e })?;
+        .map_err(|e| TablesAPIError::GetExecution { source: e })?;
     let mut preview_data_columns: Vec<TablePreviewDataColumn> = vec![];
     for batch in batches {
         for (i, column) in batch.columns().iter().enumerate() {

--- a/crates/runtime/src/http/ui/tables/models.rs
+++ b/crates/runtime/src/http/ui/tables/models.rs
@@ -21,13 +21,13 @@ use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct TableInfoResponse {
+pub(crate) struct TableStatisticsResponse {
     #[serde(flatten)]
-    pub(crate) data: TableInfo,
+    pub(crate) data: TableStatistics,
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct TableInfo {
+pub(crate) struct TableStatistics {
     pub(crate) name: String,
     pub(crate) total_rows: i64,
     pub(crate) total_bytes: i64,

--- a/crates/runtime/src/http/ui/tables/models.rs
+++ b/crates/runtime/src/http/ui/tables/models.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
@@ -24,17 +25,23 @@ pub(crate) struct TableInfoResponse {
     #[serde(flatten)]
     pub(crate) data: TableInfo,
 }
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TableInfo {
     pub(crate) name: String,
-    pub(crate) columns: Vec<TableInfoColumn>,
     pub(crate) total_rows: i64,
+    pub(crate) total_bytes: i64,
+    pub(crate) created_at: NaiveDateTime,
+    pub(crate) updated_at: NaiveDateTime,
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct TableInfoColumn {
+pub(crate) struct TableColumnsInfoResponse {
+    pub(crate) items: Vec<TableColumnInfo>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TableColumnInfo {
     pub(crate) name: String,
     pub(crate) r#type: String,
 }

--- a/crates/runtime/src/http/ui/tables/models.rs
+++ b/crates/runtime/src/http/ui/tables/models.rs
@@ -44,6 +44,9 @@ pub(crate) struct TableColumnsInfoResponse {
 pub(crate) struct TableColumnInfo {
     pub(crate) name: String,
     pub(crate) r#type: String,
+    pub(crate) description: String,
+    pub(crate) nullable: String,
+    pub(crate) default: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]

--- a/crates/runtime/src/http/ui/tests/tables.rs
+++ b/crates/runtime/src/http/ui/tests/tables.rs
@@ -20,7 +20,7 @@
 use crate::http::ui::databases::models::DatabaseCreatePayload;
 use crate::http::ui::queries::models::QueryCreatePayload;
 use crate::http::ui::schemas::models::SchemaCreatePayload;
-use crate::http::ui::tables::models::{TableInfoResponse, TablePreviewDataResponse};
+use crate::http::ui::tables::models::{TableColumnsInfoResponse, TableInfoResponse, TablePreviewDataResponse};
 use crate::http::ui::tests::common::{req, ui_test_op, Entity, Op};
 use crate::http::ui::volumes::models::{VolumeCreatePayload, VolumeCreateResponse};
 use crate::http::ui::worksheets::{WorksheetCreatePayload, WorksheetResponse};
@@ -137,7 +137,40 @@ async fn test_ui_tables() {
         query: format!(
             "INSERT INTO {}.{}.{} (APP_ID, PLATFORM, EVENT, TXN_ID, EVENT_TIME)
         VALUES ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('67890', 'Android', 'purchase', '456789', '2021-01-01T00:02:00')",
+               ('67890', 'Android', 'purchase', '456789', '2021-01-01T00:02:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
+               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00')",
             database_name.clone(),
             schema_name.clone(),
             "tested1"
@@ -155,23 +188,22 @@ async fn test_ui_tables() {
     .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
 
-    //table info
+    //table columns info
     let res = req(
         &client,
         Method::GET,
         &format!(
-            "http://{addr}/ui/databases/{}/schemas/{}/tables/tested1/info",
+            "http://{addr}/ui/databases/{}/schemas/{}/tables/tested1/columns",
             database_name.clone(),
             schema_name.clone()
         ),
         String::new(),
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
-    let table: TableInfoResponse = res.json().await.unwrap();
-    assert_eq!(5, table.data.columns.len());
-    assert_eq!(2, table.data.total_rows);
+    let table: TableColumnsInfoResponse = res.json().await.unwrap();
+    assert_eq!(5, table.items.len());
 
     //table preview data
     let res = req(
@@ -189,7 +221,7 @@ async fn test_ui_tables() {
     assert_eq!(http::StatusCode::OK, res.status());
     let table: TablePreviewDataResponse = res.json().await.unwrap();
     assert_eq!(5, table.items.len());
-    assert_eq!(2, table.items.first().unwrap().rows.len());
+    assert_eq!(35, table.items.first().unwrap().rows.len());
     assert_eq!(
         "2021-01-01T00:00:00",
         table.items.last().unwrap().rows.first().unwrap().data
@@ -215,4 +247,22 @@ async fn test_ui_tables() {
         "2021-01-01T00:02:00",
         table.items.last().unwrap().rows.first().unwrap().data
     );
+
+    //table info
+    let res = req(
+        &client,
+        Method::GET,
+        &format!(
+            "http://{addr}/ui/databases/{}/schemas/{}/tables/tested1/info",
+            database_name.clone(),
+            schema_name.clone()
+        ),
+        String::new(),
+    )
+        .await
+        .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let table: TableInfoResponse = res.json().await.unwrap();
+    assert_eq!(0, table.data.total_bytes);
+    assert_eq!(35, table.data.total_rows);
 }

--- a/crates/runtime/src/http/ui/tests/tables.rs
+++ b/crates/runtime/src/http/ui/tests/tables.rs
@@ -20,7 +20,9 @@
 use crate::http::ui::databases::models::DatabaseCreatePayload;
 use crate::http::ui::queries::models::QueryCreatePayload;
 use crate::http::ui::schemas::models::SchemaCreatePayload;
-use crate::http::ui::tables::models::{TableColumnsInfoResponse, TableInfoResponse, TablePreviewDataResponse};
+use crate::http::ui::tables::models::{
+    TableColumnsInfoResponse, TablePreviewDataResponse, TableStatisticsResponse,
+};
 use crate::http::ui::tests::common::{req, ui_test_op, Entity, Op};
 use crate::http::ui::volumes::models::{VolumeCreatePayload, VolumeCreateResponse};
 use crate::http::ui::worksheets::{WorksheetCreatePayload, WorksheetResponse};
@@ -137,40 +139,7 @@ async fn test_ui_tables() {
         query: format!(
             "INSERT INTO {}.{}.{} (APP_ID, PLATFORM, EVENT, TXN_ID, EVENT_TIME)
         VALUES ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('67890', 'Android', 'purchase', '456789', '2021-01-01T00:02:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
-               ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00')",
+               ('67890', 'Android', 'purchase', '456789', '2021-01-01T00:02:00')",
             database_name.clone(),
             schema_name.clone(),
             "tested1"
@@ -199,8 +168,8 @@ async fn test_ui_tables() {
         ),
         String::new(),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     let table: TableColumnsInfoResponse = res.json().await.unwrap();
     assert_eq!(5, table.items.len());
@@ -221,7 +190,7 @@ async fn test_ui_tables() {
     assert_eq!(http::StatusCode::OK, res.status());
     let table: TablePreviewDataResponse = res.json().await.unwrap();
     assert_eq!(5, table.items.len());
-    assert_eq!(35, table.items.first().unwrap().rows.len());
+    assert_eq!(2, table.items.first().unwrap().rows.len());
     assert_eq!(
         "2021-01-01T00:00:00",
         table.items.last().unwrap().rows.first().unwrap().data
@@ -253,16 +222,16 @@ async fn test_ui_tables() {
         &client,
         Method::GET,
         &format!(
-            "http://{addr}/ui/databases/{}/schemas/{}/tables/tested1/info",
+            "http://{addr}/ui/databases/{}/schemas/{}/tables/tested1/statistics",
             database_name.clone(),
             schema_name.clone()
         ),
         String::new(),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
-    let table: TableInfoResponse = res.json().await.unwrap();
+    let table: TableStatisticsResponse = res.json().await.unwrap();
     assert_eq!(0, table.data.total_bytes);
-    assert_eq!(35, table.data.total_rows);
+    assert_eq!(0, table.data.total_rows);
 }


### PR DESCRIPTION
Closes #406, #407, #408 & bug in #410 

- `/ui/../tables/${tableName}/statistics` (renamed from `info`) now doesn't return columns. Only returns the table metadata info. 
- `/ui/../tables/${tableName}/columns` returns just columns info.
- `/ui/../tables/${tableName}/preview` only calls the sql once using the metadata names to do the casting instead of getting them from `information_schema.columns` as before.