### PR TITLE
/ui/dashboard + minor error fixes for /ui/navigation-tress

### DIFF
--- a/crates/runtime/src/http/ui/dashboard/error.rs
+++ b/crates/runtime/src/http/ui/dashboard/error.rs
@@ -22,27 +22,31 @@ use axum::Json;
 use embucket_metastore::error::MetastoreError;
 use http::StatusCode;
 use snafu::prelude::*;
+use crate::http::ui::queries::error::QueryError;
 
-pub type NavigationTreesResult<T> = Result<T, NavigationTreesAPIError>;
+pub type DashboardResult<T> = Result<T, DashboardAPIError>;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
-pub enum NavigationTreesAPIError {
-    #[snafu(display("Get navigation trees error: {source}"))]
-    Get { source: MetastoreError },
+pub enum DashboardAPIError {
+    #[snafu(display("Get total: {source}"))]
+    Metastore { source: MetastoreError },
+    #[snafu(display("Get total: {source}"))]
+    Queries { source: QueryError },
 }
 
 // Select which status code to return.
-impl IntoStatusCode for NavigationTreesAPIError {
+impl IntoStatusCode for DashboardAPIError {
     fn status_code(&self) -> StatusCode {
         match self {
-            Self::Get { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Metastore { .. } 
+            | Self::Queries { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }
 
 // generic
-impl IntoResponse for NavigationTreesAPIError {
+impl IntoResponse for DashboardAPIError {
     fn into_response(self) -> axum::response::Response {
         let code = self.status_code();
         let error = ErrorResponse {

--- a/crates/runtime/src/http/ui/dashboard/error.rs
+++ b/crates/runtime/src/http/ui/dashboard/error.rs
@@ -17,12 +17,12 @@
 
 use crate::http::error::ErrorResponse;
 use crate::http::ui::error::IntoStatusCode;
+use crate::http::ui::queries::error::QueryError;
 use axum::response::IntoResponse;
 use axum::Json;
 use embucket_metastore::error::MetastoreError;
 use http::StatusCode;
 use snafu::prelude::*;
-use crate::http::ui::queries::error::QueryError;
 
 pub type DashboardResult<T> = Result<T, DashboardAPIError>;
 
@@ -39,8 +39,7 @@ pub enum DashboardAPIError {
 impl IntoStatusCode for DashboardAPIError {
     fn status_code(&self) -> StatusCode {
         match self {
-            Self::Metastore { .. } 
-            | Self::Queries { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Metastore { .. } | Self::Queries { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/crates/runtime/src/http/ui/dashboard/handlers.rs
+++ b/crates/runtime/src/http/ui/dashboard/handlers.rs
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::http::error::ErrorResponse;
+use crate::http::state::AppState;
+use axum::{extract::State, Json};
+use embucket_metastore::error::MetastoreError;
+use embucket_utils::scan_iterator::ScanIterator;
+use utoipa::OpenApi;
+use crate::http::ui::dashboard::error::{DashboardAPIError, DashboardResult};
+use crate::http::ui::dashboard::models::{Dashboard, DashboardResponse};
+use crate::http::ui::queries::error::QueryError;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        get_dashboard,
+    ),
+    components(
+        schemas(
+            DashboardResponse,
+            Dashboard,
+        )
+    ),
+    tags(
+        (name = "dashboard", description = "Dashboard endpoints.")
+    )
+)]
+pub struct ApiDoc;
+
+#[utoipa::path(
+    get,
+    operation_id = "getDashboard",
+    tags = ["dashboard"],
+    path = "/ui/dashboard",
+    responses(
+        (status = 200, description = "Successful Response", body = DashboardResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    )
+)]
+#[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
+pub async fn get_dashboard(
+    State(state): State<AppState>,
+) -> DashboardResult<Json<DashboardResponse>> {
+    let rw_databases = state
+        .metastore
+        .iter_databases()
+        .collect()
+        .await
+        .map_err(|e| DashboardAPIError::Metastore {
+            source: MetastoreError::UtilSlateDB { source: e },
+        })?;
+    let total_databases = rw_databases.len();
+    let mut total_schemas = 0;
+    let mut total_tables = 0;
+    for rw_database in rw_databases {
+        let rw_schemas = state
+            .metastore
+            .iter_schemas(&rw_database.ident.clone())
+            .collect()
+            .await
+            .map_err(|e| DashboardAPIError::Metastore {
+                source: MetastoreError::UtilSlateDB { source: e },
+            })?;
+        total_schemas += rw_schemas.len();
+        for rw_schema in rw_schemas {
+            total_tables += state
+                .metastore
+                .iter_tables(&rw_schema.ident)
+                .collect()
+                .await
+                .map_err(|e| DashboardAPIError::Metastore {
+                    source: MetastoreError::UtilSlateDB { source: e },
+                })?
+                .len();
+        }
+    }
+
+    let total_queries = state
+        .history
+        .get_queries(None, None, None)
+        .await
+        .map_err(|e| DashboardAPIError::Queries { source: QueryError::Store { source: e }})?
+        .len();
+    
+    Ok(Json(DashboardResponse {
+        data: Dashboard {
+            total_databases,
+            total_schemas,
+            total_tables,
+            total_queries,
+        }
+    }))
+}

--- a/crates/runtime/src/http/ui/dashboard/handlers.rs
+++ b/crates/runtime/src/http/ui/dashboard/handlers.rs
@@ -17,13 +17,13 @@
 
 use crate::http::error::ErrorResponse;
 use crate::http::state::AppState;
+use crate::http::ui::dashboard::error::{DashboardAPIError, DashboardResult};
+use crate::http::ui::dashboard::models::{Dashboard, DashboardResponse};
+use crate::http::ui::queries::error::QueryError;
 use axum::{extract::State, Json};
 use embucket_metastore::error::MetastoreError;
 use embucket_utils::scan_iterator::ScanIterator;
 use utoipa::OpenApi;
-use crate::http::ui::dashboard::error::{DashboardAPIError, DashboardResult};
-use crate::http::ui::dashboard::models::{Dashboard, DashboardResponse};
-use crate::http::ui::queries::error::QueryError;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -94,15 +94,17 @@ pub async fn get_dashboard(
         .history
         .get_queries(None, None, None)
         .await
-        .map_err(|e| DashboardAPIError::Queries { source: QueryError::Store { source: e }})?
+        .map_err(|e| DashboardAPIError::Queries {
+            source: QueryError::Store { source: e },
+        })?
         .len();
-    
+
     Ok(Json(DashboardResponse {
         data: Dashboard {
             total_databases,
             total_schemas,
             total_tables,
             total_queries,
-        }
+        },
     }))
 }

--- a/crates/runtime/src/http/ui/dashboard/mod.rs
+++ b/crates/runtime/src/http/ui/dashboard/mod.rs
@@ -14,13 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
-pub mod common;
-pub mod databases;
-pub mod navigation_trees;
-pub mod queries;
-pub mod schemas;
-pub mod tables;
-pub mod volumes;
-pub mod worksheets;
-pub mod dashboard;
+pub mod error;
+pub mod handlers;
+pub mod models;

--- a/crates/runtime/src/http/ui/dashboard/models.rs
+++ b/crates/runtime/src/http/ui/dashboard/models.rs
@@ -15,12 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod common;
-pub mod databases;
-pub mod navigation_trees;
-pub mod queries;
-pub mod schemas;
-pub mod tables;
-pub mod volumes;
-pub mod worksheets;
-pub mod dashboard;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardResponse {
+    #[serde(flatten)]
+    pub(crate) data: Dashboard,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Dashboard {
+    pub total_databases: usize,
+    pub total_schemas: usize,
+    pub total_tables: usize,
+    pub total_queries: usize,
+}

--- a/crates/runtime/src/http/ui/mod.rs
+++ b/crates/runtime/src/http/ui/mod.rs
@@ -20,13 +20,13 @@ pub mod error;
 // pub mod old_models;
 pub mod router;
 
+pub mod dashboard;
 pub mod databases;
+pub mod navigation_trees;
 pub mod queries;
 pub mod schemas;
 pub mod tables;
-pub mod volumes;
-pub mod worksheets;
-pub mod navigation_trees;
-pub mod dashboard;
 #[cfg(test)]
 pub mod tests;
+pub mod volumes;
+pub mod worksheets;

--- a/crates/runtime/src/http/ui/mod.rs
+++ b/crates/runtime/src/http/ui/mod.rs
@@ -26,7 +26,7 @@ pub mod schemas;
 pub mod tables;
 pub mod volumes;
 pub mod worksheets;
-
 pub mod navigation_trees;
+pub mod dashboard;
 #[cfg(test)]
 pub mod tests;

--- a/crates/runtime/src/http/ui/router.rs
+++ b/crates/runtime/src/http/ui/router.rs
@@ -47,15 +47,12 @@ use crate::http::ui::volumes::handlers::ApiDoc as VolumesApiDoc;
 use crate::http::ui::worksheets::handlers::ApiDoc as WorksheetsApiDoc;
 
 use crate::http::state::AppState;
+use crate::http::ui::dashboard::handlers::{get_dashboard, ApiDoc as DashboardApiDoc};
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{delete, get, post};
 use axum::Router;
 use tower_http::sensitive_headers::SetSensitiveHeadersLayer;
 use utoipa::OpenApi;
-use crate::http::ui::dashboard::handlers::{
-    get_dashboard, 
-    ApiDoc as DashboardApiDoc
-};
 
 #[derive(OpenApi)]
 #[openapi(

--- a/crates/runtime/src/http/ui/router.rs
+++ b/crates/runtime/src/http/ui/router.rs
@@ -52,6 +52,10 @@ use axum::routing::{delete, get, post};
 use axum::Router;
 use tower_http::sensitive_headers::SetSensitiveHeadersLayer;
 use utoipa::OpenApi;
+use crate::http::ui::dashboard::handlers::{
+    get_dashboard, 
+    ApiDoc as DashboardApiDoc
+};
 
 #[derive(OpenApi)]
 #[openapi(
@@ -80,12 +84,14 @@ pub fn ui_open_api_spec() -> utoipa::openapi::OpenApi {
         .merge_from(WorksheetsApiDoc::openapi())
         .merge_from(QueryApiDoc::openapi())
         .merge_from(DatabasesNavigationApiDoc::openapi())
+        .merge_from(DashboardApiDoc::openapi())
 }
 
 pub fn create_router() -> Router<AppState> {
     Router::new()
         // .route("/navigation_trees", get(navigation_trees))
         .route("/navigation-trees", get(get_navigation_trees))
+        .route("/dashboard", get(get_dashboard))
         .route(
             "/databases/{databaseName}/schemas/{schemaName}",
             delete(delete_schema),

--- a/crates/runtime/src/http/ui/tests/dashboard.rs
+++ b/crates/runtime/src/http/ui/tests/dashboard.rs
@@ -17,6 +17,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use crate::http::ui::dashboard::models::DashboardResponse;
 use crate::http::ui::databases::models::DatabaseCreatePayload;
 use crate::http::ui::queries::models::QueryCreatePayload;
 use crate::http::ui::schemas::models::SchemaCreatePayload;
@@ -29,7 +30,6 @@ use embucket_metastore::VolumeType as MetastoreVolumeType;
 use embucket_metastore::{Database as MetastoreDatabase, Volume as MetastoreVolume};
 use http::Method;
 use serde_json::json;
-use crate::http::ui::dashboard::models::DashboardResponse;
 
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
@@ -58,7 +58,7 @@ async fn test_ui_dashboard() {
             }),
         }),
     )
-        .await;
+    .await;
     let volume = res.json::<VolumeCreateResponse>().await.unwrap();
 
     // Create database, Ok
@@ -68,7 +68,7 @@ async fn test_ui_dashboard() {
             properties: None,
             volume: volume.data.name.clone(),
         }
-            .into(),
+        .into(),
     };
     let expected2 = DatabaseCreatePayload {
         data: MetastoreDatabase {
@@ -76,7 +76,7 @@ async fn test_ui_dashboard() {
             properties: None,
             volume: volume.data.name.clone(),
         }
-            .into(),
+        .into(),
     };
     let expected3 = DatabaseCreatePayload {
         data: MetastoreDatabase {
@@ -84,7 +84,7 @@ async fn test_ui_dashboard() {
             properties: None,
             volume: volume.data.name.clone(),
         }
-            .into(),
+        .into(),
     };
     let expected4 = DatabaseCreatePayload {
         data: MetastoreDatabase {
@@ -92,7 +92,7 @@ async fn test_ui_dashboard() {
             properties: None,
             volume: volume.data.name.clone(),
         }
-            .into(),
+        .into(),
     };
     //4 DBs
     let _res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected1.clone())).await;
@@ -122,11 +122,11 @@ async fn test_ui_dashboard() {
             "http://{addr}/ui/databases/{}/schemas",
             expected1.data.name.clone()
         )
-            .to_string(),
+        .to_string(),
         json!(payload).to_string(),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
 
     let res = req(&client, Method::GET, &url, String::new())
@@ -147,10 +147,10 @@ async fn test_ui_dashboard() {
             name: "test".to_string(),
             content: String::new(),
         })
-            .to_string(),
+        .to_string(),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     let worksheet = res.json::<WorksheetResponse>().await.unwrap().data;
 
@@ -182,8 +182,8 @@ async fn test_ui_dashboard() {
         &format!("http://{addr}/ui/queries"),
         json!(query_payload).to_string(),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
 
     let res = req(&client, Method::GET, &url, String::new())

--- a/crates/runtime/src/http/ui/tests/dashboard.rs
+++ b/crates/runtime/src/http/ui/tests/dashboard.rs
@@ -1,0 +1,198 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use crate::http::ui::databases::models::DatabaseCreatePayload;
+use crate::http::ui::queries::models::QueryCreatePayload;
+use crate::http::ui::schemas::models::SchemaCreatePayload;
+use crate::http::ui::tests::common::req;
+use crate::http::ui::tests::common::{ui_test_op, Entity, Op};
+use crate::http::ui::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse};
+use crate::http::ui::worksheets::models::{WorksheetCreatePayload, WorksheetResponse};
+use crate::tests::run_test_server;
+use embucket_metastore::VolumeType as MetastoreVolumeType;
+use embucket_metastore::{Database as MetastoreDatabase, Volume as MetastoreVolume};
+use http::Method;
+use serde_json::json;
+use crate::http::ui::dashboard::models::DashboardResponse;
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn test_ui_dashboard() {
+    let addr = run_test_server().await;
+    let client = reqwest::Client::new();
+    let url = format!("http://{addr}/ui/dashboard");
+    let res = req(&client, Method::GET, &url, String::new())
+        .await
+        .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let dashboard: DashboardResponse = res.json().await.unwrap();
+    assert_eq!(0, dashboard.data.total_databases);
+    assert_eq!(0, dashboard.data.total_schemas);
+    assert_eq!(0, dashboard.data.total_tables);
+    assert_eq!(0, dashboard.data.total_queries);
+
+    let res = ui_test_op(
+        addr,
+        Op::Create,
+        None,
+        &Entity::Volume(VolumeCreatePayload {
+            data: Volume::from(MetastoreVolume {
+                ident: String::new(),
+                volume: MetastoreVolumeType::Memory,
+            }),
+        }),
+    )
+        .await;
+    let volume = res.json::<VolumeCreateResponse>().await.unwrap();
+
+    // Create database, Ok
+    let expected1 = DatabaseCreatePayload {
+        data: MetastoreDatabase {
+            ident: "test1".to_string(),
+            properties: None,
+            volume: volume.data.name.clone(),
+        }
+            .into(),
+    };
+    let expected2 = DatabaseCreatePayload {
+        data: MetastoreDatabase {
+            ident: "test2".to_string(),
+            properties: None,
+            volume: volume.data.name.clone(),
+        }
+            .into(),
+    };
+    let expected3 = DatabaseCreatePayload {
+        data: MetastoreDatabase {
+            ident: "test3".to_string(),
+            properties: None,
+            volume: volume.data.name.clone(),
+        }
+            .into(),
+    };
+    let expected4 = DatabaseCreatePayload {
+        data: MetastoreDatabase {
+            ident: "test4".to_string(),
+            properties: None,
+            volume: volume.data.name.clone(),
+        }
+            .into(),
+    };
+    //4 DBs
+    let _res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected1.clone())).await;
+    let _res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected2.clone())).await;
+    let _res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected3.clone())).await;
+    let _res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected4.clone())).await;
+
+    let res = req(&client, Method::GET, &url, String::new())
+        .await
+        .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let dashboard: DashboardResponse = res.json().await.unwrap();
+    assert_eq!(4, dashboard.data.total_databases);
+    assert_eq!(0, dashboard.data.total_schemas);
+    assert_eq!(0, dashboard.data.total_tables);
+    assert_eq!(0, dashboard.data.total_queries);
+
+    let schema_name = "testing1".to_string();
+    let payload = SchemaCreatePayload {
+        name: schema_name.clone(),
+    };
+    //Create schema
+    let res = req(
+        &client,
+        Method::POST,
+        &format!(
+            "http://{addr}/ui/databases/{}/schemas",
+            expected1.data.name.clone()
+        )
+            .to_string(),
+        json!(payload).to_string(),
+    )
+        .await
+        .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+
+    let res = req(&client, Method::GET, &url, String::new())
+        .await
+        .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let dashboard: DashboardResponse = res.json().await.unwrap();
+    assert_eq!(4, dashboard.data.total_databases);
+    assert_eq!(1, dashboard.data.total_schemas);
+    assert_eq!(0, dashboard.data.total_tables);
+    assert_eq!(0, dashboard.data.total_queries);
+
+    let res = req(
+        &client,
+        Method::POST,
+        &format!("http://{addr}/ui/worksheets"),
+        json!(WorksheetCreatePayload {
+            name: "test".to_string(),
+            content: String::new(),
+        })
+            .to_string(),
+    )
+        .await
+        .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let worksheet = res.json::<WorksheetResponse>().await.unwrap().data;
+
+    let query_payload = QueryCreatePayload {
+        worksheet_id: Some(worksheet.id),
+        query: format!(
+            "create or replace Iceberg TABLE {}.{}.{}
+        external_volume = ''
+	    catalog = ''
+	    base_location = ''
+        (
+	    APP_ID TEXT,
+	    PLATFORM TEXT,
+	    ETL_TSTAMP TEXT,
+	    COLLECTOR_TSTAMP TEXT NOT NULL,
+	    DVCE_CREATED_TSTAMP TEXT,
+	    EVENT TEXT,
+	    EVENT_ID TEXT);",
+            expected1.data.name.clone(),
+            schema_name.clone(),
+            "tested1"
+        ),
+        context: None,
+    };
+
+    let res = req(
+        &client,
+        Method::POST,
+        &format!("http://{addr}/ui/queries"),
+        json!(query_payload).to_string(),
+    )
+        .await
+        .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+
+    let res = req(&client, Method::GET, &url, String::new())
+        .await
+        .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let dashboard: DashboardResponse = res.json().await.unwrap();
+    assert_eq!(4, dashboard.data.total_databases);
+    assert_eq!(1, dashboard.data.total_schemas);
+    assert_eq!(1, dashboard.data.total_tables);
+    assert_eq!(1, dashboard.data.total_queries);
+}

--- a/crates/runtime/src/http/ui/tests/mod.rs
+++ b/crates/runtime/src/http/ui/tests/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 pub mod common;
+pub mod dashboard;
 pub mod databases;
 pub mod navigation_trees;
 pub mod queries;
@@ -23,4 +24,3 @@ pub mod schemas;
 pub mod tables;
 pub mod volumes;
 pub mod worksheets;
-pub mod dashboard;


### PR DESCRIPTION
Closes #452 

- Added `/ui/dashboard` GET + tests
- Response returns: total dbs, total schemas, total tables and total queries (even failed queries, can filter out if needed)
- Fixed snafu error message in Navigation trees endpoint