### PR TITLE
Set correct columns name and default limit

### DIFF
--- a/crates/runtime/src/http/ui/tables/handlers.rs
+++ b/crates/runtime/src/http/ui/tables/handlers.rs
@@ -237,7 +237,9 @@ pub async fn get_table_preview_data(
     let column_names = column_names
         .iter()
         //UNSUPPORTED TYPES: ListArray, StructArray, Binary (Arrow Cast for Datafusion)
-        .map(|column_name| format!("COALESCE(CAST({column_name} AS STRING), 'Unsupported')"))
+        .map(|column_name| {
+            format!("COALESCE(CAST({column_name} AS STRING), 'Unsupported') AS {column_name}")
+        })
         .collect::<Vec<_>>();
     let sql_string = format!(
         "SELECT {} FROM {database_name}.{schema_name}.{table_name}",

--- a/crates/runtime/src/http/ui/tables/models.rs
+++ b/crates/runtime/src/http/ui/tables/models.rs
@@ -72,7 +72,13 @@ pub struct TablePreviewDataRow {
 #[derive(Debug, Deserialize, ToSchema, IntoParams)]
 pub struct TablePreviewDataParameters {
     pub offset: Option<u32>,
+    #[serde(default = "default_limit")]
     pub limit: Option<u16>,
+}
+
+#[allow(clippy::unnecessary_wraps)]
+const fn default_limit() -> Option<u16> {
+    Some(10)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
- set correct column name instead of COALESCE(CAST({column_name} AS STRING), 'Unsupported')
- set default limit since the full dataset is returned (10K-20K rows takes 70MB..)