### PR TITLE
Recording Execution Service

### DIFF
--- a/crates/runtime/src/execution/mod.rs
+++ b/crates/runtime/src/execution/mod.rs
@@ -8,5 +8,6 @@ pub mod service;
 pub mod session;
 pub mod utils;
 
+pub mod recording_service;
 #[cfg(test)]
 pub mod tests;

--- a/crates/runtime/src/execution/query.rs
+++ b/crates/runtime/src/execution/query.rs
@@ -48,18 +48,28 @@ use super::error::{self as ex_error, ExecutionError, ExecutionResult};
 use super::session::UserSession;
 use super::utils::{is_logical_plan_effectively_empty, NormalizedIdent};
 use crate::execution::datafusion::visitors::{functions_rewriter, json_element};
+use embucket_history::WorksheetId;
 use tracing_attributes::instrument;
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct QueryContext {
     pub database: Option<String>,
     pub schema: Option<String>,
+    pub worksheet_id: Option<WorksheetId>,
 }
 
 impl QueryContext {
     #[must_use]
-    pub const fn new(database: Option<String>, schema: Option<String>) -> Self {
-        Self { database, schema }
+    pub const fn new(
+        database: Option<String>,
+        schema: Option<String>,
+        worksheet_id: Option<WorksheetId>,
+    ) -> Self {
+        Self {
+            database,
+            schema,
+            worksheet_id,
+        }
     }
 }
 

--- a/crates/runtime/src/execution/recording_service.rs
+++ b/crates/runtime/src/execution/recording_service.rs
@@ -1,0 +1,96 @@
+use crate::execution::error::ExecutionResult;
+use crate::execution::models::ColumnInfo;
+use crate::execution::query::QueryContext;
+use crate::execution::service::ExecutionService;
+use crate::execution::utils::Config;
+use crate::http::ui::queries::models::ResultSet;
+use arrow::csv::reader::Format;
+use arrow_array::RecordBatch;
+use bytes::Bytes;
+use embucket_history::{QueryRecord, QueryRecordActions, WorksheetsStore};
+use embucket_metastore::TableIdent as MetastoreTableIdent;
+use std::sync::Arc;
+
+pub struct RecordingExecutionService {
+    pub execution: Arc<dyn ExecutionService>,
+    pub store: Arc<dyn WorksheetsStore>,
+}
+
+//TODO: add tests
+impl RecordingExecutionService {
+    pub fn new(execution: Arc<dyn ExecutionService>, store: Arc<dyn WorksheetsStore>) -> Self {
+        Self { execution, store }
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutionService for RecordingExecutionService {
+    async fn create_session(&self, session_id: String) -> ExecutionResult<()> {
+        self.execution.create_session(session_id).await
+    }
+
+    async fn delete_session(&self, session_id: String) -> ExecutionResult<()> {
+        self.execution.delete_session(session_id).await
+    }
+
+    async fn query(
+        &self,
+        session_id: &str,
+        query: &str,
+        query_context: QueryContext,
+    ) -> ExecutionResult<(Vec<RecordBatch>, Vec<ColumnInfo>)> {
+        let mut query_record = QueryRecord::query_start(query, query_context.worksheet_id);
+        let query_res = self.execution.query(session_id, query, query_context).await;
+        match query_res {
+            Ok((ref records, ref columns)) => {
+                let result_set = ResultSet::query_result_to_result_set(records, columns);
+                match result_set {
+                    Ok(result_set) => {
+                        let encoded_res = serde_json::to_string(&result_set);
+
+                        if let Ok(encoded_res) = encoded_res {
+                            let result_count = i64::try_from(records.len()).unwrap_or(0);
+                            query_record.query_finished(result_count, Some(encoded_res));
+                        }
+                        // failed to wrap query results
+                        else if let Err(err) = encoded_res {
+                            query_record.query_finished_with_error(err.to_string());
+                        }
+                    }
+                    // error getting result_set
+                    Err(err) => {
+                        query_record.query_finished_with_error(err.to_string());
+                    }
+                }
+            }
+            // query error
+            Err(ref err) => {
+                // query execution error
+                query_record.query_finished_with_error(err.to_string());
+            }
+        }
+        // add query record
+        if let Err(err) = self.store.add_query(&query_record).await {
+            // do not raise error, just log ?
+            tracing::error!("{err}");
+        }
+        query_res
+    }
+
+    async fn upload_data_to_table(
+        &self,
+        session_id: &str,
+        table_ident: &MetastoreTableIdent,
+        data: Bytes,
+        file_name: &str,
+        format: Format,
+    ) -> ExecutionResult<usize> {
+        self.execution
+            .upload_data_to_table(session_id, table_ident, data, file_name, format)
+            .await
+    }
+
+    fn config(&self) -> &Config {
+        self.execution.config()
+    }
+}

--- a/crates/runtime/src/execution/tests/query.rs
+++ b/crates/runtime/src/execution/tests/query.rs
@@ -198,7 +198,7 @@ async fn test_context_name_injection() {
 
     let query2 = session.query(
         "SELECT * from table2",
-        QueryContext::new(Some("db2".to_string()), Some("sch2".to_string())),
+        QueryContext::new(Some("db2".to_string()), Some("sch2".to_string()), None),
     );
     let query_statement2 = if let DFStatement::Statement(statement) =
         query2.parse_query().expect("Failed to parse query")

--- a/crates/runtime/src/execution/tests/service.rs
+++ b/crates/runtime/src/execution/tests/service.rs
@@ -1,14 +1,18 @@
+use std::sync::Arc;
 use crate::execution::query::QueryContext;
 use crate::execution::service::{CoreExecutionService, ExecutionService};
 use crate::execution::utils::{Config, DataSerializationFormat};
 use crate::SlateDBMetastore;
 use datafusion::{arrow::csv::reader::Format, assert_batches_eq};
+use embucket_history::{GetQueries, SlateDBWorksheetsStore, WorksheetsStore};
 use embucket_metastore::models::table::TableIdent as MetastoreTableIdent;
 use embucket_metastore::Metastore;
 use embucket_metastore::{
     Database as MetastoreDatabase, Schema as MetastoreSchema, SchemaIdent as MetastoreSchemaIdent,
     Volume as MetastoreVolume,
 };
+use embucket_utils::Db;
+use crate::execution::recording_service::RecordingExecutionService;
 
 #[tokio::test]
 #[allow(clippy::expect_used)]
@@ -264,4 +268,61 @@ async fn test_service_create_table_file_volume() {
         ],
         &res
     );
+}
+
+#[tokio::test]
+#[allow(clippy::expect_used, clippy::too_many_lines)]
+async fn test_recording_service() {
+    let db = Db::memory().await;
+    let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
+    let history_store = Arc::new(SlateDBWorksheetsStore::new(db));
+    let execution = Arc::new(CoreExecutionService::new(
+        metastore.clone(),
+        Config {
+            dbt_serialization_format: DataSerializationFormat::Json,
+        },
+    ));
+    let execution_svc = RecordingExecutionService::new(execution.clone(), history_store.clone());
+
+    metastore
+        .create_volume(
+            &"test_volume".to_string(),
+            MetastoreVolume::new(
+                "test_volume".to_string(),
+                embucket_metastore::VolumeType::Memory,
+            ),
+        )
+        .await
+        .expect("Failed to create volume");
+    
+    let database_name = "embucket".to_string();
+    
+    metastore
+        .create_database(
+            &database_name.clone(),
+            MetastoreDatabase {
+                ident: "embucket".to_string(),
+                properties: None,
+                volume: "test_volume".to_string(),
+            },
+        )
+        .await
+        .expect("Failed to create database");
+
+    let session_id = "test_session_id";
+    execution_svc
+        .create_session(session_id.to_string())
+        .await
+        .expect("Failed to create session");
+    
+    let schema_name = "public".to_string();
+    
+    let context = QueryContext::new(Some(database_name.clone()), Some(schema_name.clone()), None);
+    
+    execution_svc
+        .query(&session_id, format!("CREATE SCHEMA {}.{}", database_name.clone(), schema_name.clone()).as_str(), context)
+        .await
+        .expect("Failed to add schema");
+    
+    assert_eq!(1, history_store.get_queries(GetQueries::default()).await.expect("Failed to get queries").len());
 }

--- a/crates/runtime/src/execution/tests/service.rs
+++ b/crates/runtime/src/execution/tests/service.rs
@@ -276,13 +276,13 @@ async fn test_recording_service() {
     let db = Db::memory().await;
     let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
     let history_store = Arc::new(SlateDBWorksheetsStore::new(db));
-    let execution = Arc::new(CoreExecutionService::new(
+    let execution_svc = Arc::new(CoreExecutionService::new(
         metastore.clone(),
         Config {
             dbt_serialization_format: DataSerializationFormat::Json,
         },
     ));
-    let execution_svc = RecordingExecutionService::new(execution.clone(), history_store.clone());
+    let execution_svc = RecordingExecutionService::new(execution_svc.clone(), history_store.clone());
 
     metastore
         .create_volume(

--- a/crates/runtime/src/execution/tests/service.rs
+++ b/crates/runtime/src/execution/tests/service.rs
@@ -282,7 +282,8 @@ async fn test_recording_service() {
             dbt_serialization_format: DataSerializationFormat::Json,
         },
     ));
-    let execution_svc = RecordingExecutionService::new(execution_svc.clone(), history_store.clone());
+    let execution_svc =
+        RecordingExecutionService::new(execution_svc.clone(), history_store.clone());
 
     metastore
         .create_volume(

--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -48,9 +48,9 @@ pub fn make_app(
     config: &WebConfig,
 ) -> Result<Router, Box<dyn std::error::Error>> {
     let execution_cfg = execution::utils::Config::new(&config.data_format)?;
-    let execution = Arc::new(CoreExecutionService::new(metastore.clone(), execution_cfg));
+    let execution_svc = Arc::new(CoreExecutionService::new(metastore.clone(), execution_cfg));
     let execution_svc = Arc::new(RecordingExecutionService::new(
-        execution,
+        execution_svc,
         history_store.clone(),
     ));
 

--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -18,6 +18,7 @@ use tower_sessions::{Expiry, SessionManagerLayer};
 use layers::make_cors_middleware;
 use session::{RequestSessionMemory, RequestSessionStore};
 
+use crate::execution::recording_service::RecordingExecutionService;
 use crate::execution::{self, service::CoreExecutionService};
 
 pub mod error;
@@ -47,7 +48,11 @@ pub fn make_app(
     config: &WebConfig,
 ) -> Result<Router, Box<dyn std::error::Error>> {
     let execution_cfg = execution::utils::Config::new(&config.data_format)?;
-    let execution_svc = Arc::new(CoreExecutionService::new(metastore.clone(), execution_cfg));
+    let execution = Arc::new(CoreExecutionService::new(metastore.clone(), execution_cfg));
+    let execution_svc = Arc::new(RecordingExecutionService::new(
+        execution,
+        history_store.clone(),
+    ));
 
     let session_memory = RequestSessionMemory::default();
     let session_store = RequestSessionStore::new(session_memory, execution_svc.clone());

--- a/crates/runtime/src/http/ui/queries/handlers.rs
+++ b/crates/runtime/src/http/ui/queries/handlers.rs
@@ -85,6 +85,7 @@ pub async fn query(
             .context
             .as_ref()
             .and_then(|c| c.get("schema").cloned()),
+        payload.worksheet_id,
     );
 
     //TODO: map to result correctly without using duplicate code
@@ -124,11 +125,11 @@ pub async fn query(
         }
     }
 
-    // add query record
-    if let Err(err) = state.history_store.add_query(&query_record).await {
-        // do not raise error, just log ?
-        tracing::error!("{err}");
-    }
+    // // add query record
+    // if let Err(err) = state.history_store.add_query(&query_record).await {
+    //     // do not raise error, just log ?
+    //     tracing::error!("{err}");
+    // }
 
     if let Err(err) = query_res {
         Err(QueriesAPIError::Query {

--- a/crates/runtime/src/http/ui/schemas/handlers.rs
+++ b/crates/runtime/src/http/ui/schemas/handlers.rs
@@ -1,7 +1,6 @@
 use crate::execution::query::QueryContext;
 use crate::http::session::DFSessionId;
 use crate::http::state::AppState;
-use crate::http::ui::queries::models::ResultSet;
 use crate::http::ui::schemas::models::SchemasParameters;
 use crate::http::{
     error::ErrorResponse,
@@ -15,7 +14,6 @@ use axum::{
     extract::{Path, Query, State},
     Json,
 };
-use embucket_history::{QueryRecord, QueryRecordActions};
 use embucket_metastore::error::MetastoreError;
 use embucket_metastore::models::SchemaIdent as MetastoreSchemaIdent;
 use embucket_utils::scan_iterator::ScanIterator;
@@ -70,53 +68,24 @@ pub async fn create_schema(
     Path(database_name): Path<String>,
     Json(payload): Json<SchemaCreatePayload>,
 ) -> SchemasResult<Json<SchemaCreateResponse>> {
-    let context = QueryContext::new(Some(database_name.clone()), Some(payload.name.clone()));
+    let context = QueryContext::new(
+        Some(database_name.clone()),
+        Some(payload.name.clone()),
+        None,
+    );
     let sql_string = format!(
         "CREATE SCHEMA {}.{}",
         database_name.clone(),
         payload.name.clone()
     );
-    //TODO: figure out how to unify this, with the delete, instead of copying code (possibly a generic query history `fn`)
-    let mut query_record = QueryRecord::query_start(&sql_string, None);
-    let query_res = state
+    let _ = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)
-        .await;
-    match query_res {
-        Ok((ref records, ref columns)) => {
-            let result_set = ResultSet::query_result_to_result_set(records, columns);
-            match result_set {
-                Ok(result_set) => {
-                    let encoded_res = serde_json::to_string(&result_set);
-
-                    if let Ok(encoded_res) = encoded_res {
-                        let result_count = i64::try_from(records.len()).unwrap_or(0);
-                        query_record.query_finished(result_count, Some(encoded_res));
-                    }
-                    // failed to wrap query results
-                    else if let Err(err) = encoded_res {
-                        query_record.query_finished_with_error(err.to_string());
-                    }
-                }
-                // error getting result_set
-                Err(err) => {
-                    query_record.query_finished_with_error(err.to_string());
-                }
-            }
-        }
-        // query error
-        Err(ref err) => {
-            // query execution error
-            query_record.query_finished_with_error(err.to_string());
-        }
-    }
-    if let Err(err) = query_res {
-        Err(SchemasAPIError::Create { source: err })
-    } else {
-        Ok(Json(SchemaCreateResponse {
-            data: Schema::new(payload.name, database_name),
-        }))
-    }
+        .await
+        .map_err(|e| SchemasAPIError::Create { source: e })?;
+    Ok(Json(SchemaCreateResponse {
+        data: Schema::new(payload.name, database_name),
+    }))
 }
 
 #[utoipa::path(
@@ -140,51 +109,18 @@ pub async fn delete_schema(
     State(state): State<AppState>,
     Path((database_name, schema_name)): Path<(String, String)>,
 ) -> SchemasResult<()> {
-    let context = QueryContext::new(Some(database_name.clone()), Some(schema_name.clone()));
+    let context = QueryContext::new(Some(database_name.clone()), Some(schema_name.clone()), None);
     let sql_string = format!(
         "DROP SCHEMA {}.{}",
         database_name.clone(),
         schema_name.clone()
     );
-    //TODO: figure out how to unify this, with the create, instead of copying code (possibly a generic query history `fn`)
-    let mut query_record = QueryRecord::query_start(&sql_string, None);
-    let query_res = state
+    let _ = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)
-        .await;
-    match query_res {
-        Ok((ref records, ref columns)) => {
-            let result_set = ResultSet::query_result_to_result_set(records, columns);
-            match result_set {
-                Ok(result_set) => {
-                    let encoded_res = serde_json::to_string(&result_set);
-
-                    if let Ok(encoded_res) = encoded_res {
-                        let result_count = i64::try_from(records.len()).unwrap_or(0);
-                        query_record.query_finished(result_count, Some(encoded_res));
-                    }
-                    // failed to wrap query results
-                    else if let Err(err) = encoded_res {
-                        query_record.query_finished_with_error(err.to_string());
-                    }
-                }
-                // error getting result_set
-                Err(err) => {
-                    query_record.query_finished_with_error(err.to_string());
-                }
-            }
-        }
-        // query error
-        Err(ref err) => {
-            // query execution error
-            query_record.query_finished_with_error(err.to_string());
-        }
-    }
-    if let Err(err) = query_res {
-        Err(SchemasAPIError::Delete { source: err })
-    } else {
-        Ok(())
-    }
+        .await
+        .map_err(|e| SchemasAPIError::Delete { source: e })?;
+    Ok(())
 }
 
 #[utoipa::path(

--- a/crates/runtime/src/http/ui/tables/handlers.rs
+++ b/crates/runtime/src/http/ui/tables/handlers.rs
@@ -138,7 +138,7 @@ pub async fn get_table_columns(
     State(state): State<AppState>,
     Path((database_name, schema_name, table_name)): Path<(String, String, String)>,
 ) -> TablesResult<Json<TableColumnsResponse>> {
-    let context = QueryContext::new(Some(database_name.clone()), Some(schema_name.clone()));
+    let context = QueryContext::new(Some(database_name.clone()), Some(schema_name.clone()), None);
     let sql_string = format!("SELECT * FROM {database_name}.{schema_name}.{table_name} LIMIT 0");
     let (_, column_infos) = state
         .execution_svc
@@ -191,7 +191,7 @@ pub async fn get_table_preview_data(
     State(state): State<AppState>,
     Path((database_name, schema_name, table_name)): Path<(String, String, String)>,
 ) -> TablesResult<Json<TablePreviewDataResponse>> {
-    let context = QueryContext::new(Some(database_name.clone()), Some(schema_name.clone()));
+    let context = QueryContext::new(Some(database_name.clone()), Some(schema_name.clone()), None);
     let ident = MetastoreTableIdent::new(&database_name, &schema_name, &table_name);
     let column_names = match state.metastore.get_table(&ident).await {
         Ok(Some(rw_object)) => {

--- a/crates/runtime/src/http/ui/tests/dashboard.rs
+++ b/crates/runtime/src/http/ui/tests/dashboard.rs
@@ -120,7 +120,8 @@ async fn test_ui_dashboard() {
     assert_eq!(4, dashboard.data.total_databases);
     assert_eq!(1, dashboard.data.total_schemas);
     assert_eq!(0, dashboard.data.total_tables);
-    assert_eq!(0, dashboard.data.total_queries);
+    //Since schemas are created with sql
+    assert_eq!(1, dashboard.data.total_queries);
 
     let res = req(
         &client,
@@ -177,5 +178,6 @@ async fn test_ui_dashboard() {
     assert_eq!(4, dashboard.data.total_databases);
     assert_eq!(1, dashboard.data.total_schemas);
     assert_eq!(1, dashboard.data.total_tables);
-    assert_eq!(1, dashboard.data.total_queries);
+    //Since schemas are created with sql
+    assert_eq!(2, dashboard.data.total_queries);
 }


### PR DESCRIPTION
Closes #541 & #425

- `RecordingExecutionService` is a struct implementing the `ExecutionService` trait
- To avoid circular dependency it is done inside the `runtime` crate
- `QueryContext` now contains the `worksheet_id`, again UI is a dripping roof, that drips down to internals (not good)
- If you have other solutions to pass down `worksheet_id` feel free to suggest it
- Fixed some tests
- Added tests for `RecordingExecutionService`