### PR TITLE
SlateDb graceful shudown

### DIFF
--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -20,6 +20,7 @@ use session::{RequestSessionMemory, RequestSessionStore};
 
 use crate::execution::recording_service::RecordingExecutionService;
 use crate::execution::{self, service::CoreExecutionService};
+use embucket_utils::Db;
 
 pub mod error;
 
@@ -88,14 +89,18 @@ pub fn make_app(
 }
 
 #[allow(clippy::as_conversions)]
-pub async fn run_app(app: Router, config: &WebConfig) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run_app(
+    app: Router,
+    config: &WebConfig,
+    db: Db,
+) -> Result<(), Box<dyn std::error::Error>> {
     let host = config.host.clone();
     let port = config.port;
     let listener = tokio::net::TcpListener::bind(format!("{host}:{port}")).await?;
     let addr = listener.local_addr()?;
     tracing::info!("Listening on http://{}", addr);
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(shutdown_signal(db))
         .await
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
 }
@@ -110,7 +115,7 @@ pub async fn run_app(app: Router, config: &WebConfig) -> Result<(), Box<dyn std:
     clippy::redundant_pub_crate,
     clippy::cognitive_complexity
 )]
-async fn shutdown_signal() {
+async fn shutdown_signal(db: Db) {
     let ctrl_c = async {
         signal::ctrl_c()
             .await
@@ -130,9 +135,11 @@ async fn shutdown_signal() {
 
     tokio::select! {
         () = ctrl_c => {
+            db.close().await.expect("Failed to close database");
             tracing::warn!("Ctrl+C received, starting graceful shutdown");
         },
         () = terminate => {
+            db.close().await.expect("Failed to close database");
             tracing::warn!("SIGTERM received, starting graceful shutdown");
         },
     }

--- a/crates/runtime/src/http/mod.rs
+++ b/crates/runtime/src/http/mod.rs
@@ -92,7 +92,7 @@ pub fn make_app(
 pub async fn run_app(
     app: Router,
     config: &WebConfig,
-    db: Db,
+    db: Arc<Db>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let host = config.host.clone();
     let port = config.port;
@@ -115,7 +115,7 @@ pub async fn run_app(
     clippy::redundant_pub_crate,
     clippy::cognitive_complexity
 )]
-async fn shutdown_signal(db: Db) {
+async fn shutdown_signal(db: Arc<Db>) {
     let ctrl_c = async {
         signal::ctrl_c()
             .await

--- a/crates/runtime/src/http/ui/tables/handlers.rs
+++ b/crates/runtime/src/http/ui/tables/handlers.rs
@@ -32,6 +32,7 @@ use utoipa::OpenApi;
         get_table_columns,
         get_table_preview_data,
         upload_file,
+        get_tables,
     ),
     components(
         schemas(
@@ -40,11 +41,14 @@ use utoipa::OpenApi;
             TableColumnsResponse,
             TableColumn,
             TablePreviewDataResponse,
+            TablePreviewDataParameters,
             TablePreviewDataColumn,
             TablePreviewDataRow,
             UploadParameters,
             TableUploadPayload,
             TableUploadResponse,
+            TablesResponse,
+            TablesParameters,
             ErrorResponse,
         )
     ),

--- a/crates/runtime/src/http/web_assets/server.rs
+++ b/crates/runtime/src/http/web_assets/server.rs
@@ -1,7 +1,7 @@
 use super::config::StaticWebConfig;
 use super::handler::WEB_ASSETS_MOUNT_PATH;
 use super::handler::{root_handler, tar_handler};
-use crate::http::{layers::make_cors_middleware, shutdown_signal};
+use crate::http::layers::make_cors_middleware;
 use axum::{routing::get, Router};
 use core::net::SocketAddr;
 use tower_http::trace::TraceLayer;
@@ -34,7 +34,7 @@ pub async fn run_web_assets_server(
 
     tokio::spawn(async move {
         axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
+            // .with_graceful_shutdown(shutdown_signal())
             .await
     });
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -35,10 +35,10 @@ pub async fn run_binary(
     };
 
     let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
-    let history_store = Arc::new(SlateDBWorksheetsStore::new(db));
+    let history_store = Arc::new(SlateDBWorksheetsStore::new(db.clone()));
     let app = make_app(metastore, history_store, &config.web)?;
 
     let _ = run_web_assets_server(&config.web_assets).await?;
 
-    run_app(app, &config.web).await
+    run_app(app, &config.web, db).await
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -40,5 +40,5 @@ pub async fn run_binary(
 
     let _ = run_web_assets_server(&config.web_assets).await?;
 
-    run_app(app, &config.web, db).await
+    run_app(app, &config.web, Arc::new(db)).await
 }


### PR DESCRIPTION
Closes #695, also partially related to #56, #57 & #435

- Removed double messaging of graceful shutdown
- Provided `Db` to the `fn graceful_shudown`
- `Arc`ed the `Db` just in case (works without it also)
- Some fixes to `utoipa` schema (possibly false)