### PR TITLE
Reasonable default for cli options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Shared settings (default is first option (memory) with the shared settings)
+# Iceberg Catalog settings
+# Set to your catalog url
+CATALOG_URL=http://127.0.0.1:3000
+# Optional: CORS settings
+CORS_ENABLED=true
+CORS_ALLOW_ORIGIN=http://127.0.0.1:8080
+
+# Option 1 (Memory)
+# SlateDB storage settings
+OBJECT_STORE_BACKEND=memory
+
+# Option 2 (File)
+# SlateDB storage settings
+#OBJECT_STORE_BACKEND=file
+#FILE_STORAGE_PATH=storage
+#SLATEDB_PREFIX=state
+
+# Option 3 (S3)
+# SlateDB storage settings
+#OBJECT_STORE_BACKEND=s3
+# Optional: AWS S3 storage (leave blank if using local storage)
+#AWS_ACCESS_KEY_ID="<your_aws_access_key_id>"
+#AWS_SECRET_ACCESS_KEY="<your_aws_secret_access_key>"
+#AWS_REGION="<your_aws_region>"
+#S3_BUCKET="<your_s3_bucket>"
+#S3_ALLOW_HTTP=

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Shared settings (default is first option (memory) with the shared settings)
+# Shared settings (if no env vars are used, it will default to the first option (memory) with the shared settings)
 # Iceberg Catalog settings
 # Set to your catalog url
 CATALOG_URL=http://127.0.0.1:3000

--- a/bin/bucketd/src/cli.rs
+++ b/bin/bucketd/src/cli.rs
@@ -15,6 +15,7 @@ pub struct CliOpts {
         long,
         value_enum,
         env = "OBJECT_STORE_BACKEND",
+        default_value = "memory",
         help = "Backend to use for state storage"
     )]
     backend: StoreBackend,
@@ -75,7 +76,7 @@ pub struct CliOpts {
     )]
     file_storage_path: Option<PathBuf>,
 
-    #[arg(short, long, env = "SLATEDB_PREFIX")]
+    #[arg(short, long, env = "SLATEDB_PREFIX", default_value = "state")]
     pub slatedb_prefix: String,
 
     #[arg(
@@ -114,13 +115,14 @@ pub struct CliOpts {
         long,
         env = "CORS_ENABLED",
         help = "Enable CORS",
-        default_value = "false"
+        default_value = "true"
     )]
     pub cors_enabled: Option<bool>,
 
     #[arg(
         long,
         env = "CORS_ALLOW_ORIGIN",
+        default_value = "http://127.0.0.1:8080",
         required_if_eq("cors_enabled", "true"),
         help = "CORS Allow Origin"
     )]


### PR DESCRIPTION
Closes #691, #692 & #702

- Default `cors_enabled = true`
- Default `cors_allow_origin = http://127.0.0.1:8080`
- Default `object_backend_store = memory`
- Default `slatedb_prefix = state`

For ease of first launch, I think having this as default is great for experimentation.