### PR TITLE
Add information schema provider

### DIFF
--- a/crates/runtime/src/execution/catalog/information_schema/columns.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/columns.rs
@@ -1,0 +1,235 @@
+//! [`InformationSchemaColumns`] that implements the SQL [Information Schema Column] for Snowflake.
+//!
+//! [Information Schema Column]: https://docs.snowflake.com/en/sql-reference/info-schema/columns
+
+use crate::execution::catalog::information_schema::config::InformationSchemaConfig;
+use arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use arrow_array::builder::UInt64Builder;
+use arrow_schema::ArrowError;
+use datafusion::execution::TaskContext;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+use DataType::{
+    Binary, Decimal128, Float16, Float32, Float64, Int16, Int32, Int8, LargeBinary, LargeUtf8,
+    UInt16, UInt32, UInt64, UInt8, Utf8,
+};
+
+#[derive(Debug)]
+pub struct InformationSchemaColumns {
+    schema: SchemaRef,
+    config: InformationSchemaConfig,
+}
+
+impl InformationSchemaColumns {
+    pub fn new(config: InformationSchemaConfig) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("table_catalog", Utf8, false),
+            Field::new("table_schema", Utf8, false),
+            Field::new("table_name", Utf8, false),
+            Field::new("column_name", Utf8, false),
+            Field::new("ordinal_position", UInt64, false),
+            Field::new("column_default", Utf8, true),
+            Field::new("is_nullable", Utf8, false),
+            Field::new("data_type", Utf8, false),
+            Field::new("character_maximum_length", UInt64, true),
+            Field::new("character_octet_length", UInt64, true),
+            Field::new("numeric_precision", UInt64, true),
+            Field::new("numeric_precision_radix", UInt64, true),
+            Field::new("numeric_scale", UInt64, true),
+            Field::new("datetime_precision", UInt64, true),
+            Field::new("interval_type", Utf8, true),
+        ]));
+
+        Self { schema, config }
+    }
+
+    fn builder(&self) -> InformationSchemaColumnsBuilder {
+        // StringBuilder requires providing an initial capacity, so
+        // pick 10 here arbitrarily as this is not performance
+        // critical code and the number of tables is unavailable here.
+        let default_capacity = 10;
+
+        InformationSchemaColumnsBuilder {
+            catalog_names: StringBuilder::new(),
+            schema_names: StringBuilder::new(),
+            table_names: StringBuilder::new(),
+            column_names: StringBuilder::new(),
+            ordinal_positions: UInt64Builder::with_capacity(default_capacity),
+            column_defaults: StringBuilder::new(),
+            is_nullables: StringBuilder::new(),
+            data_types: StringBuilder::new(),
+            character_maximum_lengths: UInt64Builder::with_capacity(default_capacity),
+            character_octet_lengths: UInt64Builder::with_capacity(default_capacity),
+            numeric_precisions: UInt64Builder::with_capacity(default_capacity),
+            numeric_precision_radixes: UInt64Builder::with_capacity(default_capacity),
+            numeric_scales: UInt64Builder::with_capacity(default_capacity),
+            datetime_precisions: UInt64Builder::with_capacity(default_capacity),
+            interval_types: StringBuilder::new(),
+            schema: Arc::clone(&self.schema),
+        }
+    }
+}
+
+impl PartitionStream for InformationSchemaColumns {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        let config = self.config.clone();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            // TODO: Stream this
+            futures::stream::once(async move {
+                config.make_columns(&mut builder).await?;
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}
+
+pub struct InformationSchemaColumnsBuilder {
+    schema: SchemaRef,
+    catalog_names: StringBuilder,
+    schema_names: StringBuilder,
+    table_names: StringBuilder,
+    column_names: StringBuilder,
+    ordinal_positions: UInt64Builder,
+    column_defaults: StringBuilder,
+    is_nullables: StringBuilder,
+    data_types: StringBuilder,
+    character_maximum_lengths: UInt64Builder,
+    character_octet_lengths: UInt64Builder,
+    numeric_precisions: UInt64Builder,
+    numeric_precision_radixes: UInt64Builder,
+    numeric_scales: UInt64Builder,
+    datetime_precisions: UInt64Builder,
+    interval_types: StringBuilder,
+}
+
+impl InformationSchemaColumnsBuilder {
+    #[allow(clippy::as_conversions, clippy::cast_sign_loss)]
+    pub fn add_column(
+        &mut self,
+        catalog_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        field_position: usize,
+        field: &Field,
+    ) {
+        // Note: append_value is actually infallable.
+        self.catalog_names.append_value(catalog_name);
+        self.schema_names.append_value(schema_name);
+        self.table_names.append_value(table_name);
+
+        self.column_names.append_value(field.name());
+
+        self.ordinal_positions.append_value(field_position as u64);
+
+        // DataFusion does not support column default values, so null
+        self.column_defaults.append_null();
+
+        // "YES if the column is possibly nullable, NO if it is known not nullable. "
+        let nullable_str = if field.is_nullable() { "YES" } else { "NO" };
+        self.is_nullables.append_value(nullable_str);
+
+        // "System supplied type" --> Use debug format of the datatype
+        self.data_types
+            .append_value(format!("{:?}", field.data_type()));
+
+        // "If data_type identifies a character or bit string type, the
+        // declared maximum length; null for all other data types or
+        // if no maximum length was declared."
+        //
+        // Arrow has no equivalent of VARCHAR(20), so we leave this as Null
+        self.character_maximum_lengths.append_option(None);
+
+        // "Maximum length, in bytes, for binary data, character data,
+        // or text and image data."
+        let char_len: Option<u64> = match field.data_type() {
+            Utf8 | Binary => Some(i32::MAX as u64),
+            LargeBinary | LargeUtf8 => Some(i64::MAX as u64),
+            _ => None,
+        };
+        self.character_octet_lengths.append_option(char_len);
+
+        // numeric_precision: "If data_type identifies a numeric type, this column
+        // contains the (declared or implicit) precision of the type
+        // for this column. The precision indicates the number of
+        // significant digits. It can be expressed in decimal (base
+        // 10) or binary (base 2) terms, as specified in the column
+        // numeric_precision_radix. For all other data types, this
+        // column is null."
+        //
+        // numeric_radix: If data_type identifies a numeric type, this
+        // column indicates in which base the values in the columns
+        // numeric_precision and numeric_scale are expressed. The
+        // value is either 2 or 10. For all other data types, this
+        // column is null.
+        //
+        // numeric_scale: If data_type identifies an exact numeric
+        // type, this column contains the (declared or implicit) scale
+        // of the type for this column. The scale indicates the number
+        // of significant digits to the right of the decimal point. It
+        // can be expressed in decimal (base 10) or binary (base 2)
+        // terms, as specified in the column
+        // numeric_precision_radix. For all other data types, this
+        // column is null.
+        let (numeric_precision, numeric_radix, numeric_scale) = match field.data_type() {
+            Int8 | UInt8 => (Some(8), Some(2), None),
+            Int16 | UInt16 => (Some(16), Some(2), None),
+            Int32 | UInt32 => (Some(32), Some(2), None),
+            // From max value of 65504 as explained on
+            // https://en.wikipedia.org/wiki/Half-precision_floating-point_format#Exponent_encoding
+            Float16 => (Some(15), Some(2), None),
+            // Numbers from postgres `real` type
+            Float32 | Float64 => (Some(24), Some(2), None),
+            // Numbers from postgres `double` type and postgres `double` type
+            Decimal128(precision, scale) => {
+                (Some(u64::from(*precision)), Some(10), Some(*scale as u64))
+            }
+            _ => (None, None, None),
+        };
+
+        self.numeric_precisions.append_option(numeric_precision);
+        self.numeric_precision_radixes.append_option(numeric_radix);
+        self.numeric_scales.append_option(numeric_scale);
+
+        self.datetime_precisions.append_option(None);
+        self.interval_types.append_null();
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.catalog_names.finish()),
+                Arc::new(self.schema_names.finish()),
+                Arc::new(self.table_names.finish()),
+                Arc::new(self.column_names.finish()),
+                Arc::new(self.ordinal_positions.finish()),
+                Arc::new(self.column_defaults.finish()),
+                Arc::new(self.is_nullables.finish()),
+                Arc::new(self.data_types.finish()),
+                Arc::new(self.character_maximum_lengths.finish()),
+                Arc::new(self.character_octet_lengths.finish()),
+                Arc::new(self.numeric_precisions.finish()),
+                Arc::new(self.numeric_precision_radixes.finish()),
+                Arc::new(self.numeric_scales.finish()),
+                Arc::new(self.datetime_precisions.finish()),
+                Arc::new(self.interval_types.finish()),
+            ],
+        )
+    }
+}

--- a/crates/runtime/src/execution/catalog/information_schema/config.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/config.rs
@@ -1,0 +1,359 @@
+use super::columns::InformationSchemaColumnsBuilder;
+use super::df_settings::InformationSchemaDfSettingsBuilder;
+use super::information_schema::{INFORMATION_SCHEMA, INFORMATION_SCHEMA_TABLES};
+use super::parameters::{
+    get_udaf_args_and_return_types, get_udf_args_and_return_types, get_udwf_args_and_return_types,
+    InformationSchemaParametersBuilder,
+};
+use super::routines::InformationSchemaRoutinesBuilder;
+use super::schemata::InformationSchemataBuilder;
+use super::tables::InformationSchemaTablesBuilder;
+use super::views::InformationSchemaViewBuilder;
+use datafusion::catalog::CatalogProviderList;
+use datafusion::logical_expr::{Signature, TypeSignature, Volatility};
+use datafusion_common::config::ConfigOptions;
+use datafusion_common::DataFusionError;
+use datafusion_doc::Documentation;
+use datafusion_expr::{AggregateUDF, ScalarUDF, TableType, WindowUDF};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct InformationSchemaConfig {
+    pub(crate) catalog_list: Arc<dyn CatalogProviderList>,
+    pub(crate) catalog_name: Arc<str>,
+}
+
+impl InformationSchemaConfig {
+    /// Construct the `information_schema.tables` virtual table
+    pub(crate) async fn make_tables(
+        &self,
+        builder: &mut InformationSchemaTablesBuilder,
+    ) -> datafusion_common::Result<(), DataFusionError> {
+        let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) else {
+            return Ok(());
+        };
+
+        for schema_name in catalog.schema_names() {
+            if schema_name == INFORMATION_SCHEMA {
+                continue;
+            }
+
+            // schema name may not exist in the catalog, so we need to check
+            let Some(schema) = catalog.schema(&schema_name) else {
+                continue;
+            };
+
+            for table_name in schema.table_names() {
+                if let Some(table) = schema.table(&table_name).await? {
+                    builder.add_table(
+                        &self.catalog_name,
+                        &schema_name,
+                        &table_name,
+                        table.table_type(),
+                    );
+                }
+            }
+        }
+        // Add a final list for the information schema tables themselves
+        for table_name in INFORMATION_SCHEMA_TABLES {
+            builder.add_table(
+                &self.catalog_name,
+                INFORMATION_SCHEMA,
+                table_name,
+                TableType::View,
+            );
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn make_schemata(&self, builder: &mut InformationSchemataBuilder) {
+        let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) else {
+            return;
+        };
+
+        for schema_name in catalog.schema_names() {
+            if schema_name == INFORMATION_SCHEMA {
+                continue;
+            }
+
+            let Some(schema) = catalog.schema(&schema_name) else {
+                continue;
+            };
+
+            let schema_owner = schema.owner_name();
+            builder.add_schemata(&self.catalog_name, &schema_name, schema_owner);
+        }
+    }
+
+    pub(crate) async fn make_views(
+        &self,
+        builder: &mut InformationSchemaViewBuilder,
+    ) -> datafusion_common::Result<(), DataFusionError> {
+        let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) else {
+            return Ok(());
+        };
+
+        for schema_name in catalog.schema_names() {
+            if schema_name == INFORMATION_SCHEMA {
+                continue;
+            }
+
+            let Some(schema) = catalog.schema(&schema_name) else {
+                continue;
+            };
+
+            for table_name in schema.table_names() {
+                let Some(table) = schema.table(&table_name).await? else {
+                    continue;
+                };
+
+                builder.add_view(
+                    &self.catalog_name,
+                    &schema_name,
+                    &table_name,
+                    table.get_table_definition(),
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Construct the `information_schema.columns` virtual table
+    pub(crate) async fn make_columns(
+        &self,
+        builder: &mut InformationSchemaColumnsBuilder,
+    ) -> datafusion_common::Result<(), DataFusionError> {
+        let Some(catalog) = self.catalog_list.catalog(&self.catalog_name) else {
+            return Ok(());
+        };
+
+        for schema_name in catalog.schema_names() {
+            if schema_name == INFORMATION_SCHEMA {
+                continue;
+            }
+
+            let Some(schema) = catalog.schema(&schema_name) else {
+                continue;
+            };
+
+            for table_name in schema.table_names() {
+                let Some(table) = schema.table(&table_name).await? else {
+                    continue;
+                };
+
+                for (field_position, field) in table.schema().fields().iter().enumerate() {
+                    builder.add_column(
+                        &self.catalog_name,
+                        &schema_name,
+                        &table_name,
+                        field_position,
+                        field,
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Construct the `information_schema.df_settings` virtual table
+    pub(crate) fn make_df_settings(
+        config_options: &ConfigOptions,
+        builder: &mut InformationSchemaDfSettingsBuilder,
+    ) {
+        for entry in config_options.entries() {
+            builder.add_setting(entry);
+        }
+    }
+
+    pub(crate) fn make_routines(
+        udfs: &HashMap<String, Arc<ScalarUDF>>,
+        udafs: &HashMap<String, Arc<AggregateUDF>>,
+        udwfs: &HashMap<String, Arc<WindowUDF>>,
+        config_options: &ConfigOptions,
+        builder: &mut InformationSchemaRoutinesBuilder,
+    ) {
+        let catalog_name = &config_options.catalog.default_catalog;
+        let schema_name = &config_options.catalog.default_schema;
+
+        let mut add_routines = |name: &str,
+                                return_types: Vec<Option<String>>,
+                                routine_type: &str,
+                                is_deterministic: bool,
+                                doc: Option<&Documentation>| {
+            let description = doc.map(|d| d.description.to_string());
+            let example = doc.map(|d| d.syntax_example.to_string());
+
+            for return_type in return_types {
+                builder.add_routine(
+                    catalog_name,
+                    schema_name,
+                    name,
+                    "FUNCTION",
+                    is_deterministic,
+                    return_type,
+                    routine_type,
+                    description.clone(),
+                    example.clone(),
+                );
+            }
+        };
+
+        for (name, udf) in udfs {
+            let return_types = get_udf_args_and_return_types(udf)
+                .into_iter()
+                .map(|(_, ret)| ret)
+                .collect();
+            add_routines(
+                name,
+                return_types,
+                "SCALAR",
+                Self::is_deterministic(udf.signature()),
+                udf.documentation(),
+            );
+        }
+
+        for (name, udaf) in udafs {
+            let return_types = get_udaf_args_and_return_types(udaf)
+                .into_iter()
+                .map(|(_, ret)| ret)
+                .collect();
+            add_routines(
+                name,
+                return_types,
+                "AGGREGATE",
+                Self::is_deterministic(udaf.signature()),
+                udaf.documentation(),
+            );
+        }
+
+        for (name, udwf) in udwfs {
+            let return_types = get_udwf_args_and_return_types(udwf)
+                .into_iter()
+                .map(|(_, ret)| ret)
+                .collect();
+            add_routines(
+                name,
+                return_types,
+                "WINDOW",
+                Self::is_deterministic(udwf.signature()),
+                udwf.documentation(),
+            );
+        }
+    }
+
+    fn is_deterministic(signature: &Signature) -> bool {
+        signature.volatility == Volatility::Immutable
+    }
+    pub(crate) fn make_parameters(
+        udfs: &HashMap<String, Arc<ScalarUDF>>,
+        udafs: &HashMap<String, Arc<AggregateUDF>>,
+        udwfs: &HashMap<String, Arc<WindowUDF>>,
+        config_options: &ConfigOptions,
+        builder: &mut InformationSchemaParametersBuilder,
+    ) -> datafusion_common::Result<()> {
+        let catalog_name = &config_options.catalog.default_catalog;
+        let schema_name = &config_options.catalog.default_schema;
+        let mut add_parameters = |func_name: &str,
+                                  args: Option<&Vec<(String, String)>>,
+                                  arg_types: Vec<String>,
+                                  return_type: Option<String>,
+                                  is_variadic: bool,
+                                  rid: usize|
+         -> datafusion_common::Result<()> {
+            let rid = u8::try_from(rid)
+                .map_err(|_| DataFusionError::Execution("rid param doesn't fit in u8)".into()))?;
+            for (position, type_name) in arg_types.iter().enumerate() {
+                let param_name = args.and_then(|a| a.get(position).map(|arg| arg.0.as_str()));
+                let ordinal_position = u64::try_from(position + 1).map_err(|_| {
+                    DataFusionError::Execution("ordinal_position param overflow".into())
+                })?;
+
+                builder.add_parameter(
+                    catalog_name,
+                    schema_name,
+                    func_name,
+                    ordinal_position,
+                    "IN",
+                    param_name.map(String::from),
+                    type_name,
+                    None,
+                    is_variadic,
+                    rid,
+                );
+            }
+            if let Some(return_type) = return_type {
+                builder.add_parameter(
+                    catalog_name,
+                    schema_name,
+                    func_name,
+                    1,
+                    "OUT",
+                    None,
+                    return_type.as_str(),
+                    None,
+                    false,
+                    rid,
+                );
+            }
+            Ok(())
+        };
+
+        for (func_name, udf) in udfs {
+            let args = udf.documentation().and_then(|d| d.arguments.clone());
+            let combinations = get_udf_args_and_return_types(udf);
+            for (rid, (arg_types, return_type)) in combinations.into_iter().enumerate() {
+                add_parameters(
+                    func_name,
+                    args.as_ref(),
+                    arg_types,
+                    return_type,
+                    Self::is_variadic(udf.signature()),
+                    rid,
+                )?;
+            }
+        }
+
+        for (func_name, udaf) in udafs {
+            let args = udaf.documentation().and_then(|d| d.arguments.clone());
+            let combinations = get_udaf_args_and_return_types(udaf);
+            for (rid, (arg_types, return_type)) in combinations.into_iter().enumerate() {
+                add_parameters(
+                    func_name,
+                    args.as_ref(),
+                    arg_types,
+                    return_type,
+                    Self::is_variadic(udaf.signature()),
+                    rid,
+                )?;
+            }
+        }
+
+        for (func_name, udwf) in udwfs {
+            let args = udwf.documentation().and_then(|d| d.arguments.clone());
+            let combinations = get_udwf_args_and_return_types(udwf);
+            for (rid, (arg_types, return_type)) in combinations.into_iter().enumerate() {
+                add_parameters(
+                    func_name,
+                    args.as_ref(),
+                    arg_types,
+                    return_type,
+                    Self::is_variadic(udwf.signature()),
+                    rid,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    const fn is_variadic(signature: &Signature) -> bool {
+        matches!(
+            signature.type_signature,
+            TypeSignature::Variadic(_) | TypeSignature::VariadicAny
+        )
+    }
+}

--- a/crates/runtime/src/execution/catalog/information_schema/config.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/config.rs
@@ -9,6 +9,7 @@ use super::routines::InformationSchemaRoutinesBuilder;
 use super::schemata::InformationSchemataBuilder;
 use super::tables::InformationSchemaTablesBuilder;
 use super::views::InformationSchemaViewBuilder;
+use crate::execution::catalog::information_schema::databases::InformationSchemaDatabasesBuilder;
 use datafusion::catalog::CatalogProviderList;
 use datafusion::logical_expr::{Signature, TypeSignature, Volatility};
 use datafusion_common::config::ConfigOptions;
@@ -157,6 +158,14 @@ impl InformationSchemaConfig {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn make_databases(&self, builder: &mut InformationSchemaDatabasesBuilder) {
+        self.catalog_list
+            .catalog_names()
+            .iter()
+            .filter_map(|name| self.catalog_list.catalog(name).map(|_| name))
+            .for_each(|name| builder.add_database(name, "", ""));
     }
 
     /// Construct the `information_schema.df_settings` virtual table

--- a/crates/runtime/src/execution/catalog/information_schema/databases.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/databases.rs
@@ -1,0 +1,97 @@
+//! [`InformationSchemaDatabases`] that implements the SQL [Information Schema Databases] for Snowflake.
+//!
+//! [Information Schema Databases]: https://docs.snowflake.com/en/sql-reference/info-schema/databases
+
+use crate::execution::catalog::information_schema::config::InformationSchemaConfig;
+use arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use arrow_schema::ArrowError;
+use datafusion::execution::TaskContext;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct InformationSchemaDatabases {
+    schema: SchemaRef,
+    config: InformationSchemaConfig,
+}
+
+impl InformationSchemaDatabases {
+    pub(crate) fn new(config: InformationSchemaConfig) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("database_name", DataType::Utf8, false),
+            Field::new("database_owner", DataType::Utf8, false),
+            Field::new("database_types", DataType::Utf8, false),
+            // TODO add fields from https://docs.snowflake.com/en/sql-reference/info-schema/databases
+        ]));
+
+        Self { schema, config }
+    }
+
+    fn builder(&self) -> InformationSchemaDatabasesBuilder {
+        InformationSchemaDatabasesBuilder {
+            schema: Arc::clone(&self.schema),
+            database_names: StringBuilder::new(),
+            database_owners: StringBuilder::new(),
+            database_types: StringBuilder::new(),
+        }
+    }
+}
+
+impl PartitionStream for InformationSchemaDatabases {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        self.config.make_databases(&mut builder);
+        let result = builder
+            .finish()
+            .map_err(|e| DataFusionError::ArrowError(e, None));
+
+        let stream = futures::stream::iter(vec![result]);
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            stream,
+        ))
+    }
+}
+
+pub struct InformationSchemaDatabasesBuilder {
+    schema: SchemaRef,
+    database_names: StringBuilder,
+    database_owners: StringBuilder,
+    database_types: StringBuilder,
+}
+
+impl InformationSchemaDatabasesBuilder {
+    pub fn add_database(
+        &mut self,
+        database_name: impl AsRef<str>,
+        database_owner: impl AsRef<str>,
+        database_type: impl AsRef<str>,
+    ) {
+        self.database_names.append_value(database_name.as_ref());
+        self.database_owners.append_value(database_owner.as_ref());
+        self.database_types.append_value(database_type.as_ref());
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.database_names.finish()),
+                Arc::new(self.database_owners.finish()),
+                Arc::new(self.database_types.finish()),
+            ],
+        )
+    }
+}

--- a/crates/runtime/src/execution/catalog/information_schema/df_settings.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/df_settings.rs
@@ -1,0 +1,90 @@
+use crate::execution::catalog::information_schema::config::InformationSchemaConfig;
+use arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use arrow_schema::ArrowError;
+use datafusion::execution::TaskContext;
+use datafusion_common::config::ConfigEntry;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct InformationSchemaDfSettings {
+    schema: SchemaRef,
+}
+
+impl InformationSchemaDfSettings {
+    pub fn new() -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, true),
+            Field::new("description", DataType::Utf8, true),
+        ]));
+
+        Self { schema }
+    }
+
+    fn builder(&self) -> InformationSchemaDfSettingsBuilder {
+        InformationSchemaDfSettingsBuilder {
+            names: StringBuilder::new(),
+            values: StringBuilder::new(),
+            descriptions: StringBuilder::new(),
+            schema: Arc::clone(&self.schema),
+        }
+    }
+}
+
+impl PartitionStream for InformationSchemaDfSettings {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            // TODO: Stream this
+            futures::stream::once(async move {
+                InformationSchemaConfig::make_df_settings(
+                    ctx.session_config().options(),
+                    &mut builder,
+                );
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}
+
+pub struct InformationSchemaDfSettingsBuilder {
+    schema: SchemaRef,
+    names: StringBuilder,
+    values: StringBuilder,
+    descriptions: StringBuilder,
+}
+
+impl InformationSchemaDfSettingsBuilder {
+    pub fn add_setting(&mut self, entry: ConfigEntry) {
+        self.names.append_value(entry.key);
+        self.values.append_option(entry.value);
+        self.descriptions.append_value(entry.description);
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.names.finish()),
+                Arc::new(self.values.finish()),
+                Arc::new(self.descriptions.finish()),
+            ],
+        )
+    }
+}

--- a/crates/runtime/src/execution/catalog/information_schema/information_schema.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/information_schema.rs
@@ -1,0 +1,102 @@
+//! [`InformationSchemaProvider`] that implements the SQL [Information Schema] for Snowflake.
+//!
+//! [Information Schema]: https://docs.snowflake.com/en/sql-reference/info-schema
+
+use super::config::InformationSchemaConfig;
+use super::schemata::InformationSchemata;
+use super::tables::InformationSchemaTables;
+use super::views::InformationSchemaViews;
+
+use crate::execution::catalog::information_schema::columns::InformationSchemaColumns;
+use crate::execution::catalog::information_schema::df_settings::InformationSchemaDfSettings;
+use crate::execution::catalog::information_schema::parameters::InformationSchemaParameters;
+use crate::execution::catalog::information_schema::routines::InformationSchemaRoutines;
+use async_trait::async_trait;
+use datafusion::catalog::streaming::StreamingTable;
+use datafusion::catalog::{CatalogProviderList, SchemaProvider, TableProvider};
+use datafusion_common::error::Result;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::streaming::PartitionStream;
+use std::fmt::Debug;
+use std::{any::Any, sync::Arc};
+
+pub const INFORMATION_SCHEMA: &str = "information_schema";
+pub const TABLES: &str = "tables";
+pub const VIEWS: &str = "views";
+pub const COLUMNS: &str = "columns";
+pub const SCHEMATA: &str = "schemata";
+pub const DF_SETTINGS: &str = "df_settings";
+pub const ROUTINES: &str = "routines";
+pub const PARAMETERS: &str = "parameters";
+
+/// All information schema tables
+pub const INFORMATION_SCHEMA_TABLES: &[&str] = &[
+    TABLES,
+    VIEWS,
+    COLUMNS,
+    SCHEMATA,
+    DF_SETTINGS,
+    ROUTINES,
+    PARAMETERS,
+];
+
+/// Implements the `information_schema` virtual schema and tables
+///
+/// The underlying tables in the `information_schema` are created on
+/// demand. This means that if more tables are added to the underlying
+/// providers, they will appear the next time the `information_schema`
+/// table is queried.
+#[derive(Debug)]
+pub struct InformationSchemaProvider {
+    config: InformationSchemaConfig,
+}
+
+impl InformationSchemaProvider {
+    /// Creates a new [`InformationSchemaProvider`] for the provided `catalog_list`
+    pub fn new(catalog_list: Arc<dyn CatalogProviderList>, catalog_name: Arc<str>) -> Self {
+        Self {
+            config: InformationSchemaConfig {
+                catalog_list,
+                catalog_name,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for InformationSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        INFORMATION_SCHEMA_TABLES
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
+        let config = self.config.clone();
+        let table: Arc<dyn PartitionStream> = match name.to_ascii_lowercase().as_str() {
+            TABLES => Arc::new(InformationSchemaTables::new(config)),
+            COLUMNS => Arc::new(InformationSchemaColumns::new(config)),
+            VIEWS => Arc::new(InformationSchemaViews::new(config)),
+            SCHEMATA => Arc::new(InformationSchemata::new(config)),
+            // TODO: Check if non-Snowflake related tables are required
+            DF_SETTINGS => Arc::new(InformationSchemaDfSettings::new()),
+            ROUTINES => Arc::new(InformationSchemaRoutines::new()),
+            PARAMETERS => Arc::new(InformationSchemaParameters::new()),
+            _ => return Ok(None),
+        };
+
+        Ok(Some(Arc::new(StreamingTable::try_new(
+            Arc::clone(table.schema()),
+            vec![table],
+        )?)))
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        INFORMATION_SCHEMA_TABLES.contains(&name.to_ascii_lowercase().as_str())
+    }
+}

--- a/crates/runtime/src/execution/catalog/information_schema/information_schema.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/information_schema.rs
@@ -8,6 +8,7 @@ use super::tables::InformationSchemaTables;
 use super::views::InformationSchemaViews;
 
 use crate::execution::catalog::information_schema::columns::InformationSchemaColumns;
+use crate::execution::catalog::information_schema::databases::InformationSchemaDatabases;
 use crate::execution::catalog::information_schema::df_settings::InformationSchemaDfSettings;
 use crate::execution::catalog::information_schema::parameters::InformationSchemaParameters;
 use crate::execution::catalog::information_schema::routines::InformationSchemaRoutines;
@@ -25,6 +26,8 @@ pub const TABLES: &str = "tables";
 pub const VIEWS: &str = "views";
 pub const COLUMNS: &str = "columns";
 pub const SCHEMATA: &str = "schemata";
+pub const DATABASES: &str = "databases";
+
 pub const DF_SETTINGS: &str = "df_settings";
 pub const ROUTINES: &str = "routines";
 pub const PARAMETERS: &str = "parameters";
@@ -83,6 +86,7 @@ impl SchemaProvider for InformationSchemaProvider {
             COLUMNS => Arc::new(InformationSchemaColumns::new(config)),
             VIEWS => Arc::new(InformationSchemaViews::new(config)),
             SCHEMATA => Arc::new(InformationSchemata::new(config)),
+            DATABASES => Arc::new(InformationSchemaDatabases::new(config)),
             // TODO: Check if non-Snowflake related tables are required
             DF_SETTINGS => Arc::new(InformationSchemaDfSettings::new()),
             ROUTINES => Arc::new(InformationSchemaRoutines::new()),

--- a/crates/runtime/src/execution/catalog/information_schema/mod.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/mod.rs
@@ -1,0 +1,10 @@
+mod columns;
+mod config;
+mod df_settings;
+#[allow(clippy::module_inception)]
+pub mod information_schema;
+mod parameters;
+mod routines;
+mod schemata;
+mod tables;
+mod views;

--- a/crates/runtime/src/execution/catalog/information_schema/mod.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/mod.rs
@@ -1,5 +1,6 @@
 mod columns;
 mod config;
+mod databases;
 mod df_settings;
 #[allow(clippy::module_inception)]
 pub mod information_schema;

--- a/crates/runtime/src/execution/catalog/information_schema/parameters.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/parameters.rs
@@ -1,0 +1,192 @@
+use crate::execution::catalog::information_schema::config::InformationSchemaConfig;
+use arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use arrow_array::builder::{BooleanBuilder, UInt64Builder, UInt8Builder};
+use arrow_schema::ArrowError;
+use datafusion::execution::TaskContext;
+use datafusion::logical_expr::Signature;
+use datafusion_common::DataFusionError;
+use datafusion_expr::{AggregateUDF, ScalarUDF, WindowUDF};
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct InformationSchemaParameters {
+    schema: SchemaRef,
+}
+
+impl InformationSchemaParameters {
+    pub fn new() -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("specific_catalog", DataType::Utf8, false),
+            Field::new("specific_schema", DataType::Utf8, false),
+            Field::new("specific_name", DataType::Utf8, false),
+            Field::new("ordinal_position", DataType::UInt64, false),
+            Field::new("parameter_mode", DataType::Utf8, false),
+            Field::new("parameter_name", DataType::Utf8, true),
+            Field::new("data_type", DataType::Utf8, false),
+            Field::new("parameter_default", DataType::Utf8, true),
+            Field::new("is_variadic", DataType::Boolean, false),
+            // `rid` (short for `routine id`) is used to differentiate parameters from different signatures
+            // (It serves as the group-by key when generating the `SHOW FUNCTIONS` query).
+            // For example, the following signatures have different `rid` values:
+            //     - `datetrunc(Utf8, Timestamp(Microsecond, Some("+TZ"))) -> Timestamp(Microsecond, Some("+TZ"))`
+            //     - `datetrunc(Utf8View, Timestamp(Nanosecond, None)) -> Timestamp(Nanosecond, None)`
+            Field::new("rid", DataType::UInt8, false),
+        ]));
+
+        Self { schema }
+    }
+
+    fn builder(&self) -> InformationSchemaParametersBuilder {
+        InformationSchemaParametersBuilder {
+            schema: Arc::clone(&self.schema),
+            specific_catalog: StringBuilder::new(),
+            specific_schema: StringBuilder::new(),
+            specific_name: StringBuilder::new(),
+            ordinal_position: UInt64Builder::new(),
+            parameter_mode: StringBuilder::new(),
+            parameter_name: StringBuilder::new(),
+            data_type: StringBuilder::new(),
+            parameter_default: StringBuilder::new(),
+            is_variadic: BooleanBuilder::new(),
+            rid: UInt8Builder::new(),
+        }
+    }
+}
+
+impl PartitionStream for InformationSchemaParameters {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            futures::stream::once(async move {
+                InformationSchemaConfig::make_parameters(
+                    ctx.scalar_functions(),
+                    ctx.aggregate_functions(),
+                    ctx.window_functions(),
+                    ctx.session_config().options(),
+                    &mut builder,
+                )?;
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}
+
+pub struct InformationSchemaParametersBuilder {
+    schema: SchemaRef,
+    specific_catalog: StringBuilder,
+    specific_schema: StringBuilder,
+    specific_name: StringBuilder,
+    ordinal_position: UInt64Builder,
+    parameter_mode: StringBuilder,
+    parameter_name: StringBuilder,
+    data_type: StringBuilder,
+    parameter_default: StringBuilder,
+    is_variadic: BooleanBuilder,
+    rid: UInt8Builder,
+}
+
+impl InformationSchemaParametersBuilder {
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_parameter(
+        &mut self,
+        specific_catalog: impl AsRef<str>,
+        specific_schema: impl AsRef<str>,
+        specific_name: impl AsRef<str>,
+        ordinal_position: u64,
+        parameter_mode: impl AsRef<str>,
+        parameter_name: Option<String>,
+        data_type: impl AsRef<str>,
+        parameter_default: Option<String>,
+        is_variadic: bool,
+        rid: u8,
+    ) {
+        self.specific_catalog
+            .append_value(specific_catalog.as_ref());
+        self.specific_schema.append_value(specific_schema.as_ref());
+        self.specific_name.append_value(specific_name.as_ref());
+        self.ordinal_position.append_value(ordinal_position);
+        self.parameter_mode.append_value(parameter_mode.as_ref());
+        self.parameter_name.append_option(parameter_name);
+        self.data_type.append_value(data_type.as_ref());
+        self.parameter_default.append_option(parameter_default);
+        self.is_variadic.append_value(is_variadic);
+        self.rid.append_value(rid);
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.specific_catalog.finish()),
+                Arc::new(self.specific_schema.finish()),
+                Arc::new(self.specific_name.finish()),
+                Arc::new(self.ordinal_position.finish()),
+                Arc::new(self.parameter_mode.finish()),
+                Arc::new(self.parameter_name.finish()),
+                Arc::new(self.data_type.finish()),
+                Arc::new(self.parameter_default.finish()),
+                Arc::new(self.is_variadic.finish()),
+                Arc::new(self.rid.finish()),
+            ],
+        )
+    }
+}
+
+pub fn get_udf_args_and_return_types(udf: &Arc<ScalarUDF>) -> Vec<(Vec<String>, Option<String>)> {
+    get_args_and_return_types(udf.signature(), |arg_types| {
+        udf.return_type(arg_types).ok().map(|t| t.to_string())
+    })
+}
+
+pub fn get_udaf_args_and_return_types(
+    udaf: &Arc<AggregateUDF>,
+) -> Vec<(Vec<String>, Option<String>)> {
+    get_args_and_return_types(udaf.signature(), |arg_types| {
+        udaf.return_type(arg_types).ok().map(|t| t.to_string())
+    })
+}
+
+pub fn get_udwf_args_and_return_types(udwf: &Arc<WindowUDF>) -> Vec<(Vec<String>, Option<String>)> {
+    get_args_and_return_types(udwf.signature(), |_| None)
+}
+
+fn get_args_and_return_types<F>(
+    signature: &Signature,
+    get_return_type: F,
+) -> Vec<(Vec<String>, Option<String>)>
+where
+    F: Fn(&[DataType]) -> Option<String>,
+{
+    let arg_type_combinations = signature.type_signature.get_example_types();
+
+    if arg_type_combinations.is_empty() {
+        vec![(vec![], None)]
+    } else {
+        arg_type_combinations
+            .into_iter()
+            .map(|arg_types| {
+                let return_type = get_return_type(&arg_types);
+                let arg_types = arg_types
+                    .into_iter()
+                    .map(|t| t.to_string())
+                    .collect::<Vec<_>>();
+                (arg_types, return_type)
+            })
+            .collect()
+    }
+}

--- a/crates/runtime/src/execution/catalog/information_schema/routines.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/routines.rs
@@ -1,0 +1,149 @@
+use crate::execution::catalog::information_schema::config::InformationSchemaConfig;
+use arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use arrow_array::builder::BooleanBuilder;
+use arrow_schema::ArrowError;
+use datafusion::execution::TaskContext;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct InformationSchemaRoutines {
+    schema: SchemaRef,
+}
+
+impl InformationSchemaRoutines {
+    pub fn new() -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("specific_catalog", DataType::Utf8, false),
+            Field::new("specific_schema", DataType::Utf8, false),
+            Field::new("specific_name", DataType::Utf8, false),
+            Field::new("routine_catalog", DataType::Utf8, false),
+            Field::new("routine_schema", DataType::Utf8, false),
+            Field::new("routine_name", DataType::Utf8, false),
+            Field::new("routine_type", DataType::Utf8, false),
+            Field::new("is_deterministic", DataType::Boolean, true),
+            Field::new("data_type", DataType::Utf8, true),
+            Field::new("function_type", DataType::Utf8, true),
+            Field::new("description", DataType::Utf8, true),
+            Field::new("syntax_example", DataType::Utf8, true),
+        ]));
+
+        Self { schema }
+    }
+
+    fn builder(&self) -> InformationSchemaRoutinesBuilder {
+        InformationSchemaRoutinesBuilder {
+            schema: Arc::clone(&self.schema),
+            specific_catalog: StringBuilder::new(),
+            specific_schema: StringBuilder::new(),
+            specific_name: StringBuilder::new(),
+            routine_catalog: StringBuilder::new(),
+            routine_schema: StringBuilder::new(),
+            routine_name: StringBuilder::new(),
+            routine_type: StringBuilder::new(),
+            is_deterministic: BooleanBuilder::new(),
+            data_type: StringBuilder::new(),
+            function_type: StringBuilder::new(),
+            description: StringBuilder::new(),
+            syntax_example: StringBuilder::new(),
+        }
+    }
+}
+
+impl PartitionStream for InformationSchemaRoutines {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            futures::stream::once(async move {
+                InformationSchemaConfig::make_routines(
+                    ctx.scalar_functions(),
+                    ctx.aggregate_functions(),
+                    ctx.window_functions(),
+                    ctx.session_config().options(),
+                    &mut builder,
+                );
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}
+
+pub struct InformationSchemaRoutinesBuilder {
+    schema: SchemaRef,
+    specific_catalog: StringBuilder,
+    specific_schema: StringBuilder,
+    specific_name: StringBuilder,
+    routine_catalog: StringBuilder,
+    routine_schema: StringBuilder,
+    routine_name: StringBuilder,
+    routine_type: StringBuilder,
+    is_deterministic: BooleanBuilder,
+    data_type: StringBuilder,
+    function_type: StringBuilder,
+    description: StringBuilder,
+    syntax_example: StringBuilder,
+}
+
+impl InformationSchemaRoutinesBuilder {
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_routine(
+        &mut self,
+        catalog_name: impl AsRef<str>,
+        schema_name: impl AsRef<str>,
+        routine_name: impl AsRef<str>,
+        routine_type: impl AsRef<str>,
+        is_deterministic: bool,
+        data_type: Option<String>,
+        function_type: impl AsRef<str>,
+        description: Option<String>,
+        syntax_example: Option<String>,
+    ) {
+        self.specific_catalog.append_value(catalog_name.as_ref());
+        self.specific_schema.append_value(schema_name.as_ref());
+        self.specific_name.append_value(routine_name.as_ref());
+        self.routine_catalog.append_value(catalog_name.as_ref());
+        self.routine_schema.append_value(schema_name.as_ref());
+        self.routine_name.append_value(routine_name.as_ref());
+        self.routine_type.append_value(routine_type.as_ref());
+        self.is_deterministic.append_value(is_deterministic);
+        self.data_type.append_option(data_type);
+        self.function_type.append_value(function_type.as_ref());
+        self.description.append_option(description);
+        self.syntax_example.append_option(syntax_example);
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.specific_catalog.finish()),
+                Arc::new(self.specific_schema.finish()),
+                Arc::new(self.specific_name.finish()),
+                Arc::new(self.routine_catalog.finish()),
+                Arc::new(self.routine_schema.finish()),
+                Arc::new(self.routine_name.finish()),
+                Arc::new(self.routine_type.finish()),
+                Arc::new(self.is_deterministic.finish()),
+                Arc::new(self.data_type.finish()),
+                Arc::new(self.function_type.finish()),
+                Arc::new(self.description.finish()),
+                Arc::new(self.syntax_example.finish()),
+            ],
+        )
+    }
+}

--- a/crates/runtime/src/execution/catalog/information_schema/schemata.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/schemata.rs
@@ -1,0 +1,119 @@
+//! [`InformationSchemata`] that implements the SQL [Information Schema Schemata] for Snowflake.
+//!
+//! [Information Schema Schemata]: https://docs.snowflake.com/en/sql-reference/info-schema/schemata
+
+use crate::execution::catalog::information_schema::config::InformationSchemaConfig;
+use arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use arrow_schema::ArrowError;
+use datafusion::execution::TaskContext;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct InformationSchemata {
+    schema: SchemaRef,
+    config: InformationSchemaConfig,
+}
+
+impl InformationSchemata {
+    pub fn new(config: InformationSchemaConfig) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("catalog_name", DataType::Utf8, false),
+            Field::new("schema_name", DataType::Utf8, false),
+            Field::new("schema_owner", DataType::Utf8, true),
+            Field::new("default_character_set_catalog", DataType::Utf8, true),
+            Field::new("default_character_set_schema", DataType::Utf8, true),
+            Field::new("default_character_set_name", DataType::Utf8, true),
+            Field::new("sql_path", DataType::Utf8, true),
+        ]));
+        Self { schema, config }
+    }
+
+    fn builder(&self) -> InformationSchemataBuilder {
+        InformationSchemataBuilder {
+            schema: Arc::clone(&self.schema),
+            catalog_name: StringBuilder::new(),
+            schema_name: StringBuilder::new(),
+            schema_owner: StringBuilder::new(),
+            default_character_set_catalog: StringBuilder::new(),
+            default_character_set_schema: StringBuilder::new(),
+            default_character_set_name: StringBuilder::new(),
+            sql_path: StringBuilder::new(),
+        }
+    }
+}
+
+pub struct InformationSchemataBuilder {
+    schema: SchemaRef,
+    catalog_name: StringBuilder,
+    schema_name: StringBuilder,
+    schema_owner: StringBuilder,
+    default_character_set_catalog: StringBuilder,
+    default_character_set_schema: StringBuilder,
+    default_character_set_name: StringBuilder,
+    sql_path: StringBuilder,
+}
+
+impl InformationSchemataBuilder {
+    pub(crate) fn add_schemata(
+        &mut self,
+        catalog_name: &str,
+        schema_name: &str,
+        schema_owner: Option<&str>,
+    ) {
+        self.catalog_name.append_value(catalog_name);
+        self.schema_name.append_value(schema_name);
+        match schema_owner {
+            Some(owner) => self.schema_owner.append_value(owner),
+            None => self.schema_owner.append_null(),
+        }
+        self.default_character_set_catalog.append_null();
+        self.default_character_set_schema.append_null();
+        self.default_character_set_name.append_null();
+        self.sql_path.append_null();
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.catalog_name.finish()),
+                Arc::new(self.schema_name.finish()),
+                Arc::new(self.schema_owner.finish()),
+                Arc::new(self.default_character_set_catalog.finish()),
+                Arc::new(self.default_character_set_schema.finish()),
+                Arc::new(self.default_character_set_name.finish()),
+                Arc::new(self.sql_path.finish()),
+            ],
+        )
+    }
+}
+
+impl PartitionStream for InformationSchemata {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        let config = self.config.clone();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            // TODO: Stream this
+            futures::stream::once(async move {
+                config.make_schemata(&mut builder);
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}

--- a/crates/runtime/src/execution/catalog/information_schema/tables.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/tables.rs
@@ -1,0 +1,109 @@
+//! [`InformationSchemaTables`] that implements the SQL [Information Schema Tables] for Snowflake.
+//!
+//! [Information Schema Tables]: https://docs.snowflake.com/en/sql-reference/info-schema/tables
+
+use crate::execution::catalog::information_schema::config::InformationSchemaConfig;
+use arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use arrow_schema::ArrowError;
+use datafusion::execution::TaskContext;
+use datafusion_common::DataFusionError;
+use datafusion_expr::TableType;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct InformationSchemaTables {
+    schema: SchemaRef,
+    config: InformationSchemaConfig,
+}
+
+impl InformationSchemaTables {
+    pub(crate) fn new(config: InformationSchemaConfig) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("table_catalog", DataType::Utf8, false),
+            Field::new("table_schema", DataType::Utf8, false),
+            Field::new("table_name", DataType::Utf8, false),
+            Field::new("table_type", DataType::Utf8, false),
+        ]));
+
+        Self { schema, config }
+    }
+
+    fn builder(&self) -> InformationSchemaTablesBuilder {
+        InformationSchemaTablesBuilder {
+            catalog_names: StringBuilder::new(),
+            schema_names: StringBuilder::new(),
+            table_names: StringBuilder::new(),
+            table_types: StringBuilder::new(),
+            schema: Arc::clone(&self.schema),
+        }
+    }
+}
+
+impl PartitionStream for InformationSchemaTables {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        let config = self.config.clone();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            // TODO: Stream this
+            futures::stream::once(async move {
+                config.make_tables(&mut builder).await?;
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}
+
+pub struct InformationSchemaTablesBuilder {
+    schema: SchemaRef,
+    catalog_names: StringBuilder,
+    schema_names: StringBuilder,
+    table_names: StringBuilder,
+    table_types: StringBuilder,
+}
+
+impl InformationSchemaTablesBuilder {
+    pub fn add_table(
+        &mut self,
+        catalog_name: impl AsRef<str>,
+        schema_name: impl AsRef<str>,
+        table_name: impl AsRef<str>,
+        table_type: TableType,
+    ) {
+        // Note: append_value is actually infallible.
+        self.catalog_names.append_value(catalog_name.as_ref());
+        self.schema_names.append_value(schema_name.as_ref());
+        self.table_names.append_value(table_name.as_ref());
+        self.table_types.append_value(match table_type {
+            TableType::Base => "BASE TABLE",
+            TableType::View => "VIEW",
+            TableType::Temporary => "TEMPORARY TABLE",
+        });
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.catalog_names.finish()),
+                Arc::new(self.schema_names.finish()),
+                Arc::new(self.table_names.finish()),
+                Arc::new(self.table_types.finish()),
+            ],
+        )
+    }
+}

--- a/crates/runtime/src/execution/catalog/information_schema/views.rs
+++ b/crates/runtime/src/execution/catalog/information_schema/views.rs
@@ -1,0 +1,104 @@
+//! [`InformationSchemaViews`] that implements the SQL [Information Schema Views] for Snowflake.
+//!
+//! [Information Schema Views]: https://docs.snowflake.com/en/sql-reference/info-schema/views
+
+use crate::execution::catalog::information_schema::config::InformationSchemaConfig;
+use arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use arrow_schema::ArrowError;
+use datafusion::execution::TaskContext;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct InformationSchemaViews {
+    schema: SchemaRef,
+    config: InformationSchemaConfig,
+}
+
+impl InformationSchemaViews {
+    pub fn new(config: InformationSchemaConfig) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("table_catalog", DataType::Utf8, false),
+            Field::new("table_schema", DataType::Utf8, false),
+            Field::new("table_name", DataType::Utf8, false),
+            Field::new("definition", DataType::Utf8, true),
+        ]));
+
+        Self { schema, config }
+    }
+
+    fn builder(&self) -> InformationSchemaViewBuilder {
+        InformationSchemaViewBuilder {
+            catalog_names: StringBuilder::new(),
+            schema_names: StringBuilder::new(),
+            table_names: StringBuilder::new(),
+            definitions: StringBuilder::new(),
+            schema: Arc::clone(&self.schema),
+        }
+    }
+}
+
+impl PartitionStream for InformationSchemaViews {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        let config = self.config.clone();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            // TODO: Stream this
+            futures::stream::once(async move {
+                config.make_views(&mut builder).await?;
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}
+
+pub struct InformationSchemaViewBuilder {
+    schema: SchemaRef,
+    catalog_names: StringBuilder,
+    schema_names: StringBuilder,
+    table_names: StringBuilder,
+    definitions: StringBuilder,
+}
+
+impl InformationSchemaViewBuilder {
+    pub(crate) fn add_view(
+        &mut self,
+        catalog_name: impl AsRef<str>,
+        schema_name: impl AsRef<str>,
+        table_name: impl AsRef<str>,
+        definition: Option<&str>,
+    ) {
+        // Note: append_value is actually infallible.
+        self.catalog_names.append_value(catalog_name.as_ref());
+        self.schema_names.append_value(schema_name.as_ref());
+        self.table_names.append_value(table_name.as_ref());
+        self.definitions.append_option(definition.as_ref());
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.catalog_names.finish()),
+                Arc::new(self.schema_names.finish()),
+                Arc::new(self.table_names.finish()),
+                Arc::new(self.definitions.finish()),
+            ],
+        )
+    }
+}

--- a/crates/runtime/src/execution/catalog/mod.rs
+++ b/crates/runtime/src/execution/catalog/mod.rs
@@ -4,3 +4,5 @@ pub mod catalog_list;
 pub mod catalogs;
 pub mod schema;
 pub mod table;
+
+pub mod information_schema;

--- a/crates/runtime/src/http/ui/navigation_trees/handlers.rs
+++ b/crates/runtime/src/http/ui/navigation_trees/handlers.rs
@@ -54,11 +54,11 @@ pub async fn get_navigation_trees(
     Query(params): Query<NavigationTreesParameters>,
     State(state): State<AppState>,
 ) -> NavigationTreesResult<Json<NavigationTreesResponse>> {
-    let (batches, _) = state
+    let (database_batches, _) = state
         .execution_svc
         .query(
             &session_id,
-            "SELECT table_catalog, table_schema, table_name FROM information_schema.tables",
+            "SELECT * FROM information_schema.databases",
             QueryContext::default(),
         )
         .await
@@ -66,22 +66,38 @@ pub async fn get_navigation_trees(
 
     let mut catalogs_tree: BTreeMap<String, BTreeMap<String, Vec<String>>> = BTreeMap::new();
 
-    for batch in batches {
-        let catalog_col = downcast_string_column(&batch, "table_catalog")?;
-        let schema_col = downcast_string_column(&batch, "table_schema")?;
-        let name_col = downcast_string_column(&batch, "table_name")?;
+    for db_batch in database_batches {
+        let catalog_col = downcast_string_column(&db_batch, "database_name")?;
 
-        for i in 0..batch.num_rows() {
-            let catalog = catalog_col.value(i).to_string();
-            let schema = schema_col.value(i).to_string();
-            let name = name_col.value(i).to_string();
+        for i in 0..db_batch.num_rows() {
+            let catalog = catalog_col.value(i);
 
-            catalogs_tree
-                .entry(catalog)
-                .or_default()
-                .entry(schema)
-                .or_default()
-                .push(name);
+            let query = format!(
+                "SELECT table_schema, table_name FROM {catalog}.information_schema.tables",
+            );
+
+            let (table_batches, _) = state
+                .execution_svc
+                .query(&session_id, &query, QueryContext::default())
+                .await
+                .map_err(|e| NavigationTreesAPIError::Execution { source: e })?;
+
+            for table_batch in table_batches {
+                let schema_col = downcast_string_column(&table_batch, "table_schema")?;
+                let name_col = downcast_string_column(&table_batch, "table_name")?;
+
+                for j in 0..table_batch.num_rows() {
+                    let schema = schema_col.value(j).to_string();
+                    let name = name_col.value(j).to_string();
+
+                    catalogs_tree
+                        .entry(catalog.to_string())
+                        .or_default()
+                        .entry(schema)
+                        .or_default()
+                        .push(name);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Added our own implementation for information schema since
- snowflake information schema [contains more ](https://docs.snowflake.com/en/sql-reference/info-schema)tables that we have in DF repo
- most of tables have different list of columns
- it will be much easier for us to extend/change information schema tables to support Snowflake
- added 3 additional system tables from DF implementation for registered functions, settings and params
- most of tables should work per catalog, full list can be found here https://docs.snowflake.com/en/sql-reference/info-schema
- **added i[nformation_schema.databases](https://docs.snowflake.com/en/sql-reference/info-schema/databases) to get list of databases (catalogs) to fetch navigation tree** 
![Screenshot 2025-05-07 at 19 33 01](https://github.com/user-attachments/assets/e1c2cd4f-a160-4906-9af8-36cea3a2188e)

Closes #701 