### PR TITLE
Add physical plan optimizer rules for empty datasources

### DIFF
--- a/crates/core-executor/src/datafusion/mod.rs
+++ b/crates/core-executor/src/datafusion/mod.rs
@@ -2,6 +2,7 @@
 //pub mod error;
 pub mod analyzer;
 pub mod error;
+pub mod physical_optimizer;
 pub mod planner;
 pub mod type_planner;
 pub mod visitors;

--- a/crates/core-executor/src/datafusion/physical_optimizer/eliminate_empty_datasource_exec.rs
+++ b/crates/core-executor/src/datafusion/physical_optimizer/eliminate_empty_datasource_exec.rs
@@ -1,0 +1,177 @@
+use datafusion::datasource::source::DataSourceExec;
+use datafusion::error::Result as DFResult;
+use datafusion::physical_expr::Partitioning;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion_common::config::ConfigOptions;
+use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion_physical_plan::ExecutionPlan;
+use datafusion_physical_plan::empty::EmptyExec;
+use std::sync::Arc;
+
+/// A physical optimizer rule that replaces empty `DataSourceExec`
+/// nodes with an `EmptyExec`.
+///
+/// This optimization detects `DataSourceExec` instances that are
+/// guaranteed to yield no data (i.e., they have no file groups and
+/// their output partitioning is `UnknownPartitioning(0)`). Rather than
+/// letting them propagate through the plan (e.g., into sorts or joins),
+/// this rule replaces them directly with an `EmptyExec`, which short-circuits
+/// further computation and avoids unnecessary execution.
+///
+/// This is especially useful in cases like:
+/// - Filtered queries resulting in zero-matching partitions
+/// - Static analysis detecting empty scans
+/// - Preventing creation of empty files in sinks like Iceberg
+///
+/// # Example
+///
+/// Before:
+/// ```text
+/// SortExec
+///   DataSourceExec (file_groups = [], partitioning = UnknownPartitioning(0))
+/// ```
+///
+/// After:
+/// ```text
+/// SortExec
+///   EmptyExec
+/// ```
+///
+/// This rule is safe and conservative — it only applies when the
+/// input is provably empty.
+#[derive(Default, Debug)]
+pub struct EliminateEmptyDataSourceExec {}
+
+impl EliminateEmptyDataSourceExec {
+    pub const fn new() -> Self {
+        Self {}
+    }
+}
+
+impl PhysicalOptimizerRule for EliminateEmptyDataSourceExec {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        plan.transform_up(|plan| {
+            if let Some(source_exec) = plan.as_any().downcast_ref::<DataSourceExec>() {
+                if matches!(
+                    source_exec.properties().output_partitioning(),
+                    Partitioning::UnknownPartitioning(0)
+                ) {
+                    let schema = source_exec.schema();
+                    return Ok(Transformed::yes(Arc::new(EmptyExec::new(schema))));
+                }
+            }
+
+            Ok(Transformed::no(plan))
+        })
+        .data()
+    }
+
+    fn name(&self) -> &'static str {
+        "EliminateEmptyDataSourceExec"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::compute::SortOptions;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::listing::PartitionedFile;
+    use datafusion::datasource::object_store::ObjectStoreUrl;
+    use datafusion::datasource::physical_plan::{FileGroup, FileScanConfigBuilder, ParquetSource};
+    use datafusion::physical_expr::expressions::col;
+    use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
+    use datafusion_common::Result;
+    use datafusion_common::config::TableParquetOptions;
+    use datafusion_physical_plan::sorts::sort::SortExec;
+    use std::sync::Arc;
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]))
+    }
+
+    #[tokio::test]
+    async fn test_eliminate_empty_data_source_exec_transformation() -> Result<()> {
+        let object_store_url = ObjectStoreUrl::parse("s3://bucket")?;
+        let file_source = Arc::new(ParquetSource::new(TableParquetOptions::default()));
+        let file_scan_config = Arc::new(
+            FileScanConfigBuilder::new(object_store_url, schema(), file_source)
+                .with_file_groups(vec![])
+                .build(),
+        );
+        let data_source_exec = Arc::new(DataSourceExec::new(file_scan_config));
+
+        let rule = EliminateEmptyDataSourceExec::new();
+        let optimized = rule.optimize(data_source_exec, &ConfigOptions::default())?;
+        assert!(
+            optimized.as_any().downcast_ref::<EmptyExec>().is_some(),
+            "DataSourceExec with UnknownPartitioning(0) should be transformed to EmptyExec"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_no_transformation_for_non_empty_data_source_exec() -> Result<()> {
+        let object_store_url = ObjectStoreUrl::parse("s3://bucket")?;
+        let file_source = Arc::new(ParquetSource::new(TableParquetOptions::default()));
+        let file_scan_config = Arc::new(
+            FileScanConfigBuilder::new(object_store_url, schema(), file_source)
+                .with_file_groups(vec![FileGroup::new(vec![PartitionedFile::new("path", 1)])])
+                .build(),
+        );
+        let data_source_exec = Arc::new(DataSourceExec::new(file_scan_config));
+
+        let rule = EliminateEmptyDataSourceExec::new();
+        let optimized = rule.optimize(data_source_exec, &ConfigOptions::default())?;
+        // The rule should not transform the DataSourceExec since it's not empty
+        assert!(
+            optimized
+                .as_any()
+                .downcast_ref::<DataSourceExec>()
+                .is_some(),
+            "DataSourceExec with non-empty partitioning should not be transformed to EmptyExec"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_eliminate_sort_exec_above_empty_data_source_exec() -> Result<()> {
+        let object_store_url = ObjectStoreUrl::parse("s3://bucket")?;
+        let file_source = Arc::new(ParquetSource::new(TableParquetOptions::default()));
+        let file_scan_config = Arc::new(
+            FileScanConfigBuilder::new(object_store_url, schema(), file_source)
+                .with_file_groups(vec![])
+                .build(),
+        );
+        let data_source_exec = Arc::new(DataSourceExec::new(file_scan_config));
+
+        let sort_exprs = LexOrdering::from(vec![PhysicalSortExpr {
+            expr: col("id", &schema())?,
+            options: SortOptions::default(),
+        }]);
+        let sort_exec = Arc::new(SortExec::new(sort_exprs, data_source_exec));
+
+        let rule = EliminateEmptyDataSourceExec::new();
+        let optimized = rule.optimize(sort_exec, &ConfigOptions::default())?;
+        let sort = optimized
+            .as_any()
+            .downcast_ref::<SortExec>()
+            .expect("Expected SortExec");
+
+        let inner = sort.input();
+        assert!(
+            inner.as_any().downcast_ref::<EmptyExec>().is_some(),
+            "Inner DataSourceExec should be replaced with EmptyExec"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/core-executor/src/datafusion/physical_optimizer/mod.rs
+++ b/crates/core-executor/src/datafusion/physical_optimizer/mod.rs
@@ -1,0 +1,22 @@
+mod eliminate_empty_datasource_exec;
+mod remove_exec_above_empty;
+
+use datafusion::physical_optimizer::optimizer::{PhysicalOptimizer, PhysicalOptimizerRule};
+use std::sync::Arc;
+
+use super::physical_optimizer::eliminate_empty_datasource_exec::EliminateEmptyDataSourceExec;
+use super::physical_optimizer::remove_exec_above_empty::RemoveExecAboveEmpty;
+
+/// Returns a list of physical optimizer rules including custom rules.
+#[must_use]
+pub fn physical_optimizer_rules() -> Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> {
+    let mut rules: Vec<Arc<dyn PhysicalOptimizerRule + Send + Sync>> = vec![
+        Arc::new(EliminateEmptyDataSourceExec::new()),
+        Arc::new(RemoveExecAboveEmpty::new()),
+    ];
+
+    // Append the default DataFusion optimizer rules
+    rules.extend(PhysicalOptimizer::default().rules);
+
+    rules
+}

--- a/crates/core-executor/src/datafusion/physical_optimizer/remove_exec_above_empty.rs
+++ b/crates/core-executor/src/datafusion/physical_optimizer/remove_exec_above_empty.rs
@@ -1,0 +1,222 @@
+use std::sync::Arc;
+
+use datafusion::error::Result as DFResult;
+use datafusion::physical_optimizer::optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::execution_plan::ExecutionPlan;
+use datafusion_common::config::ConfigOptions;
+use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
+
+/// A physical optimizer rule that removes any execution plan node
+/// whose all inputs are `EmptyExec`. Since an `EmptyExec` always
+/// returns no rows, operations like `SortExec`, `FilterExec`,
+/// `ProjectionExec`, `JoinExec` (with both sides empty), etc., can be
+/// safely replaced with a single `EmptyExec`.
+///
+/// This helps avoid unnecessary execution overhead and simplifies the final plan.
+///
+/// # Examples
+///
+/// Unary (e.g., SortExec):
+/// ```text
+/// SortExec
+///   └── EmptyExec
+/// => EmptyExec
+/// ```
+///
+/// Binary (e.g., JoinExec):
+/// ```text
+/// HashJoinExec
+///   ├── EmptyExec
+///   └── EmptyExec
+/// => EmptyExec
+/// ```
+#[derive(Default, Debug)]
+pub struct RemoveExecAboveEmpty;
+
+impl RemoveExecAboveEmpty {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl PhysicalOptimizerRule for RemoveExecAboveEmpty {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        plan.transform_up(|plan| {
+            // Skip EmptyExec itself
+            if plan.as_any().is::<EmptyExec>() {
+                return Ok(Transformed::no(plan));
+            }
+
+            let inputs = plan.as_ref().children();
+            if inputs.is_empty() {
+                return Ok(Transformed::no(plan));
+            }
+
+            // Replace the current node with EmptyExec if all inputs are EmptyExec
+            let all_empty = inputs.iter().all(|input| input.as_any().is::<EmptyExec>());
+
+            if all_empty {
+                return Ok(Transformed::yes(Arc::new(EmptyExec::new(plan.schema()))));
+            }
+
+            Ok(Transformed::no(plan))
+        })
+        .data()
+    }
+
+    fn name(&self) -> &'static str {
+        "RemoveExecAboveEmpty"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::datafusion::physical_optimizer::remove_exec_above_empty::RemoveExecAboveEmpty;
+    use datafusion::arrow::compute::SortOptions;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_expr::{LexOrdering, PhysicalExprRef, PhysicalSortExpr};
+    use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion::physical_plan::expressions::col;
+    use datafusion::physical_plan::filter::FilterExec;
+    use datafusion::physical_plan::projection::ProjectionExec;
+    use datafusion_common::config::ConfigOptions;
+    use datafusion_common::{JoinType, Result};
+    use datafusion_physical_plan::joins::{
+        HashJoinExec, JoinOn, NestedLoopJoinExec, PartitionMode,
+    };
+    use datafusion_physical_plan::limit::GlobalLimitExec;
+    use datafusion_physical_plan::sorts::sort::SortExec;
+    use std::sync::Arc;
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]))
+    }
+
+    fn empty_exec() -> Arc<dyn ExecutionPlan> {
+        Arc::new(EmptyExec::new(schema()))
+    }
+
+    #[tokio::test]
+    async fn test_remove_sort_above_empty() -> Result<()> {
+        let sort_exprs = LexOrdering::from(vec![PhysicalSortExpr {
+            expr: col("id", &schema())?,
+            options: SortOptions::default(),
+        }]);
+        let sort = Arc::new(SortExec::new(sort_exprs, empty_exec()));
+
+        let optimizer = RemoveExecAboveEmpty::new();
+        let optimized = optimizer.optimize(sort, &ConfigOptions::new())?;
+        assert!(
+            optimized.as_any().is::<EmptyExec>(),
+            "Plan was not optimized to EmptyExec"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_remove_filter_above_empty() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "id",
+            DataType::Boolean,
+            false,
+        )]));
+        let predicate = col("id", &schema)?;
+        let filter = Arc::new(FilterExec::try_new(
+            predicate,
+            Arc::new(EmptyExec::new(schema)),
+        )?);
+
+        let rule = RemoveExecAboveEmpty::new();
+        let optimized = rule.optimize(filter, &ConfigOptions::default())?;
+        assert!(
+            optimized.as_any().is::<EmptyExec>(),
+            "Plan was not optimized to EmptyExec"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_remove_projection_above_empty() -> Result<()> {
+        let proj_exprs = vec![(col("id", &schema())?, "id".to_string())];
+        let proj = Arc::new(ProjectionExec::try_new(proj_exprs, empty_exec())?);
+
+        let rule = RemoveExecAboveEmpty::new();
+        let optimized = rule.optimize(proj, &ConfigOptions::default())?;
+        assert!(
+            optimized.as_any().is::<EmptyExec>(),
+            "Plan was not optimized to EmptyExec"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_remove_exec_above_empty_limit_exec() -> Result<()> {
+        let global_limit_exec = Arc::new(GlobalLimitExec::new(empty_exec(), 10, None));
+
+        let rule = RemoveExecAboveEmpty::new();
+        let optimized = rule.optimize(global_limit_exec, &ConfigOptions::default())?;
+        assert!(
+            optimized.as_any().downcast_ref::<EmptyExec>().is_some(),
+            "LimitExec should be removed above EmptyExec"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[allow(clippy::as_conversions)]
+    async fn test_remove_exec_above_empty_hash_join_exec() -> Result<()> {
+        let on: JoinOn = vec![(
+            Arc::new(Column::new("id", 0)) as PhysicalExprRef,
+            Arc::new(Column::new("id", 0)) as PhysicalExprRef,
+        )];
+        let hash_join_exec = Arc::new(HashJoinExec::try_new(
+            empty_exec(),
+            empty_exec(),
+            on,
+            None,
+            &JoinType::Inner,
+            None,
+            PartitionMode::Partitioned,
+            true,
+        )?);
+
+        let rule = RemoveExecAboveEmpty::new();
+        let optimized = rule.optimize(hash_join_exec, &ConfigOptions::default())?;
+        assert!(
+            optimized.as_any().downcast_ref::<EmptyExec>().is_some(),
+            "HashJoinExec should be removed above EmptyExec"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_remove_exec_above_empty_nested_loop_join_exec() -> Result<()> {
+        let nested_loop_join_exec = Arc::new(NestedLoopJoinExec::try_new(
+            empty_exec(),
+            empty_exec(),
+            None,
+            &JoinType::Inner,
+            None,
+        )?);
+
+        let rule = RemoveExecAboveEmpty::new();
+        let optimized = rule.optimize(nested_loop_join_exec, &ConfigOptions::default())?;
+        assert!(
+            optimized.as_any().downcast_ref::<EmptyExec>().is_some(),
+            "NestedLoopJoinExec should be removed above EmptyExec"
+        );
+        Ok(())
+    }
+}

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -28,6 +28,7 @@ use df_builtins::register_udafs;
 use df_catalog::catalog_list::{DEFAULT_CATALOG, EmbucketCatalogList};
 // TODO: We need to fix this after geodatafusion is updated to datafusion 47
 //use geodatafusion::udf::native::register_native as register_geo_native;
+use crate::datafusion::physical_optimizer::physical_optimizer_rules;
 use iceberg_rust::object_store::ObjectStoreBuilder;
 use iceberg_s3tables_catalog::S3TablesCatalog;
 use snafu::ResultExt;
@@ -71,6 +72,7 @@ impl UserSession {
             .with_query_planner(Arc::new(IcebergQueryPlanner::new()))
             .with_type_planner(Arc::new(CustomTypePlanner {}))
             .with_analyzer_rule(Arc::new(IcebergTypesAnalyzer {}))
+            .with_physical_optimizer_rules(physical_optimizer_rules())
             .build();
         let mut ctx = SessionContext::new_with_state(state);
         register_udfs(&mut ctx).context(ex_error::RegisterUDFSnafu)?;

--- a/crates/df-catalog/src/catalog_list.rs
+++ b/crates/df-catalog/src/catalog_list.rs
@@ -185,7 +185,7 @@ impl EmbucketCatalogList {
                         catalog
                             .schemas_cache
                             .insert(schema.name.clone(), Arc::new(schema));
-                    };
+                    }
                 }
                 // Cleanup removed schemas from the cache
                 for schema in &catalog.schemas_cache {


### PR DESCRIPTION
This PR introduces two new PhysicalOptimizerRules:
	•	EliminateEmptyDataSourceExec: replaces DataSourceExec with EmptyExec when no files are present.
	•	RemoveExecAboveEmpty: removes unnecessary operators (e.g. SortExec, LimitExec, JoinExec) when all inputs are EmptyExec.

These rules help avoid unnecessary execution of empty inputs and improve physical plan efficiency.

Related to https://github.com/Embucket/embucket/issues/732, https://github.com/apache/datafusion/issues/16001
