### PR TITLE
removed wrong jwt check

### DIFF
--- a/crates/api-ui/src/auth/handlers.rs
+++ b/crates/api-ui/src/auth/handlers.rs
@@ -186,8 +186,6 @@ pub async fn login(
     let audience = state.config.host.clone();
     let jwt_secret = state.auth_config.jwt_secret();
 
-    ensure_jwt_secret_is_valid(jwt_secret)?;
-
     let access_token_claims = access_token_claims(&username, &audience);
 
     let access_token = create_jwt(&access_token_claims, jwt_secret).context(CreateJwtSnafu)?;


### PR DESCRIPTION
the initial value jwt secret is empty.
and this check is wrong, as the jwt token is created after verification is done and we decide what dat to store in jwt
.