### PR TITLE
Set correct http code for existing schemas and tables

### DIFF
--- a/crates/api-snowflake-rest/src/error.rs
+++ b/crates/api-snowflake-rest/src/error.rs
@@ -123,12 +123,12 @@ fn convert_into_response(error: &ExecutionError) -> axum::response::Response {
         | ExecutionError::Utf8 { .. }
         | ExecutionError::VolumeNotFound { .. }
         | ExecutionError::ObjectStore { .. }
-        | ExecutionError::ObjectAlreadyExists { .. }
         | ExecutionError::UnsupportedFileFormat { .. }
         | ExecutionError::RefreshCatalogList { .. }
         | ExecutionError::UrlParse { .. }
         | ExecutionError::JobError { .. }
         | ExecutionError::UploadFailed { .. } => http::StatusCode::BAD_REQUEST,
+        ExecutionError::ObjectAlreadyExists { .. } => http::StatusCode::CONFLICT,
         ExecutionError::Arrow { .. }
         | ExecutionError::S3Tables { .. }
         | ExecutionError::Iceberg { .. }


### PR DESCRIPTION
Snowplow DBT should stop in case the table/schema already exists without additional flags (`if exists`, `or replace`)
This is possible in case **409** or **422** code was returned.