### PR TITLE
Reduce preprocess_query logic

### DIFF
--- a/crates/core-executor/src/datafusion/visitors/copy_into_identifiers.rs
+++ b/crates/core-executor/src/datafusion/visitors/copy_into_identifiers.rs
@@ -1,0 +1,48 @@
+use datafusion_expr::sqlparser::ast::VisitMut;
+use datafusion_expr::sqlparser::ast::{Statement, VisitorMut};
+use sqlparser::ast::{ObjectName, ObjectNamePart};
+use std::ops::ControlFlow;
+
+/// Visitor that processes `COPY INTO` statements in Snowflake SQL AST.
+///
+/// It normalizes table identifiers by removing unsupported prefix characters such as:
+/// `@`, `~`, `/` (or any combination of them), which are commonly found in stage references:
+///
+/// Internal stages:
+/// - `@~/<path>`
+/// - `@<namespace>.%<table_name>/<path>`
+/// - `@%<table_name>`
+///
+/// External stages:
+/// - `@<namespace>.<ext_stage_name>/<path>`
+///
+/// Since those prefixes are not valid table names in many downstream systems,
+/// this visitor ensures that `into` and `from_obj` identifiers are cleaned accordingly.
+#[derive(Debug, Default)]
+pub struct CopyIntoStatementIdentifiers {}
+
+impl VisitorMut for CopyIntoStatementIdentifiers {
+    type Break = ();
+
+    fn pre_visit_statement(&mut self, statement: &mut Statement) -> ControlFlow<Self::Break> {
+        if let Statement::CopyIntoSnowflake { into, from_obj, .. } = statement {
+            fn sanitize_identifier(obj_name: &mut ObjectName) {
+                if let Some(ObjectNamePart::Identifier(ident)) = obj_name.0.first_mut() {
+                    // Remove any leading @, ~, or / characters
+                    let sanitized = ident.value.trim_start_matches(['@', '~', '/']).to_string();
+                    ident.value = sanitized;
+                }
+            }
+            sanitize_identifier(into);
+            if let Some(from_obj) = from_obj {
+                sanitize_identifier(from_obj);
+            }
+        }
+
+        ControlFlow::Continue(())
+    }
+}
+
+pub fn visit(stmt: &mut Statement) {
+    stmt.visit(&mut CopyIntoStatementIdentifiers {});
+}

--- a/crates/core-executor/src/datafusion/visitors/mod.rs
+++ b/crates/core-executor/src/datafusion/visitors/mod.rs
@@ -1,4 +1,5 @@
 //pub mod analyzer;
 //pub mod error;
+pub mod copy_into_identifiers;
 pub mod functions_rewriter;
 pub mod json_element;

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -52,7 +52,7 @@ use super::datafusion::planner::ExtendedSqlToRel;
 use super::error::{self as ex_error, ExecutionError, ExecutionResult, RefreshCatalogListSnafu};
 use super::session::UserSession;
 use super::utils::{NormalizedIdent, is_logical_plan_effectively_empty};
-use crate::datafusion::visitors::{functions_rewriter, json_element};
+use crate::datafusion::visitors::{copy_into_identifiers, functions_rewriter, json_element};
 use df_catalog::catalog::CachingCatalog;
 use tracing_attributes::instrument;
 
@@ -159,6 +159,7 @@ impl UserQuery {
         if let DFStatement::Statement(value) = statement {
             json_element::visit(value);
             functions_rewriter::visit(value);
+            copy_into_identifiers::visit(value);
         }
     }
 
@@ -302,16 +303,9 @@ impl UserQuery {
     pub fn preprocess_query(query: &str) -> String {
         // TODO: This regex should be a static allocation
         let alter_iceberg_table = regex::Regex::new(r"alter\s+iceberg\s+table").unwrap();
-        let mut query = alter_iceberg_table
+        alter_iceberg_table
             .replace_all(query, "alter table")
-            .to_string();
-        // TODO remove this check after release of https://github.com/Embucket/datafusion-sqlparser-rs/pull/8
-        if query.to_lowercase().contains("alter session") {
-            query = query.replace(';', "");
-        }
-        query
-            .replace("skip_header=1", "skip_header=TRUE")
-            .replace("FROM @~/", "FROM ")
+            .to_string()
     }
 
     pub fn get_catalog(&self, name: &str) -> ExecutionResult<Arc<dyn CatalogProvider>> {
@@ -701,7 +695,7 @@ impl UserQuery {
 
         let skip_header = file_format.options.iter().any(|option| {
             option.option_name.eq_ignore_ascii_case("skip_header")
-                && option.value.eq_ignore_ascii_case("true")
+                && option.value.eq_ignore_ascii_case("1")
         });
 
         let field_optionally_enclosed_by = file_format
@@ -789,7 +783,6 @@ impl UserQuery {
                 ),
             });
         };
-
         if let Some(from_obj) = from_obj {
             let from_stage: Vec<ObjectNamePart> = from_obj
                 .0


### PR DESCRIPTION
- removed alter session semicolon
- removed `@~/ ` from table/stage identifier in COPY into statement (moved to visitors)
- removed stage file type params replacement

The last part to fix is `ALTER ICEBERG TABLE` because sql parser cannot create AST for it.

related to #751 