### PR TITLE
Add background task to auto-refresh internal catalogs

### DIFF
--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -89,7 +89,7 @@ impl UserSession {
             .refresh()
             .await
             .context(RefreshCatalogListSnafu)?;
-
+        catalog_list_impl.start_refresh_internal_catalogs_task();
         let enable_ident_normalization = ctx.enable_ident_normalization();
         let session = Self {
             metastore,

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -89,7 +89,7 @@ impl UserSession {
             .refresh()
             .await
             .context(RefreshCatalogListSnafu)?;
-        catalog_list_impl.start_refresh_internal_catalogs_task();
+        catalog_list_impl.start_refresh_internal_catalogs_task(10);
         let enable_ident_normalization = ctx.enable_ident_normalization();
         let session = Self {
             metastore,

--- a/crates/df-catalog/Cargo.toml
+++ b/crates/df-catalog/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = { version = "1.20.2" }
 snafu = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/df-catalog/src/catalog_list.rs
+++ b/crates/df-catalog/src/catalog_list.rs
@@ -23,6 +23,8 @@ use object_store::local::LocalFileSystem;
 use snafu::ResultExt;
 use std::any::Any;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::interval;
 use url::Url;
 
 pub const DEFAULT_CATALOG: &str = "embucket";
@@ -196,6 +198,44 @@ impl EmbucketCatalogList {
             }
         }
         Ok(())
+    }
+
+    /// Spawns a background task that periodically refreshes the list of internal catalogs
+    /// by querying the metastore for newly created databases.
+    ///
+    /// # Description
+    /// When a user creates a new database, it is not automatically available as a catalog
+    /// in the current session. This method solves that limitation by launching an asynchronous
+    /// background job that runs every 10 seconds.
+    /// - Fetches the list of databases via `internal_catalogs()`.
+    /// - Adds any new catalogs not already present in `self.catalogs`.
+    ///
+    /// If any error occurs during fetching or processing, the error is logged via `tracing::warn`
+    /// but does not interrupt the loop.
+    ///
+    /// This ensures that newly created databases are gradually recognized and integrated
+    /// into the query engine without requiring a full session restart.
+    pub fn start_refresh_internal_catalogs_task(self: Arc<Self>) {
+        tokio::spawn(async move {
+            let mut interval = interval(Duration::from_secs(10));
+            loop {
+                interval.tick().await;
+                match self.internal_catalogs().await {
+                    Ok(catalogs) => {
+                        for catalog in catalogs {
+                            if self.catalogs.contains_key(&catalog.name) {
+                                continue;
+                            }
+                            self.catalogs
+                                .insert(catalog.name.clone(), Arc::new(catalog));
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to refresh internal catalogs: {:?}", e);
+                    }
+                }
+            }
+        });
     }
 }
 

--- a/crates/df-catalog/src/catalog_list.rs
+++ b/crates/df-catalog/src/catalog_list.rs
@@ -215,9 +215,9 @@ impl EmbucketCatalogList {
     ///
     /// This ensures that newly created databases are gradually recognized and integrated
     /// into the query engine without requiring a full session restart.
-    pub fn start_refresh_internal_catalogs_task(self: Arc<Self>) {
+    pub fn start_refresh_internal_catalogs_task(self: Arc<Self>, interval_secs: u64) {
         tokio::spawn(async move {
-            let mut interval = interval(Duration::from_secs(10));
+            let mut interval = interval(Duration::from_secs(interval_secs));
             loop {
                 interval.tick().await;
                 match self.internal_catalogs().await {


### PR DESCRIPTION
📌 **Summary**
This pull request introduces a background task that periodically checks the metastore for newly created databases and dynamically adds them as internal catalogs to the current session. This ensures that users who create new databases don’t need to start new session.

✨ **Motivation**
Previously, new databases created via the metastore would not appear in the catalog list until the process was restarted or manually reloaded. This limited usability in multi-tenant or dynamic environments where databases are frequently created on-the-fly.
To address this, we introduce a periodic refresh mechanism that automatically integrates new internal catalogs into the session.

The code:
-  Spawns a background tokio task.
-  Every 10 seconds:
   - Calls internal_catalogs() to get the current list of databases.
   - Inserts any new catalogs into self.catalogs if not already present.
   - Logs any errors that occur during refresh.
   - Ensures thread safety using DashMap for concurrent catalog access.
Closes #796 and #783