### PR TITLE
Schemas DF View Store (SlateDb)

### DIFF
--- a/crates/core-metastore/src/metastore.rs
+++ b/crates/core-metastore/src/metastore.rs
@@ -380,6 +380,7 @@ impl Metastore for SlateDBMetastore {
     }
 
     fn iter_schemas(&self, database: &DatabaseIdent) -> VecScanIterator<RwObject<Schema>> {
+        //If database is empty, we are iterating over all schemas
         let key = if database.is_empty() {
             KEY_SCHEMA.to_string()
         } else {

--- a/crates/core-metastore/src/metastore.rs
+++ b/crates/core-metastore/src/metastore.rs
@@ -380,7 +380,11 @@ impl Metastore for SlateDBMetastore {
     }
 
     fn iter_schemas(&self, database: &DatabaseIdent) -> VecScanIterator<RwObject<Schema>> {
-        let key = format!("{KEY_SCHEMA}/{database}");
+        let key = if database.len() != 0 {
+            format!("{KEY_SCHEMA}/{database}")
+        } else {
+            format!("{KEY_SCHEMA}")
+        };
         self.iter_objects(key)
     }
 

--- a/crates/core-metastore/src/metastore.rs
+++ b/crates/core-metastore/src/metastore.rs
@@ -380,10 +380,10 @@ impl Metastore for SlateDBMetastore {
     }
 
     fn iter_schemas(&self, database: &DatabaseIdent) -> VecScanIterator<RwObject<Schema>> {
-        let key = if database.len() != 0 {
-            format!("{KEY_SCHEMA}/{database}")
+        let key = if database.is_empty() {
+            KEY_SCHEMA.to_string()
         } else {
-            format!("{KEY_SCHEMA}")
+            format!("{KEY_SCHEMA}/{database}")
         };
         self.iter_objects(key)
     }

--- a/crates/df-catalog/src/catalogs/slatedb/config.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/config.rs
@@ -56,8 +56,8 @@ impl SlateDBViewConfig {
             .map_err(|e| DataFusionError::Execution(format!("failed to get schemas: {e}")))?;
         for schema in schemas {
             builder.add_schema(
-                schema.ident.schema.as_str(),
-                schema.ident.database.as_str(),
+                &schema.ident.schema,
+                &schema.ident.database,
                 schema.created_at.to_string(),
                 schema.updated_at.to_string(),
             );

--- a/crates/df-catalog/src/catalogs/slatedb/config.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/config.rs
@@ -50,12 +50,12 @@ impl SlateDBViewConfig {
     ) -> datafusion_common::Result<(), DataFusionError> {
         let schemas = self
             .metastore
-            .iter_schemas()
+            .iter_schemas(&"".to_string())
             .collect()
             .await
-            .map_err(|e| DataFusionError::Execution(format!("failed to get databases: {e}")))?;
+            .map_err(|e| DataFusionError::Execution(format!("failed to get schemas: {e}")))?;
         for schema in schemas {
-            builder.add_schema(schema.ident.schema, &database.volume);
+            builder.add_schema(schema.ident.schema.as_str(), schema.ident.database.as_str(), schema.created_at.to_string(), schema.updated_at.to_string());
         }
         Ok(())
     }

--- a/crates/df-catalog/src/catalogs/slatedb/config.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/config.rs
@@ -4,6 +4,7 @@ use core_metastore::Metastore;
 use core_utils::scan_iterator::ScanIterator;
 use datafusion_common::DataFusionError;
 use std::sync::Arc;
+use crate::catalogs::slatedb::schemas::SchemasViewBuilder;
 
 #[derive(Clone, Debug)]
 pub struct SlateDBViewConfig {
@@ -40,6 +41,21 @@ impl SlateDBViewConfig {
             .map_err(|e| DataFusionError::Execution(format!("failed to get databases: {e}")))?;
         for database in databases {
             builder.add_database(database.ident.as_str(), &database.volume);
+        }
+        Ok(())
+    }
+    pub async fn make_schemas(
+        &self,
+        builder: &mut SchemasViewBuilder,
+    ) -> datafusion_common::Result<(), DataFusionError> {
+        let schemas = self
+            .metastore
+            .iter_schemas()
+            .collect()
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("failed to get databases: {e}")))?;
+        for schema in schemas {
+            builder.add_schema(schema.ident.schema, &database.volume);
         }
         Ok(())
     }

--- a/crates/df-catalog/src/catalogs/slatedb/config.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/config.rs
@@ -1,10 +1,10 @@
 use crate::catalogs::slatedb::databases::DatabasesViewBuilder;
+use crate::catalogs::slatedb::schemas::SchemasViewBuilder;
 use crate::catalogs::slatedb::volumes::VolumesViewBuilder;
 use core_metastore::Metastore;
 use core_utils::scan_iterator::ScanIterator;
 use datafusion_common::DataFusionError;
 use std::sync::Arc;
-use crate::catalogs::slatedb::schemas::SchemasViewBuilder;
 
 #[derive(Clone, Debug)]
 pub struct SlateDBViewConfig {
@@ -50,12 +50,17 @@ impl SlateDBViewConfig {
     ) -> datafusion_common::Result<(), DataFusionError> {
         let schemas = self
             .metastore
-            .iter_schemas(&"".to_string())
+            .iter_schemas(&String::new())
             .collect()
             .await
             .map_err(|e| DataFusionError::Execution(format!("failed to get schemas: {e}")))?;
         for schema in schemas {
-            builder.add_schema(schema.ident.schema.as_str(), schema.ident.database.as_str(), schema.created_at.to_string(), schema.updated_at.to_string());
+            builder.add_schema(
+                schema.ident.schema.as_str(),
+                schema.ident.database.as_str(),
+                schema.created_at.to_string(),
+                schema.updated_at.to_string(),
+            );
         }
         Ok(())
     }

--- a/crates/df-catalog/src/catalogs/slatedb/mod.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/mod.rs
@@ -1,5 +1,5 @@
 pub mod config;
 pub mod databases;
 pub mod schema;
-pub mod volumes;
 pub mod schemas;
+pub mod volumes;

--- a/crates/df-catalog/src/catalogs/slatedb/mod.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/mod.rs
@@ -2,3 +2,4 @@ pub mod config;
 pub mod databases;
 pub mod schema;
 pub mod volumes;
+pub mod schemas;

--- a/crates/df-catalog/src/catalogs/slatedb/schema.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/schema.rs
@@ -1,5 +1,6 @@
 use crate::catalogs::slatedb::config::SlateDBViewConfig;
 use crate::catalogs::slatedb::databases::DatabasesView;
+use crate::catalogs::slatedb::schemas::SchemasView;
 use crate::catalogs::slatedb::volumes::VolumesView;
 use async_trait::async_trait;
 use core_metastore::Metastore;
@@ -9,7 +10,6 @@ use datafusion_common::DataFusionError;
 use datafusion_physical_plan::streaming::PartitionStream;
 use std::any::Any;
 use std::sync::Arc;
-use crate::catalogs::slatedb::schemas::SchemasView;
 
 pub const SLATEDB_SCHEMA: &str = "public";
 pub const SLATEDB_CATALOG: &str = "slatedb";

--- a/crates/df-catalog/src/catalogs/slatedb/schema.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/schema.rs
@@ -9,13 +9,15 @@ use datafusion_common::DataFusionError;
 use datafusion_physical_plan::streaming::PartitionStream;
 use std::any::Any;
 use std::sync::Arc;
+use crate::catalogs::slatedb::schemas::SchemasView;
 
 pub const SLATEDB_SCHEMA: &str = "public";
 pub const SLATEDB_CATALOG: &str = "slatedb";
 pub const DATABASES: &str = "databases";
 pub const VOLUMES: &str = "volumes";
+pub const SCHEMAS: &str = "schemas";
 
-pub const VIEW_TABLES: &[&str] = &[DATABASES, VOLUMES];
+pub const VIEW_TABLES: &[&str] = &[SCHEMAS, DATABASES, VOLUMES];
 
 pub struct SlateDBViewSchemaProvider {
     config: SlateDBViewConfig,
@@ -54,6 +56,7 @@ impl SchemaProvider for SlateDBViewSchemaProvider {
         let table: Arc<dyn PartitionStream> = match name.to_ascii_lowercase().as_str() {
             DATABASES => Arc::new(DatabasesView::new(config)),
             VOLUMES => Arc::new(VolumesView::new(config)),
+            SCHEMAS => Arc::new(SchemasView::new(config)),
             _ => return Ok(None),
         };
 

--- a/crates/df-catalog/src/catalogs/slatedb/schemas.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/schemas.rs
@@ -71,7 +71,13 @@ pub struct SchemasViewBuilder {
 }
 
 impl SchemasViewBuilder {
-    pub fn add_schema(&mut self, schema_name: impl AsRef<str>, database_name: impl AsRef<str>, created_at: impl AsRef<str>, updated_at: impl AsRef<str>) {
+    pub fn add_schema(
+        &mut self,
+        schema_name: impl AsRef<str>,
+        database_name: impl AsRef<str>,
+        created_at: impl AsRef<str>,
+        updated_at: impl AsRef<str>,
+    ) {
         // Note: append_value is actually infallible.
         self.schema_names.append_value(schema_name.as_ref());
         self.database_names.append_value(database_name.as_ref());
@@ -86,7 +92,7 @@ impl SchemasViewBuilder {
                 Arc::new(self.schema_names.finish()),
                 Arc::new(self.database_names.finish()),
                 Arc::new(self.created_at_timestamps.finish()),
-                Arc::new(self.updated_at_timestamps.finish()),           
+                Arc::new(self.updated_at_timestamps.finish()),
             ],
         )
     }

--- a/crates/df-catalog/src/catalogs/slatedb/schemas.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/schemas.rs
@@ -1,0 +1,82 @@
+use crate::catalogs::slatedb::config::SlateDBViewConfig;
+use datafusion::arrow::error::ArrowError;
+use datafusion::arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use datafusion::execution::TaskContext;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct SchemasView {
+    schema: SchemaRef,
+    config: SlateDBViewConfig,
+}
+
+impl SchemasView {
+    pub(crate) fn new(config: SlateDBViewConfig) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("schema_name", DataType::Utf8, false),
+        ]));
+
+        Self { schema, config }
+    }
+
+    fn builder(&self) -> SchemasViewBuilder {
+        SchemasViewBuilder {
+            schema_names: StringBuilder::new(),
+            created_at: StringBuilder::new(),
+            updated_at: StringBuilder::new(),
+            schema: Arc::clone(&self.schema),
+        }
+    }
+}
+
+impl PartitionStream for SchemasView {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        let config = self.config.clone();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            futures::stream::once(async move {
+                config.make_schemas(&mut builder).await?;
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}
+
+pub struct SchemasViewBuilder {
+    schema: SchemaRef,
+    schema_names: StringBuilder,
+    created_at: StringBuilder,
+    updated_at: StringBuilder,
+}
+
+impl SchemasViewBuilder {
+    pub fn add_schema(&mut self, schema_name: impl AsRef<str>, ) {
+        // Note: append_value is actually infallible.
+        self.schema_names.append_value(schema_name.as_ref());
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.schema_names.finish()),
+            ],
+        )
+    }
+}


### PR DESCRIPTION
Closes #826

```
SELECT * FROM slatedb.public.schemas
SELECT * FROM slatedb.public.schemas WHERE database_name = 'mydb1'
...
```

- Next will be starting to use this in `/ui/../schemas` GET
- The change in metastore allows us to get all the schemas (otherwise we would get an empty result), the problem was the extra `/`