### PR TITLE
Tables DF View Store (SlateDb)

### DIFF
--- a/crates/core-metastore/src/metastore.rs
+++ b/crates/core-metastore/src/metastore.rs
@@ -439,7 +439,12 @@ impl Metastore for SlateDBMetastore {
     }
 
     fn iter_tables(&self, schema: &SchemaIdent) -> VecScanIterator<RwObject<Table>> {
-        let key = format!("{KEY_TABLE}/{}/{}", schema.database, schema.schema);
+        //If database and schema is empty, we are iterating over all tables
+        let key = if schema.schema.is_empty() && schema.database.is_empty() {
+            KEY_TABLE.to_string()
+        } else {
+            format!("{KEY_TABLE}/{}/{}", schema.database, schema.schema)
+        };
         self.iter_objects(key)
     }
 

--- a/crates/core-metastore/src/models/schema.rs
+++ b/crates/core-metastore/src/models/schema.rs
@@ -7,6 +7,7 @@ use super::DatabaseIdent;
 
 #[derive(Validate, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
 /// A schema identifier
+#[derive(Default)]
 pub struct SchemaIdent {
     #[validate(length(min = 1))]
     /// The name of the schema

--- a/crates/core-metastore/src/models/table.rs
+++ b/crates/core-metastore/src/models/table.rs
@@ -73,6 +73,16 @@ pub enum TableFormat {
     Iceberg,
 }
 
+impl Display for TableFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            Self::Parquet => "parquet".to_string(),
+            Self::Iceberg => "iceberg".to_string(),
+        };
+        write!(f, "{str}")
+    }
+}
+
 impl From<String> for TableFormat {
     fn from(value: String) -> Self {
         match value.to_lowercase().as_str() {

--- a/crates/df-catalog/src/catalogs/slatedb/config.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/config.rs
@@ -1,7 +1,8 @@
 use crate::catalogs::slatedb::databases::DatabasesViewBuilder;
 use crate::catalogs::slatedb::schemas::SchemasViewBuilder;
+use crate::catalogs::slatedb::tables::TablesViewBuilder;
 use crate::catalogs::slatedb::volumes::VolumesViewBuilder;
-use core_metastore::Metastore;
+use core_metastore::{Metastore, SchemaIdent};
 use core_utils::scan_iterator::ScanIterator;
 use datafusion_common::DataFusionError;
 use std::sync::Arc;
@@ -60,6 +61,30 @@ impl SlateDBViewConfig {
                 &schema.ident.database,
                 schema.created_at.to_string(),
                 schema.updated_at.to_string(),
+            );
+        }
+        Ok(())
+    }
+    pub async fn make_tables(
+        &self,
+        builder: &mut TablesViewBuilder,
+    ) -> datafusion_common::Result<(), DataFusionError> {
+        let tables = self
+            .metastore
+            .iter_tables(&SchemaIdent::default())
+            .collect()
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("failed to get tables: {e}")))?;
+        for table in tables {
+            builder.add_tables(
+                &table.ident.table,
+                &table.ident.schema,
+                &table.ident.database,
+                table.volume_ident.clone(),
+                table.is_temporary,
+                table.format.to_string(),
+                table.created_at.to_string(),
+                table.updated_at.to_string(),
             );
         }
         Ok(())

--- a/crates/df-catalog/src/catalogs/slatedb/mod.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/mod.rs
@@ -2,4 +2,5 @@ pub mod config;
 pub mod databases;
 pub mod schema;
 pub mod schemas;
+pub mod tables;
 pub mod volumes;

--- a/crates/df-catalog/src/catalogs/slatedb/schema.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/schema.rs
@@ -1,6 +1,7 @@
 use crate::catalogs::slatedb::config::SlateDBViewConfig;
 use crate::catalogs::slatedb::databases::DatabasesView;
 use crate::catalogs::slatedb::schemas::SchemasView;
+use crate::catalogs::slatedb::tables::TablesView;
 use crate::catalogs::slatedb::volumes::VolumesView;
 use async_trait::async_trait;
 use core_metastore::Metastore;
@@ -16,8 +17,9 @@ pub const SLATEDB_CATALOG: &str = "slatedb";
 pub const DATABASES: &str = "databases";
 pub const VOLUMES: &str = "volumes";
 pub const SCHEMAS: &str = "schemas";
+pub const TABLES: &str = "tables";
 
-pub const VIEW_TABLES: &[&str] = &[SCHEMAS, DATABASES, VOLUMES];
+pub const VIEW_TABLES: &[&str] = &[TABLES, SCHEMAS, DATABASES, VOLUMES];
 
 pub struct SlateDBViewSchemaProvider {
     config: SlateDBViewConfig,
@@ -57,6 +59,7 @@ impl SchemaProvider for SlateDBViewSchemaProvider {
             DATABASES => Arc::new(DatabasesView::new(config)),
             VOLUMES => Arc::new(VolumesView::new(config)),
             SCHEMAS => Arc::new(SchemasView::new(config)),
+            TABLES => Arc::new(TablesView::new(config)),
             _ => return Ok(None),
         };
 

--- a/crates/df-catalog/src/catalogs/slatedb/tables.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/tables.rs
@@ -1,0 +1,129 @@
+use crate::catalogs::slatedb::config::SlateDBViewConfig;
+use datafusion::arrow::error::ArrowError;
+use datafusion::arrow::{
+    array::BooleanBuilder,
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use datafusion::execution::TaskContext;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct TablesView {
+    schema: SchemaRef,
+    config: SlateDBViewConfig,
+}
+
+impl TablesView {
+    pub(crate) fn new(config: SlateDBViewConfig) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("table_name", DataType::Utf8, false),
+            Field::new("schema_name", DataType::Utf8, false),
+            Field::new("database_name", DataType::Utf8, false),
+            Field::new("volume_name", DataType::Utf8, true),
+            Field::new("is_temporary", DataType::Boolean, false),
+            Field::new("table_format", DataType::Utf8, false),
+            Field::new("created_at", DataType::Utf8, false),
+            Field::new("updated_at", DataType::Utf8, false),
+        ]));
+
+        Self { schema, config }
+    }
+
+    fn builder(&self) -> TablesViewBuilder {
+        TablesViewBuilder {
+            table_names: StringBuilder::new(),
+            schema_names: StringBuilder::new(),
+            database_names: StringBuilder::new(),
+            volume_names: StringBuilder::new(),
+            is_temporary_values: BooleanBuilder::new(),
+            table_format_values: StringBuilder::new(),
+            created_at_timestamps: StringBuilder::new(),
+            updated_at_timestamps: StringBuilder::new(),
+            schema: Arc::clone(&self.schema),
+        }
+    }
+}
+
+impl PartitionStream for TablesView {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        let config = self.config.clone();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            futures::stream::once(async move {
+                config.make_tables(&mut builder).await?;
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}
+
+pub struct TablesViewBuilder {
+    schema: SchemaRef,
+    table_names: StringBuilder,
+    schema_names: StringBuilder,
+    database_names: StringBuilder,
+    volume_names: StringBuilder,
+    is_temporary_values: BooleanBuilder,
+    table_format_values: StringBuilder,
+    created_at_timestamps: StringBuilder,
+    updated_at_timestamps: StringBuilder,
+}
+
+impl TablesViewBuilder {
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_tables(
+        &mut self,
+        table_name: impl AsRef<str>,
+        schema_name: impl AsRef<str>,
+        database_name: impl AsRef<str>,
+        volume_name: Option<impl AsRef<str>>,
+        is_temporary: bool,
+        table_format: impl AsRef<str>,
+        created_at: impl AsRef<str>,
+        updated_at: impl AsRef<str>,
+    ) {
+        // Note: append_value is actually infallible.
+        self.table_names.append_value(table_name.as_ref());
+        self.schema_names.append_value(schema_name.as_ref());
+        self.database_names.append_value(database_name.as_ref());
+        if let Some(volume_name) = volume_name {
+            self.volume_names.append_value(volume_name.as_ref());
+        } else {
+            self.volume_names.append_null();
+        }
+        self.is_temporary_values.append_value(is_temporary);
+        self.table_format_values.append_value(table_format.as_ref());
+        self.created_at_timestamps.append_value(created_at.as_ref());
+        self.updated_at_timestamps.append_value(updated_at.as_ref());
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.table_names.finish()),
+                Arc::new(self.schema_names.finish()),
+                Arc::new(self.database_names.finish()),
+                Arc::new(self.volume_names.finish()),
+                Arc::new(self.is_temporary_values.finish()),
+                Arc::new(self.table_format_values.finish()),
+                Arc::new(self.created_at_timestamps.finish()),
+                Arc::new(self.updated_at_timestamps.finish()),
+            ],
+        )
+    }
+}


### PR DESCRIPTION
Closes #827

```
SELECT * FROM slatedb.public.tables
SELECT * FROM slatedb.public.tables WHERE schema_name = 'myschema1'
...
```

- Next will be starting to use this in `/ui/../tables` GET
- The change in metastore allows us to get all the tables (otherwise we would get an empty result), the problem was the two extra `/`