### PR TITLE
Implement TRUNCATE TABLE

### DIFF
--- a/crates/core-executor/src/datafusion/planner.rs
+++ b/crates/core-executor/src/datafusion/planner.rs
@@ -100,8 +100,6 @@ where
                 let column_defaults = self
                     .inner
                     .build_column_defaults(&columns, planner_context)?;
-                // println!("column_defaults: {:?}", column_defaults);
-                // println!("statement 11: {:?}", statement);
                 let has_columns = !columns.is_empty();
                 let schema = self.build_schema(columns.clone())?.to_dfschema_ref()?;
                 if has_columns {

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -41,7 +41,7 @@ use sqlparser::ast::helpers::attached_token::AttachedToken;
 use sqlparser::ast::{
     BinaryOperator, GroupByExpr, MergeAction, MergeClauseKind, MergeInsertKind, ObjectNamePart,
     ObjectType, PivotValueSource, Select, SelectItem, ShowObjects, ShowStatementFilter,
-    ShowStatementIn, Use, Value,
+    ShowStatementIn, TruncateTableTarget, Use, Value,
 };
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -287,6 +287,11 @@ impl UserQuery {
                 | Statement::ShowVariables { .. }
                 | Statement::ShowVariable { .. } => {
                     return Box::pin(self.show_query(*s)).await;
+                }
+                Statement::Truncate { table_names, .. } => {
+                    let result = Box::pin(self.truncate_table(table_names)).await;
+                    self.refresh_catalog().await?;
+                    return result;
                 }
                 Statement::Query(mut subquery) => {
                     self.update_qualify_in_query(subquery.as_mut());
@@ -1155,6 +1160,28 @@ impl UserQuery {
             }
         };
         Box::pin(self.execute_with_custom_plan(&query)).await
+    }
+
+    pub async fn truncate_table(
+        &self,
+        table_names: Vec<TruncateTableTarget>,
+    ) -> ExecutionResult<QueryResult> {
+        let Some(first_table) = table_names.into_iter().next() else {
+            return Err(ExecutionError::DataFusion {
+                source: DataFusionError::NotImplemented(
+                    "No table names provided for TRUNCATE TABLE".to_string(),
+                ),
+            });
+        };
+
+        let object_name = self.resolve_table_object_name(first_table.name.0)?;
+        let mut query = self.session.query(
+            format!(
+                "CREATE OR REPLACE TABLE {object_name} as (SELECT * FROM {object_name} WHERE FALSE)",
+            ),
+            QueryContext::default(),
+        );
+        query.execute().await
     }
 
     #[must_use]

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -519,3 +519,14 @@ test_query!(
     setup_queries = ["SET datafusion.explain.logical_plan_only = true"],
     snapshot_path = "session"
 );
+
+// TRUNCATE TABLE
+test_query!(truncate_table, "TRUNCATE TABLE employee_table");
+test_query!(
+    truncate_table_full,
+    "TRUNCATE TABLE embucket.public.employee_table"
+);
+test_query!(
+    truncate_table_full_quotes,
+    "TRUNCATE TABLE 'EMBUCKET'.'PUBLIC'.'EMPLOYEE_TABLE'"
+);

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -530,3 +530,4 @@ test_query!(
     truncate_table_full_quotes,
     "TRUNCATE TABLE 'EMBUCKET'.'PUBLIC'.'EMPLOYEE_TABLE'"
 );
+test_query!(truncate_missing, "TRUNCATE TABLE missing_table");

--- a/crates/core-executor/src/tests/snapshots/query_truncate_missing.snap
+++ b/crates/core-executor/src/tests/snapshots/query_truncate_missing.snap
@@ -1,0 +1,8 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"TRUNCATE TABLE missing_table\""
+snapshot_kind: text
+---
+Err(
+    "Error: DataFusion error: Error during planning: table 'embucket.public.missing_table' not found",
+)

--- a/crates/core-executor/src/tests/snapshots/query_truncate_table.snap
+++ b/crates/core-executor/src/tests/snapshots/query_truncate_table.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"TRUNCATE TABLE employee_table\""
+snapshot_kind: text
+---
+Ok(
+    [
+        "+-------+",
+        "| count |",
+        "+-------+",
+        "| 0     |",
+        "+-------+",
+    ],
+)

--- a/crates/core-executor/src/tests/snapshots/query_truncate_table_full.snap
+++ b/crates/core-executor/src/tests/snapshots/query_truncate_table_full.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"TRUNCATE TABLE 'EMBUCKET'.'PUBLIC'.'EMPLOYEE_TABLE'\""
+snapshot_kind: text
+---
+Ok(
+    [
+        "+-------+",
+        "| count |",
+        "+-------+",
+        "| 0     |",
+        "+-------+",
+    ],
+)

--- a/crates/core-executor/src/tests/snapshots/query_truncate_table_full_quotes.snap
+++ b/crates/core-executor/src/tests/snapshots/query_truncate_table_full_quotes.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"TRUNCATE TABLE 'EMBUCKET'.'PUBLIC'.'EMPLOYEE_TABLE'\""
+snapshot_kind: text
+---
+Ok(
+    [
+        "+-------+",
+        "| count |",
+        "+-------+",
+        "| 0     |",
+        "+-------+",
+    ],
+)


### PR DESCRIPTION
- added truncate table statement as **create or replace** to fetch all necessary table metadata (or replace means drop existing table)
- fixed SHOW OBJECTS upper case for snowflake (internally we use only normalised names)
- fixed navigation tree VIEW type (during statement parsing we add the table itself to cache, so there was a duplicate) 

This fix allows to run snowplow **dbt seed** multiple times since there we truncate table if it is already exist
Closes #843