### PR TITLE
Tables search through the query engine

### DIFF
--- a/crates/api-ui/src/lib.rs
+++ b/crates/api-ui/src/lib.rs
@@ -1,5 +1,5 @@
 use core_executor::error::ExecutionError;
-use datafusion::arrow::array::{RecordBatch, StringArray};
+use datafusion::arrow::array::{Int64Array, RecordBatch, StringArray};
 use datafusion::common::DataFusionError;
 use serde::Deserialize;
 use std::fmt::Display;
@@ -69,6 +69,18 @@ fn downcast_string_column<'a>(
     batch
         .column_by_name(name)
         .and_then(|col| col.as_any().downcast_ref::<StringArray>())
+        .ok_or_else(|| ExecutionError::DataFusion {
+            source: DataFusionError::Internal(format!("Missing or invalid column: '{name}'")),
+        })
+}
+
+fn downcast_int64_column<'a>(
+    batch: &'a RecordBatch,
+    name: &str,
+) -> Result<&'a Int64Array, ExecutionError> {
+    batch
+        .column_by_name(name)
+        .and_then(|col| col.as_any().downcast_ref::<Int64Array>())
         .ok_or_else(|| ExecutionError::DataFusion {
             source: DataFusionError::Internal(format!("Missing or invalid column: '{name}'")),
         })

--- a/crates/api-ui/src/tables/handlers.rs
+++ b/crates/api-ui/src/tables/handlers.rs
@@ -7,8 +7,9 @@ use crate::tables::error::{
 use crate::tables::models::{
     Table, TableColumn, TableColumnsResponse, TablePreviewDataColumn, TablePreviewDataParameters,
     TablePreviewDataResponse, TablePreviewDataRow, TableStatistics, TableStatisticsResponse,
-    TableUploadPayload, TableUploadResponse, TablesParameters, TablesResponse, UploadParameters,
+    TableUploadPayload, TableUploadResponse, TablesResponse, UploadParameters,
 };
+use crate::{SearchParameters, downcast_int64_column, downcast_string_column};
 use api_sessions::DFSessionId;
 use axum::extract::Query;
 use axum::{
@@ -16,9 +17,8 @@ use axum::{
     extract::{Multipart, Path, State},
 };
 use core_executor::{models::QueryResultData, query::QueryContext};
+use core_metastore::TableIdent as MetastoreTableIdent;
 use core_metastore::error::MetastoreError;
-use core_metastore::{SchemaIdent as MetastoreSchemaIdent, TableIdent as MetastoreTableIdent};
-use core_utils::scan_iterator::ScanIterator;
 use datafusion::arrow::csv::reader::Format;
 use datafusion::arrow::util::display::array_value_to_string;
 use snafu::ResultExt;
@@ -48,7 +48,6 @@ use utoipa::OpenApi;
             TableUploadPayload,
             TableUploadResponse,
             TablesResponse,
-            TablesParameters,
             ErrorResponse,
         )
     ),
@@ -378,62 +377,80 @@ pub async fn upload_file(
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
 #[allow(clippy::unwrap_used)]
 pub async fn get_tables(
-    Query(parameters): Query<TablesParameters>,
+    DFSessionId(session_id): DFSessionId,
+    Query(parameters): Query<SearchParameters>,
     State(state): State<AppState>,
     Path((database_name, schema_name)): Path<(String, String)>,
 ) -> TablesResult<Json<TablesResponse>> {
-    let ident = MetastoreSchemaIdent::new(database_name, schema_name);
-    state
-        .metastore
-        .iter_tables(&ident)
-        .cursor(parameters.cursor.clone())
-        .limit(parameters.limit)
-        .token(parameters.search)
-        .collect()
+    let context = QueryContext::new(Some(database_name.clone()), None, None);
+    let sql_string = format!(
+        "SELECT * FROM slatedb.public.tables WHERE schema_name = '{}' AND database_name = '{}'",
+        schema_name.clone(),
+        database_name.clone()
+    );
+    let sql_string = parameters.search.map_or_else(|| sql_string.clone(), |search|
+        format!("{sql_string} AND (table_name ILIKE '%{search}%' OR schema_name ILIKE '%{search}%' OR database_name ILIKE '%{search}%' OR volume_name ILIKE '%{search}%' OR table_type ILIKE '%{search}%' OR table_format ILIKE '%{search}%' OR owner ILIKE '%{search}%')")
+    );
+    let sql_string = parameters.order_by.map_or_else(
+        || format!("{sql_string} ORDER BY table_name"),
+        |order_by| format!("{sql_string} ORDER BY {order_by}"),
+    );
+    let sql_string = parameters.order_direction.map_or_else(
+        || format!("{sql_string} DESC"),
+        |order_direction| format!("{sql_string} {order_direction}"),
+    );
+    let sql_string = parameters.offset.map_or_else(
+        || sql_string.clone(),
+        |offset| format!("{sql_string} OFFSET {offset}"),
+    );
+    let sql_string = parameters.limit.map_or_else(
+        || sql_string.clone(),
+        |limit| format!("{sql_string} LIMIT {limit}"),
+    );
+    let QueryResultData { records, .. } = state
+        .execution_svc
+        .query(&session_id, sql_string.as_str(), context)
         .await
-        .map_err(|e| TablesAPIError::GetMetastore {
-            source: MetastoreError::UtilSlateDB { source: e },
-        })
-        .map(|rw_tables| {
-            let next_cursor = rw_tables
-                .iter()
-                .last()
-                .map_or(String::new(), |rw_table| rw_table.ident.table.clone());
-
-            let items = rw_tables
-                .into_iter()
-                .map(|rw_table| {
-                    let mut total_bytes = 0;
-                    let mut total_rows = 0;
-                    if let Ok(Some(latest_snapshot)) = rw_table.metadata.current_snapshot(None) {
-                        total_bytes = latest_snapshot
-                            .summary()
-                            .other
-                            .get("total-files-size")
-                            .and_then(|value| value.parse::<i64>().ok())
-                            .unwrap_or(0);
-                        total_rows = latest_snapshot
-                            .summary()
-                            .other
-                            .get("total-records")
-                            .and_then(|value| value.parse::<i64>().ok())
-                            .unwrap_or(0);
-                    }
-                    Table {
-                        name: rw_table.ident.table.clone(),
-                        r#type: "TABLE".to_string(),
-                        owner: String::new(),
-                        total_rows,
-                        total_bytes,
-                        created_at: rw_table.created_at,
-                        updated_at: rw_table.updated_at,
-                    }
-                })
-                .collect();
-            Ok(Json(TablesResponse {
-                items,
-                current_cursor: parameters.cursor,
-                next_cursor,
-            }))
-        })?
+        .map_err(|e| TablesAPIError::Execution { source: e })?;
+    let mut items = Vec::new();
+    for record in records {
+        let table_names = downcast_string_column(&record, "table_name")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let schema_names = downcast_string_column(&record, "schema_name")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let database_names = downcast_string_column(&record, "database_name")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let volume_names = downcast_string_column(&record, "volume_name")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let owners = downcast_string_column(&record, "owner")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let table_types = downcast_string_column(&record, "table_type")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let table_format_values = downcast_string_column(&record, "table_format")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let total_bytes_values = downcast_int64_column(&record, "total_bytes")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let total_rows_values = downcast_int64_column(&record, "total_rows")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let created_at_timestamps = downcast_string_column(&record, "created_at")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        let updated_at_timestamps = downcast_string_column(&record, "updated_at")
+            .map_err(|e| TablesAPIError::Execution { source: e })?;
+        for i in 0..record.num_rows() {
+            items.push(Table {
+                name: table_names.value(i).to_string(),
+                schema_name: schema_names.value(i).to_string(),
+                database_name: database_names.value(i).to_string(),
+                volume_name: volume_names.value(i).to_string(),
+                owner: owners.value(i).to_string(),
+                table_format: table_format_values.value(i).to_string(),
+                r#type: table_types.value(i).to_string(),
+                total_bytes: total_bytes_values.value(i),
+                total_rows: total_rows_values.value(i),
+                created_at: created_at_timestamps.value(i).to_string(),
+                updated_at: updated_at_timestamps.value(i).to_string(),
+            });
+        }
+    }
+    Ok(Json(TablesResponse { items }))
 }

--- a/crates/api-ui/src/tables/handlers.rs
+++ b/crates/api-ui/src/tables/handlers.rs
@@ -389,7 +389,7 @@ pub async fn get_tables(
         database_name.clone()
     );
     let sql_string = parameters.search.map_or_else(|| sql_string.clone(), |search|
-        format!("{sql_string} AND (table_name ILIKE '%{search}%' OR schema_name ILIKE '%{search}%' OR database_name ILIKE '%{search}%' OR volume_name ILIKE '%{search}%' OR table_type ILIKE '%{search}%' OR table_format ILIKE '%{search}%' OR owner ILIKE '%{search}%')")
+        format!("{sql_string} AND (table_name ILIKE '%{search}%' OR volume_name ILIKE '%{search}%' OR table_type ILIKE '%{search}%' OR table_format ILIKE '%{search}%' OR owner ILIKE '%{search}%')")
     );
     let sql_string = parameters.order_by.map_or_else(
         || format!("{sql_string} ORDER BY table_name"),

--- a/crates/api-ui/src/tables/models.rs
+++ b/crates/api-ui/src/tables/models.rs
@@ -139,24 +139,19 @@ impl Into<Format> for UploadParameters {
 #[serde(rename_all = "camelCase")]
 pub struct TablesResponse {
     pub items: Vec<Table>,
-    pub current_cursor: Option<String>,
-    pub next_cursor: String,
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Table {
     pub name: String,
-    pub r#type: String,
+    pub schema_name: String,
+    pub database_name: String,
+    pub volume_name: String,
     pub owner: String,
+    pub table_format: String,
+    pub r#type: String,
     pub total_rows: i64,
     pub total_bytes: i64,
-    pub created_at: NaiveDateTime,
-    pub updated_at: NaiveDateTime,
-}
-#[derive(Debug, Deserialize, ToSchema, IntoParams)]
-pub struct TablesParameters {
-    pub cursor: Option<String>,
-    #[serde(default = "default_limit")]
-    pub limit: Option<u16>,
-    pub search: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
 }

--- a/crates/api-ui/src/tests/tables.rs
+++ b/crates/api-ui/src/tests/tables.rs
@@ -350,15 +350,14 @@ async fn test_ui_tables() {
     assert_eq!(http::StatusCode::OK, res.status());
     let tables: TablesResponse = res.json().await.unwrap();
     assert_eq!(2, tables.items.len());
-    assert_eq!("tested1".to_string(), tables.items.first().unwrap().name);
-    let cursor = tables.next_cursor;
+    assert_eq!("tested4".to_string(), tables.items.first().unwrap().name);
 
     //GET LIST Tables with cursor
     let res = req(
         &client,
         Method::GET,
         &format!(
-            "http://{addr}/ui/databases/{}/schemas/{}/tables?cursor={cursor}",
+            "http://{addr}/ui/databases/{}/schemas/{}/tables?offset=2",
             database_name.clone(),
             schema_name.clone()
         ),
@@ -369,7 +368,7 @@ async fn test_ui_tables() {
     assert_eq!(http::StatusCode::OK, res.status());
     let tables: TablesResponse = res.json().await.unwrap();
     assert_eq!(2, tables.items.len());
-    assert_eq!("tested3".to_string(), tables.items.first().unwrap().name);
+    assert_eq!("tested2".to_string(), tables.items.first().unwrap().name);
 
     //Create a table with another name
     let query_payload = QueryCreatePayload {
@@ -411,7 +410,7 @@ async fn test_ui_tables() {
             "http://{addr}/ui/databases/{}/schemas/{}/tables?search={}",
             database_name.clone(),
             schema_name.clone(),
-            "tes"
+            "tested"
         ),
         String::new(),
     )
@@ -420,7 +419,7 @@ async fn test_ui_tables() {
     assert_eq!(http::StatusCode::OK, res.status());
     let tables: TablesResponse = res.json().await.unwrap();
     assert_eq!(4, tables.items.len());
-    assert_eq!("tested1".to_string(), tables.items.first().unwrap().name);
+    assert_eq!("tested4".to_string(), tables.items.first().unwrap().name);
 
     //GET LIST Tables with search and limit
     let res = req(
@@ -430,7 +429,7 @@ async fn test_ui_tables() {
             "http://{addr}/ui/databases/{}/schemas/{}/tables?search={}&limit=2",
             database_name.clone(),
             schema_name.clone(),
-            "tes"
+            "tested"
         ),
         String::new(),
     )
@@ -439,18 +438,17 @@ async fn test_ui_tables() {
     assert_eq!(http::StatusCode::OK, res.status());
     let tables: TablesResponse = res.json().await.unwrap();
     assert_eq!(2, tables.items.len());
-    assert_eq!("tested1".to_string(), tables.items.first().unwrap().name);
-    let cursor = tables.next_cursor;
+    assert_eq!("tested4".to_string(), tables.items.first().unwrap().name);
 
     //GET LIST Tables with cursor
     let res = req(
         &client,
         Method::GET,
         &format!(
-            "http://{addr}/ui/databases/{}/schemas/{}/tables?search={}&cursor={cursor}",
+            "http://{addr}/ui/databases/{}/schemas/{}/tables?search={}&offset=2",
             database_name.clone(),
             schema_name.clone(),
-            "tes"
+            "tested"
         ),
         String::new(),
     )
@@ -459,7 +457,7 @@ async fn test_ui_tables() {
     assert_eq!(http::StatusCode::OK, res.status());
     let tables: TablesResponse = res.json().await.unwrap();
     assert_eq!(2, tables.items.len());
-    assert_eq!("tested3".to_string(), tables.items.first().unwrap().name);
+    assert_eq!("tested2".to_string(), tables.items.first().unwrap().name);
 
     //GET LIST Tables with search for the other table
     let res = req(

--- a/crates/api-ui/src/tests/tables.rs
+++ b/crates/api-ui/src/tests/tables.rs
@@ -421,6 +421,25 @@ async fn test_ui_tables() {
     assert_eq!(4, tables.items.len());
     assert_eq!("tested4".to_string(), tables.items.first().unwrap().name);
 
+    //GET LIST Tables with search
+    let res = req(
+        &client,
+        Method::GET,
+        &format!(
+            "http://{addr}/ui/databases/{}/schemas/{}/tables?search={}&orderDirection=ASC",
+            database_name.clone(),
+            schema_name.clone(),
+            "tested"
+        ),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let tables: TablesResponse = res.json().await.unwrap();
+    assert_eq!(4, tables.items.len());
+    assert_eq!("tested1".to_string(), tables.items.first().unwrap().name);
+
     //GET LIST Tables with search and limit
     let res = req(
         &client,

--- a/crates/df-catalog/src/catalogs/slatedb/tables.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/tables.rs
@@ -1,7 +1,7 @@
 use crate::catalogs::slatedb::config::SlateDBViewConfig;
+use datafusion::arrow::array::Int64Builder;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::{
-    array::BooleanBuilder,
     array::StringBuilder,
     datatypes::{DataType, Field, Schema, SchemaRef},
     record_batch::RecordBatch,
@@ -27,8 +27,11 @@ impl TablesView {
             Field::new("schema_name", DataType::Utf8, false),
             Field::new("database_name", DataType::Utf8, false),
             Field::new("volume_name", DataType::Utf8, true),
-            Field::new("is_temporary", DataType::Boolean, false),
+            Field::new("owner", DataType::Utf8, true),
+            Field::new("table_type", DataType::Utf8, false),
             Field::new("table_format", DataType::Utf8, false),
+            Field::new("total_bytes", DataType::Int64, false),
+            Field::new("total_rows", DataType::Int64, false),
             Field::new("created_at", DataType::Utf8, false),
             Field::new("updated_at", DataType::Utf8, false),
         ]));
@@ -42,8 +45,11 @@ impl TablesView {
             schema_names: StringBuilder::new(),
             database_names: StringBuilder::new(),
             volume_names: StringBuilder::new(),
-            is_temporary_values: BooleanBuilder::new(),
+            owners: StringBuilder::new(),
+            table_types: StringBuilder::new(),
             table_format_values: StringBuilder::new(),
+            total_bytes_values: Int64Builder::new(),
+            total_rows_values: Int64Builder::new(),
             created_at_timestamps: StringBuilder::new(),
             updated_at_timestamps: StringBuilder::new(),
             schema: Arc::clone(&self.schema),
@@ -77,8 +83,11 @@ pub struct TablesViewBuilder {
     schema_names: StringBuilder,
     database_names: StringBuilder,
     volume_names: StringBuilder,
-    is_temporary_values: BooleanBuilder,
+    owners: StringBuilder,
+    table_types: StringBuilder,
     table_format_values: StringBuilder,
+    total_bytes_values: Int64Builder,
+    total_rows_values: Int64Builder,
     created_at_timestamps: StringBuilder,
     updated_at_timestamps: StringBuilder,
 }
@@ -91,8 +100,11 @@ impl TablesViewBuilder {
         schema_name: impl AsRef<str>,
         database_name: impl AsRef<str>,
         volume_name: Option<impl AsRef<str>>,
-        is_temporary: bool,
+        owner: Option<impl AsRef<str>>,
+        table_type: impl AsRef<str>,
         table_format: impl AsRef<str>,
+        total_files_size: i64,
+        total_rows: i64,
         created_at: impl AsRef<str>,
         updated_at: impl AsRef<str>,
     ) {
@@ -101,8 +113,11 @@ impl TablesViewBuilder {
         self.schema_names.append_value(schema_name.as_ref());
         self.database_names.append_value(database_name.as_ref());
         self.volume_names.append_option(volume_name);
-        self.is_temporary_values.append_value(is_temporary);
+        self.owners.append_option(owner);
+        self.table_types.append_value(table_type);
         self.table_format_values.append_value(table_format.as_ref());
+        self.total_bytes_values.append_value(total_files_size);
+        self.total_rows_values.append_value(total_rows);
         self.created_at_timestamps.append_value(created_at.as_ref());
         self.updated_at_timestamps.append_value(updated_at.as_ref());
     }
@@ -115,8 +130,11 @@ impl TablesViewBuilder {
                 Arc::new(self.schema_names.finish()),
                 Arc::new(self.database_names.finish()),
                 Arc::new(self.volume_names.finish()),
-                Arc::new(self.is_temporary_values.finish()),
+                Arc::new(self.owners.finish()),
+                Arc::new(self.table_types.finish()),
                 Arc::new(self.table_format_values.finish()),
+                Arc::new(self.total_bytes_values.finish()),
+                Arc::new(self.total_rows_values.finish()),
                 Arc::new(self.created_at_timestamps.finish()),
                 Arc::new(self.updated_at_timestamps.finish()),
             ],


### PR DESCRIPTION
Partial #522

- Making incremental prs per handler (easier to review and trying to minimize breaking changes to Yaroslav's api-structs pr)
- Extended the `slatedb.public.tables` view
- Changed the `/ui../tables` GET (list) handler to use query engine for advanced search
- Fixed & added tests