### PR TITLE
Volumes search through query engine & removed unintended info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,6 +2687,8 @@ dependencies = [
 name = "df-builtins"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.8.12",
+ "base64 0.22.1",
  "chrono",
  "datafusion",
  "datafusion-common",

--- a/crates/api-ui/src/databases/handlers.rs
+++ b/crates/api-ui/src/databases/handlers.rs
@@ -1,5 +1,5 @@
 use crate::state::AppState;
-use crate::{OrderDirection, apply_other_parameters};
+use crate::{OrderDirection, apply_parameters};
 use crate::{
     SearchParameters,
     databases::error::{DatabasesAPIError, DatabasesResult},
@@ -227,10 +227,7 @@ pub async fn list_databases(
 ) -> DatabasesResult<Json<DatabasesResponse>> {
     let context = QueryContext::default();
     let sql_string = "SELECT * FROM slatedb.public.databases".to_string();
-    let sql_string = parameters.search.clone().map_or_else(|| sql_string.clone(), |search|
-        format!("{sql_string} WHERE (database_name ILIKE '%{search}%' OR volume_name ILIKE '%{search}%')")
-    );
-    let sql_string = apply_other_parameters(&sql_string, parameters, "database_name");
+    let sql_string = apply_parameters(&sql_string, parameters, &["database_name", "volume_name"]);
     let QueryResultData { records, .. } = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)

--- a/crates/api-ui/src/databases/handlers.rs
+++ b/crates/api-ui/src/databases/handlers.rs
@@ -1,5 +1,5 @@
-use crate::OrderDirection;
 use crate::state::AppState;
+use crate::{OrderDirection, apply_other_parameters};
 use crate::{
     SearchParameters,
     databases::error::{DatabasesAPIError, DatabasesResult},
@@ -227,25 +227,10 @@ pub async fn list_databases(
 ) -> DatabasesResult<Json<DatabasesResponse>> {
     let context = QueryContext::default();
     let sql_string = "SELECT * FROM slatedb.public.databases".to_string();
-    let sql_string = parameters.search.map_or_else(|| sql_string.clone(), |search|
+    let sql_string = parameters.search.clone().map_or_else(|| sql_string.clone(), |search|
         format!("{sql_string} WHERE (database_name ILIKE '%{search}%' OR volume_name ILIKE '%{search}%')")
     );
-    let sql_string = parameters.order_by.map_or_else(
-        || format!("{sql_string} ORDER BY database_name"),
-        |order_by| format!("{sql_string} ORDER BY {order_by}"),
-    );
-    let sql_string = parameters.order_direction.map_or_else(
-        || format!("{sql_string} DESC"),
-        |order_direction| format!("{sql_string} {order_direction}"),
-    );
-    let sql_string = parameters.offset.map_or_else(
-        || sql_string.clone(),
-        |offset| format!("{sql_string} OFFSET {offset}"),
-    );
-    let sql_string = parameters.limit.map_or_else(
-        || sql_string.clone(),
-        |limit| format!("{sql_string} LIMIT {limit}"),
-    );
+    let sql_string = apply_other_parameters(&sql_string, parameters, "database_name");
     let QueryResultData { records, .. } = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)

--- a/crates/api-ui/src/lib.rs
+++ b/crates/api-ui/src/lib.rs
@@ -86,13 +86,40 @@ fn downcast_int64_column<'a>(
         })
 }
 
-fn apply_other_parameters(
+fn apply_parameters(
     sql_string: &str,
     parameters: SearchParameters,
-    order_by_default: &str,
+    search_columns: &[&str],
 ) -> String {
+    let sql_string = parameters.search.map_or_else(
+        || sql_string.to_string(),
+        |search| {
+            let separator = format!(" ILIKE '%{search}%' OR ");
+            let sql_string = sql_string.find("WHERE").map_or_else(
+                || {
+                    //if there is no WHERE clause
+                    let sql_string =
+                        format!("{sql_string} WHERE ({}", search_columns.join(&separator));
+                    sql_string
+                },
+                |_| {
+                    //if there is a WHERE clause
+                    let sql_string =
+                        format!("{sql_string} AND ({}", search_columns.join(&separator));
+                    sql_string
+                },
+            );
+            format!("{sql_string} ILIKE '%{search}%')")
+        },
+    );
+    //Default order by is the first search column or created at
     let sql_string = parameters.order_by.map_or_else(
-        || format!("{sql_string} ORDER BY {order_by_default}"),
+        || {
+            format!(
+                "{sql_string} ORDER BY {}",
+                search_columns.first().unwrap_or(&"created_at")
+            )
+        },
         |order_by| format!("{sql_string} ORDER BY {order_by}"),
     );
     let sql_string = parameters.order_direction.map_or_else(

--- a/crates/api-ui/src/lib.rs
+++ b/crates/api-ui/src/lib.rs
@@ -85,3 +85,27 @@ fn downcast_int64_column<'a>(
             source: DataFusionError::Internal(format!("Missing or invalid column: '{name}'")),
         })
 }
+
+fn apply_other_parameters(
+    sql_string: &str,
+    parameters: SearchParameters,
+    order_by_default: &str,
+) -> String {
+    let sql_string = parameters.order_by.map_or_else(
+        || format!("{sql_string} ORDER BY {order_by_default}"),
+        |order_by| format!("{sql_string} ORDER BY {order_by}"),
+    );
+    let sql_string = parameters.order_direction.map_or_else(
+        || format!("{sql_string} DESC"),
+        |order_direction| format!("{sql_string} {order_direction}"),
+    );
+    let sql_string = parameters.offset.map_or_else(
+        || sql_string.clone(),
+        |offset| format!("{sql_string} OFFSET {offset}"),
+    );
+
+    parameters.limit.map_or_else(
+        || sql_string.clone(),
+        |limit| format!("{sql_string} LIMIT {limit}"),
+    )
+}

--- a/crates/api-ui/src/schemas/handlers.rs
+++ b/crates/api-ui/src/schemas/handlers.rs
@@ -1,5 +1,5 @@
-use crate::OrderDirection;
 use crate::state::AppState;
+use crate::{OrderDirection, apply_other_parameters};
 use crate::{
     SearchParameters, downcast_string_column,
     error::ErrorResponse,
@@ -269,25 +269,10 @@ pub async fn list_schemas(
         "SELECT * FROM slatedb.public.schemas WHERE database_name = '{}'",
         database_name.clone()
     );
-    let sql_string = parameters.search.map_or_else(|| sql_string.clone(), |search|
+    let sql_string = parameters.search.clone().map_or_else(|| sql_string.clone(), |search|
         format!("{sql_string} AND (schema_name ILIKE '%{search}%' OR database_name ILIKE '%{search}%')")
     );
-    let sql_string = parameters.order_by.map_or_else(
-        || format!("{sql_string} ORDER BY schema_name"),
-        |order_by| format!("{sql_string} ORDER BY {order_by}"),
-    );
-    let sql_string = parameters.order_direction.map_or_else(
-        || format!("{sql_string} DESC"),
-        |order_direction| format!("{sql_string} {order_direction}"),
-    );
-    let sql_string = parameters.offset.map_or_else(
-        || sql_string.clone(),
-        |offset| format!("{sql_string} OFFSET {offset}"),
-    );
-    let sql_string = parameters.limit.map_or_else(
-        || sql_string.clone(),
-        |limit| format!("{sql_string} LIMIT {limit}"),
-    );
+    let sql_string = apply_other_parameters(&sql_string, parameters, "schema_name");
     let QueryResultData { records, .. } = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)

--- a/crates/api-ui/src/schemas/handlers.rs
+++ b/crates/api-ui/src/schemas/handlers.rs
@@ -1,5 +1,5 @@
 use crate::state::AppState;
-use crate::{OrderDirection, apply_other_parameters};
+use crate::{OrderDirection, apply_parameters};
 use crate::{
     SearchParameters, downcast_string_column,
     error::ErrorResponse,
@@ -269,10 +269,7 @@ pub async fn list_schemas(
         "SELECT * FROM slatedb.public.schemas WHERE database_name = '{}'",
         database_name.clone()
     );
-    let sql_string = parameters.search.clone().map_or_else(|| sql_string.clone(), |search|
-        format!("{sql_string} AND (schema_name ILIKE '%{search}%' OR database_name ILIKE '%{search}%')")
-    );
-    let sql_string = apply_other_parameters(&sql_string, parameters, "schema_name");
+    let sql_string = apply_parameters(&sql_string, parameters, &["schema_name", "database_name"]);
     let QueryResultData { records, .. } = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)

--- a/crates/api-ui/src/tables/handlers.rs
+++ b/crates/api-ui/src/tables/handlers.rs
@@ -9,7 +9,9 @@ use crate::tables::models::{
     TablePreviewDataResponse, TablePreviewDataRow, TableStatistics, TableStatisticsResponse,
     TableUploadPayload, TableUploadResponse, TablesResponse, UploadParameters,
 };
-use crate::{SearchParameters, downcast_int64_column, downcast_string_column};
+use crate::{
+    SearchParameters, apply_other_parameters, downcast_int64_column, downcast_string_column,
+};
 use api_sessions::DFSessionId;
 use axum::extract::Query;
 use axum::{
@@ -388,25 +390,10 @@ pub async fn get_tables(
         schema_name.clone(),
         database_name.clone()
     );
-    let sql_string = parameters.search.map_or_else(|| sql_string.clone(), |search|
+    let sql_string = parameters.search.clone().map_or_else(|| sql_string.clone(), |search|
         format!("{sql_string} AND (table_name ILIKE '%{search}%' OR volume_name ILIKE '%{search}%' OR table_type ILIKE '%{search}%' OR table_format ILIKE '%{search}%' OR owner ILIKE '%{search}%')")
     );
-    let sql_string = parameters.order_by.map_or_else(
-        || format!("{sql_string} ORDER BY table_name"),
-        |order_by| format!("{sql_string} ORDER BY {order_by}"),
-    );
-    let sql_string = parameters.order_direction.map_or_else(
-        || format!("{sql_string} DESC"),
-        |order_direction| format!("{sql_string} {order_direction}"),
-    );
-    let sql_string = parameters.offset.map_or_else(
-        || sql_string.clone(),
-        |offset| format!("{sql_string} OFFSET {offset}"),
-    );
-    let sql_string = parameters.limit.map_or_else(
-        || sql_string.clone(),
-        |limit| format!("{sql_string} LIMIT {limit}"),
-    );
+    let sql_string = apply_other_parameters(&sql_string, parameters, "table_name");
     let QueryResultData { records, .. } = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)

--- a/crates/api-ui/src/tests/volumes.rs
+++ b/crates/api-ui/src/tests/volumes.rs
@@ -1,23 +1,26 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
-use crate::tests::common::{Entity, Op, ui_test_op};
+
+use crate::tests::common::{Entity, Op, req, ui_test_op};
 use crate::tests::server::run_test_server;
-use crate::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse};
+use crate::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse, VolumesResponse};
 use core_metastore::Volume as MetastoreVolume;
 use core_metastore::{
     AwsAccessKeyCredentials, AwsCredentials, FileVolume as MetastoreFileVolume,
     S3Volume as MetastoreS3Volume, VolumeType as MetastoreVolumeType,
 };
+use http::Method;
 use serde_json;
 
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
-async fn test_ui_volumes_memory() {
+async fn test_ui_volumes() {
     let addr = run_test_server().await;
+    let client = reqwest::Client::new();
 
     // memory volume with empty ident create Ok
     let expected = VolumeCreatePayload {
         data: Volume::from(MetastoreVolume {
-            ident: String::new(),
+            ident: "embucket1".to_string(),
             volume: MetastoreVolumeType::Memory,
         }),
     };
@@ -25,15 +28,9 @@ async fn test_ui_volumes_memory() {
     assert_eq!(200, res.status());
     let created = res.json::<VolumeCreateResponse>().await.unwrap();
     assert_eq!(expected.data, created.data);
-}
-
-#[tokio::test]
-#[allow(clippy::too_many_lines)]
-async fn test_ui_volumes_file() {
-    let addr = run_test_server().await;
 
     // memory volume with empty ident create Ok
-    let payload = r#"{"name":"","type": "file", "path":"/tmp/data"}"#;
+    let payload = r#"{"name":"embucket2","type": "file", "path":"/tmp/data"}"#;
     let expected: VolumeCreatePayload = serde_json::from_str(payload).unwrap();
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     // let res = create_test_volume(addr, &expected).await;
@@ -43,7 +40,7 @@ async fn test_ui_volumes_file() {
 
     let expected = VolumeCreatePayload {
         data: Volume::from(MetastoreVolume {
-            ident: String::new(),
+            ident: "embucket2".to_string(),
             volume: MetastoreVolumeType::File(MetastoreFileVolume {
                 path: "/tmp/data".to_string(),
             }),
@@ -52,17 +49,11 @@ async fn test_ui_volumes_file() {
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     // let res = create_test_volume(addr, &expected).await;
     assert_eq!(409, res.status());
-}
-
-#[tokio::test]
-#[allow(clippy::too_many_lines)]
-async fn test_ui_volumes_s3() {
-    let addr = run_test_server().await;
 
     // memory volume with empty ident create Ok
     let expected = VolumeCreatePayload {
         data: Volume::from(MetastoreVolume {
-            ident: String::new(),
+            ident: "embucket3".to_string(),
             volume: MetastoreVolumeType::S3(MetastoreS3Volume {
                 region: Some("us-west-1".to_string()),
                 bucket: Some("embucket".to_string()),
@@ -81,4 +72,151 @@ async fn test_ui_volumes_s3() {
     assert_eq!(200, res.status());
     let created = res.json::<VolumeCreateResponse>().await.unwrap();
     assert_eq!(expected.data, created.data);
+
+    //Get list volumes
+    let res = req(
+        &client,
+        Method::GET,
+        &format!("http://{addr}/ui/volumes",).to_string(),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let volumes_response: VolumesResponse = res.json().await.unwrap();
+    assert_eq!(3, volumes_response.items.len());
+    assert_eq!(
+        "embucket3".to_string(),
+        volumes_response.items.first().unwrap().name
+    );
+
+    //Get list volumes with parameters
+    let res = req(
+        &client,
+        Method::GET,
+        &format!("http://{addr}/ui/volumes?limit=2",).to_string(),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let volumes_response: VolumesResponse = res.json().await.unwrap();
+    assert_eq!(2, volumes_response.items.len());
+    assert_eq!(
+        "embucket2".to_string(),
+        volumes_response.items.last().unwrap().name
+    );
+
+    //Get list volumes with parameters
+    let res = req(
+        &client,
+        Method::GET,
+        &format!("http://{addr}/ui/volumes?offset=2",).to_string(),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let volumes_response: VolumesResponse = res.json().await.unwrap();
+    assert_eq!(1, volumes_response.items.len());
+    assert_eq!(
+        "embucket1".to_string(),
+        volumes_response.items.first().unwrap().name
+    );
+
+    //Create a volume with diffrent name
+    let expected = VolumeCreatePayload {
+        data: Volume::from(MetastoreVolume {
+            ident: "icebucket1".to_string(),
+            volume: MetastoreVolumeType::Memory,
+        }),
+    };
+    let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
+    assert_eq!(200, res.status());
+    let created = res.json::<VolumeCreateResponse>().await.unwrap();
+    assert_eq!(expected.data, created.data);
+
+    //Get list volumes
+    let res = req(
+        &client,
+        Method::GET,
+        &format!("http://{addr}/ui/volumes",).to_string(),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let volumes_response: VolumesResponse = res.json().await.unwrap();
+    assert_eq!(4, volumes_response.items.len());
+
+    //Get list volumes with parameters
+    let res = req(
+        &client,
+        Method::GET,
+        &format!("http://{addr}/ui/volumes?search=embucket",).to_string(),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let volumes_response: VolumesResponse = res.json().await.unwrap();
+    assert_eq!(3, volumes_response.items.len());
+
+    //Get list volumes with parameters
+    let res = req(
+        &client,
+        Method::GET,
+        &format!("http://{addr}/ui/volumes?search=embucket&orderDirection=ASC",).to_string(),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let volumes_response: VolumesResponse = res.json().await.unwrap();
+    assert_eq!(3, volumes_response.items.len());
+    assert_eq!(
+        "embucket1".to_string(),
+        volumes_response.items.first().unwrap().name
+    );
+
+    //Get list volumes with parameters
+    let res = req(
+        &client,
+        Method::GET,
+        &format!("http://{addr}/ui/volumes?search=ice",).to_string(),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let volumes_response: VolumesResponse = res.json().await.unwrap();
+    assert_eq!(1, volumes_response.items.len());
+    assert_eq!(
+        "icebucket1".to_string(),
+        volumes_response.items.first().unwrap().name
+    );
+
+    //Delete volume
+    let res = req(
+        &client,
+        Method::DELETE,
+        &format!("http://{addr}/ui/volumes/embucket1",).to_string(),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+
+    //Get list volumes
+    let res = req(
+        &client,
+        Method::GET,
+        &format!("http://{addr}/ui/volumes",).to_string(),
+        String::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(http::StatusCode::OK, res.status());
+    let volumes_response: VolumesResponse = res.json().await.unwrap();
+    assert_eq!(3, volumes_response.items.len());
 }

--- a/crates/api-ui/src/volumes/error.rs
+++ b/crates/api-ui/src/volumes/error.rs
@@ -2,9 +2,11 @@ use crate::error::ErrorResponse;
 use crate::error::IntoStatusCode;
 use axum::Json;
 use axum::response::IntoResponse;
+use core_executor::error::ExecutionError;
 use core_metastore::error::MetastoreError;
 use http::StatusCode;
 use snafu::prelude::*;
+
 pub type VolumesResult<T> = Result<T, VolumesAPIError>;
 
 #[derive(Debug, Snafu)]
@@ -19,7 +21,7 @@ pub enum VolumesAPIError {
     #[snafu(display("Update volume error: {source}"))]
     Update { source: MetastoreError },
     #[snafu(display("Get volume error: {source}"))]
-    List { source: MetastoreError },
+    List { source: ExecutionError },
 }
 
 // Select which status code to return.

--- a/crates/api-ui/src/volumes/handlers.rs
+++ b/crates/api-ui/src/volumes/handlers.rs
@@ -1,6 +1,6 @@
 use crate::state::AppState;
 use crate::{
-    OrderDirection, SearchParameters, apply_other_parameters, downcast_string_column,
+    OrderDirection, SearchParameters, apply_parameters, downcast_string_column,
     error::ErrorResponse,
     volumes::error::{VolumesAPIError, VolumesResult},
     volumes::models::{
@@ -246,10 +246,7 @@ pub async fn list_volumes(
 ) -> VolumesResult<Json<VolumesResponse>> {
     let context = QueryContext::default();
     let sql_string = "SELECT * FROM slatedb.public.volumes".to_string();
-    let sql_string = parameters.search.clone().map_or_else(|| sql_string.clone(), |search|
-        format!("{sql_string} WHERE (volume_name ILIKE '%{search}%' OR volume_type ILIKE '%{search}%')")
-    );
-    let sql_string = apply_other_parameters(&sql_string, parameters, "volume_name");
+    let sql_string = apply_parameters(&sql_string, parameters, &["volume_name", "volume_type"]);
     let QueryResultData { records, .. } = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)

--- a/crates/api-ui/src/volumes/handlers.rs
+++ b/crates/api-ui/src/volumes/handlers.rs
@@ -1,20 +1,23 @@
 use crate::state::AppState;
-use crate::volumes::models::VolumesParameters;
 use crate::{
+    OrderDirection, SearchParameters, apply_other_parameters, downcast_string_column,
     error::ErrorResponse,
     volumes::error::{VolumesAPIError, VolumesResult},
     volumes::models::{
-        FileVolume, S3TablesVolume, S3Volume, Volume, VolumeCreatePayload, VolumeCreateResponse,
-        VolumeResponse, VolumeType, VolumeUpdatePayload, VolumeUpdateResponse, VolumesResponse,
+        FileVolume, S3TablesVolume, S3Volume, SimpleVolume, Volume, VolumeCreatePayload,
+        VolumeCreateResponse, VolumeResponse, VolumeType, VolumeUpdatePayload,
+        VolumeUpdateResponse, VolumesResponse,
     },
 };
+use api_sessions::DFSessionId;
 use axum::{
     Json,
     extract::{Path, Query, State},
 };
+use core_executor::models::QueryResultData;
+use core_executor::query::QueryContext;
 use core_metastore::error::MetastoreError;
 use core_metastore::models::{AwsAccessKeyCredentials, AwsCredentials, Volume as MetastoreVolume};
-use core_utils::scan_iterator::ScanIterator;
 use utoipa::OpenApi;
 use validator::Validate;
 
@@ -32,6 +35,7 @@ use validator::Validate;
             VolumeCreatePayload,
             VolumeCreateResponse,
             Volume,
+            SimpleVolume,
             VolumeType,
             S3Volume,
             S3TablesVolume,
@@ -124,7 +128,7 @@ pub async fn get_volume(
 ) -> VolumesResult<Json<VolumeResponse>> {
     match state.metastore.get_volume(&volume_name).await {
         Ok(Some(volume)) => Ok(Json(VolumeResponse {
-            data: volume.data.into(),
+            data: volume.into(),
         })),
         Ok(None) => Err(VolumesAPIError::Get {
             source: MetastoreError::VolumeNotFound {
@@ -215,9 +219,11 @@ pub async fn update_volume(
     get,
     operation_id = "getVolumes",
     params(
-        ("cursor" = Option<String>, Query, description = "Volumes cursor"),
+        ("offset" = Option<usize>, Query, description = "Volumes offset"),
         ("limit" = Option<usize>, Query, description = "Volumes limit"),
-        ("search" = Option<String>, Query, description = "Volumes search (start with)"),
+        ("search" = Option<String>, Query, description = "Volumes search"),
+        ("order_by" = Option<String>, Query, description = "Order by: volume_name (default), volume_type, created_at, updated_at"),
+        ("order_direction" = Option<OrderDirection>, Query, description = "Order direction: ASC, DESC (default)"),
     ),
     tags = ["volumes"],
     path = "/ui/volumes",
@@ -234,29 +240,39 @@ pub async fn update_volume(
 )]
 #[tracing::instrument(level = "debug", skip(state), err, ret(level = tracing::Level::TRACE))]
 pub async fn list_volumes(
-    Query(parameters): Query<VolumesParameters>,
+    DFSessionId(session_id): DFSessionId,
+    Query(parameters): Query<SearchParameters>,
     State(state): State<AppState>,
 ) -> VolumesResult<Json<VolumesResponse>> {
-    state
-        .metastore
-        .iter_volumes()
-        .cursor(parameters.cursor.clone())
-        .limit(parameters.limit)
-        .token(parameters.search)
-        .collect()
+    let context = QueryContext::default();
+    let sql_string = "SELECT * FROM slatedb.public.volumes".to_string();
+    let sql_string = parameters.search.clone().map_or_else(|| sql_string.clone(), |search|
+        format!("{sql_string} WHERE (volume_name ILIKE '%{search}%' OR volume_type ILIKE '%{search}%')")
+    );
+    let sql_string = apply_other_parameters(&sql_string, parameters, "volume_name");
+    let QueryResultData { records, .. } = state
+        .execution_svc
+        .query(&session_id, sql_string.as_str(), context)
         .await
-        .map_err(|e| VolumesAPIError::List {
-            source: MetastoreError::UtilSlateDB { source: e },
-        })
-        .map(|o| {
-            let next_cursor = o
-                .iter()
-                .last()
-                .map_or(String::new(), |rw_object| rw_object.ident.clone());
-            Json(VolumesResponse {
-                items: o.into_iter().map(|x| x.data.into()).collect(),
-                current_cursor: parameters.cursor,
-                next_cursor,
-            })
-        })
+        .map_err(|e| VolumesAPIError::List { source: e })?;
+    let mut items = Vec::new();
+    for record in records {
+        let volume_names = downcast_string_column(&record, "volume_name")
+            .map_err(|e| VolumesAPIError::List { source: e })?;
+        let volume_types = downcast_string_column(&record, "volume_type")
+            .map_err(|e| VolumesAPIError::List { source: e })?;
+        let created_at_timestamps = downcast_string_column(&record, "created_at")
+            .map_err(|e| VolumesAPIError::List { source: e })?;
+        let updated_at_timestamps = downcast_string_column(&record, "updated_at")
+            .map_err(|e| VolumesAPIError::List { source: e })?;
+        for i in 0..record.num_rows() {
+            items.push(SimpleVolume {
+                name: volume_names.value(i).to_string(),
+                r#type: volume_types.value(i).to_string(),
+                created_at: created_at_timestamps.value(i).to_string(),
+                updated_at: updated_at_timestamps.value(i).to_string(),
+            });
+        }
+    }
+    Ok(Json(VolumesResponse { items }))
 }


### PR DESCRIPTION
Closes #522 & #850

- `/ui/volumes` GET LIST now search though the query engine DF View
- Added `SimpleVolume`, our `Volume` struct which is used for both payload and response, when called GET or GET LIST was leaking credentials and other info - no more (`SimpleVolume` doesn't contain such info), related to #848 
- If you have a better name for `SimpleVolume` -  please (I will use such naming for related #848 & #851)
- Added `fn apply_other_parameters` to generalize search code (make it more concise)
- Added volumes tests for list handler and delete handler
- Rebased onto main (to add `fn apply_other_parameters` to the Tables search)