### PR TITLE
UI Data modeling change (naming & payload != response)

### DIFF
--- a/crates/api-ui/src/auth/handlers.rs
+++ b/crates/api-ui/src/auth/handlers.rs
@@ -175,6 +175,7 @@ pub struct ApiDoc;
 )]
 #[tracing::instrument(level = Level::ERROR, skip_all, err)]
 pub async fn login(
+    //TODO: add DFSessionId (to start the session on login)
     State(state): State<AppState>,
     Json(LoginPayload { username, password }): Json<LoginPayload>,
 ) -> AuthResult<impl IntoResponse> {

--- a/crates/api-ui/src/databases/handlers.rs
+++ b/crates/api-ui/src/databases/handlers.rs
@@ -5,7 +5,7 @@ use crate::{
     databases::error::{DatabasesAPIError, DatabasesResult},
     databases::models::{
         Database, DatabaseCreatePayload, DatabaseCreateResponse, DatabaseResponse,
-        DatabaseUpdatePayload, DatabaseUpdateResponse, DatabasesResponse,
+        DatabaseUpdatePayload, DatabaseUpdateResponse, DatabasesResponse, TimestampedDatabase,
     },
     downcast_string_column,
     error::ErrorResponse,
@@ -38,6 +38,7 @@ use validator::Validate;
             DatabaseResponse,
             DatabasesResponse,
             Database,
+            TimestampedDatabase,
             ErrorResponse,
         )
     ),
@@ -85,7 +86,11 @@ pub async fn create_database(
         .create_database(&database.ident.clone(), database)
         .await
         .map_err(|e| DatabasesAPIError::Create { source: e })
-        .map(|o| Json(DatabaseCreateResponse { data: o.into() }))
+        .map(|o| {
+            Json(DatabaseCreateResponse {
+                data: o.data.into(),
+            })
+        })
 }
 
 #[utoipa::path(
@@ -192,7 +197,11 @@ pub async fn update_database(
         .update_database(&database_name, database)
         .await
         .map_err(|e| DatabasesAPIError::Update { source: e })
-        .map(|o| Json(DatabaseUpdateResponse { data: o.into() }))
+        .map(|o| {
+            Json(DatabaseUpdateResponse {
+                data: o.data.into(),
+            })
+        })
 }
 
 #[utoipa::path(
@@ -244,7 +253,7 @@ pub async fn list_databases(
         let updated_at_timestamps = downcast_string_column(&record, "updated_at")
             .map_err(|e| DatabasesAPIError::List { source: e })?;
         for i in 0..record.num_rows() {
-            items.push(Database {
+            items.push(TimestampedDatabase {
                 name: database_names.value(i).to_string(),
                 volume: volume_names.value(i).to_string(),
                 created_at: created_at_timestamps.value(i).to_string(),

--- a/crates/api-ui/src/databases/handlers.rs
+++ b/crates/api-ui/src/databases/handlers.rs
@@ -4,8 +4,8 @@ use crate::{
     SearchParameters,
     databases::error::{DatabasesAPIError, DatabasesResult},
     databases::models::{
-        Database, DatabaseCreatePayload, DatabaseCreateResponse, DatabaseResponse,
-        DatabaseUpdatePayload, DatabaseUpdateResponse, DatabasesResponse, TimestampedDatabase,
+        Database, DatabaseCreatePayload, DatabaseCreateResponse, DatabasePayload, DatabaseResponse,
+        DatabaseUpdatePayload, DatabaseUpdateResponse, DatabasesResponse,
     },
     downcast_string_column,
     error::ErrorResponse,
@@ -37,9 +37,10 @@ use validator::Validate;
             DatabaseCreateResponse,
             DatabaseResponse,
             DatabasesResponse,
+            DatabasePayload,
             Database,
-            TimestampedDatabase,
             ErrorResponse,
+            OrderDirection,
         )
     ),
     tags(
@@ -245,7 +246,7 @@ pub async fn list_databases(
         let updated_at_timestamps = downcast_string_column(&record, "updated_at")
             .map_err(|e| DatabasesAPIError::List { source: e })?;
         for i in 0..record.num_rows() {
-            items.push(TimestampedDatabase {
+            items.push(Database {
                 name: database_names.value(i).to_string(),
                 volume: volume_names.value(i).to_string(),
                 created_at: created_at_timestamps.value(i).to_string(),

--- a/crates/api-ui/src/databases/handlers.rs
+++ b/crates/api-ui/src/databases/handlers.rs
@@ -86,11 +86,7 @@ pub async fn create_database(
         .create_database(&database.ident.clone(), database)
         .await
         .map_err(|e| DatabasesAPIError::Create { source: e })
-        .map(|o| {
-            Json(DatabaseCreateResponse {
-                data: o.data.into(),
-            })
-        })
+        .map(|o| Json(DatabaseCreateResponse { data: o.into() }))
 }
 
 #[utoipa::path(
@@ -197,11 +193,7 @@ pub async fn update_database(
         .update_database(&database_name, database)
         .await
         .map_err(|e| DatabasesAPIError::Update { source: e })
-        .map(|o| {
-            Json(DatabaseUpdateResponse {
-                data: o.data.into(),
-            })
-        })
+        .map(|o| Json(DatabaseUpdateResponse { data: o.into() }))
 }
 
 #[utoipa::path(

--- a/crates/api-ui/src/databases/models.rs
+++ b/crates/api-ui/src/databases/models.rs
@@ -7,8 +7,6 @@ use utoipa::ToSchema;
 pub struct Database {
     pub name: String,
     pub volume: String,
-    pub created_at: String,
-    pub updated_at: String,
 }
 
 impl From<MetastoreDatabase> for Database {
@@ -16,14 +14,28 @@ impl From<MetastoreDatabase> for Database {
         Self {
             name: db.ident,
             volume: db.volume,
-            //TODO: fix this, we must use a different payload or change the test suite for dbs
-            created_at: "ERROR".to_string(),
-            updated_at: "ERROR".to_string(),
         }
     }
 }
 
-impl From<RwObject<MetastoreDatabase>> for Database {
+impl From<TimestampedDatabase> for Database {
+    fn from(db: TimestampedDatabase) -> Self {
+        Self {
+            name: db.name.clone(),
+            volume: db.volume,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
+pub struct TimestampedDatabase {
+    pub name: String,
+    pub volume: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<RwObject<MetastoreDatabase>> for TimestampedDatabase {
     fn from(db: RwObject<MetastoreDatabase>) -> Self {
         Self {
             name: db.data.ident,
@@ -79,11 +91,11 @@ pub struct DatabaseUpdateResponse {
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseResponse {
     #[serde(flatten)]
-    pub data: Database,
+    pub data: TimestampedDatabase,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabasesResponse {
-    pub items: Vec<Database>,
+    pub items: Vec<TimestampedDatabase>,
 }

--- a/crates/api-ui/src/databases/models.rs
+++ b/crates/api-ui/src/databases/models.rs
@@ -77,14 +77,14 @@ pub struct DatabaseUpdatePayload {
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseCreateResponse {
     #[serde(flatten)]
-    pub data: Database,
+    pub data: TimestampedDatabase,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseUpdateResponse {
     #[serde(flatten)]
-    pub data: Database,
+    pub data: TimestampedDatabase,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/api-ui/src/databases/models.rs
+++ b/crates/api-ui/src/databases/models.rs
@@ -4,12 +4,12 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
-pub struct Database {
+pub struct DatabasePayload {
     pub name: String,
     pub volume: String,
 }
 
-impl From<MetastoreDatabase> for Database {
+impl From<MetastoreDatabase> for DatabasePayload {
     fn from(db: MetastoreDatabase) -> Self {
         Self {
             name: db.ident,
@@ -18,8 +18,8 @@ impl From<MetastoreDatabase> for Database {
     }
 }
 
-impl From<TimestampedDatabase> for Database {
-    fn from(db: TimestampedDatabase) -> Self {
+impl From<Database> for DatabasePayload {
+    fn from(db: Database) -> Self {
         Self {
             name: db.name.clone(),
             volume: db.volume,
@@ -28,14 +28,14 @@ impl From<TimestampedDatabase> for Database {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
-pub struct TimestampedDatabase {
+pub struct Database {
     pub name: String,
     pub volume: String,
     pub created_at: String,
     pub updated_at: String,
 }
 
-impl From<RwObject<MetastoreDatabase>> for TimestampedDatabase {
+impl From<RwObject<MetastoreDatabase>> for Database {
     fn from(db: RwObject<MetastoreDatabase>) -> Self {
         Self {
             name: db.data.ident,
@@ -48,7 +48,7 @@ impl From<RwObject<MetastoreDatabase>> for TimestampedDatabase {
 
 // TODO: Remove it when found why it can't locate .into() if only From trait implemeted
 #[allow(clippy::from_over_into)]
-impl Into<MetastoreDatabase> for Database {
+impl Into<MetastoreDatabase> for DatabasePayload {
     fn into(self) -> MetastoreDatabase {
         MetastoreDatabase {
             ident: self.name,
@@ -62,7 +62,7 @@ impl Into<MetastoreDatabase> for Database {
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseCreatePayload {
     #[serde(flatten)]
-    pub data: Database,
+    pub data: DatabasePayload,
 }
 
 // TODO: make Database fields optional in update payload, not used currently
@@ -70,32 +70,32 @@ pub struct DatabaseCreatePayload {
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseUpdatePayload {
     #[serde(flatten)]
-    pub data: Database,
+    pub data: DatabasePayload,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseCreateResponse {
     #[serde(flatten)]
-    pub data: TimestampedDatabase,
+    pub data: Database,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseUpdateResponse {
     #[serde(flatten)]
-    pub data: TimestampedDatabase,
+    pub data: Database,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabaseResponse {
     #[serde(flatten)]
-    pub data: TimestampedDatabase,
+    pub data: Database,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DatabasesResponse {
-    pub items: Vec<TimestampedDatabase>,
+    pub items: Vec<Database>,
 }

--- a/crates/api-ui/src/schemas/handlers.rs
+++ b/crates/api-ui/src/schemas/handlers.rs
@@ -179,7 +179,7 @@ pub async fn get_schema(
     };
     match state.metastore.get_schema(&schema_ident).await {
         Ok(Some(rw_object)) => Ok(Json(SchemaResponse {
-            data: TimestampedSchema::from(rw_object),
+            data: rw_object.into(),
         })),
         Ok(None) => Err(SchemasAPIError::Get {
             source: MetastoreError::SchemaNotFound {

--- a/crates/api-ui/src/schemas/handlers.rs
+++ b/crates/api-ui/src/schemas/handlers.rs
@@ -94,7 +94,7 @@ pub async fn create_schema(
     let schema_ident = MetastoreSchemaIdent::new(database_name.clone(), payload.name.clone());
     match state.metastore.get_schema(&schema_ident).await {
         Ok(Some(rw_object)) => Ok(Json(SchemaCreateResponse {
-            data: rw_object.data.into(),
+            data: rw_object.into(),
         })),
         Ok(None) => Err(SchemasAPIError::Get {
             source: MetastoreError::SchemaNotFound {
@@ -228,7 +228,7 @@ pub async fn update_schema(
         .map_err(|e| SchemasAPIError::Update { source: e })
         .map(|rw_object| {
             Json(SchemaUpdateResponse {
-                data: rw_object.data.into(),
+                data: rw_object.into(),
             })
         })
 }

--- a/crates/api-ui/src/schemas/handlers.rs
+++ b/crates/api-ui/src/schemas/handlers.rs
@@ -5,8 +5,8 @@ use crate::{
     error::ErrorResponse,
     schemas::error::{SchemasAPIError, SchemasResult},
     schemas::models::{
-        Schema, SchemaCreatePayload, SchemaCreateResponse, SchemaResponse, SchemaUpdatePayload,
-        SchemaUpdateResponse, SchemasResponse, TimestampedSchema,
+        Schema, SchemaCreatePayload, SchemaCreateResponse, SchemaPayload, SchemaResponse,
+        SchemaUpdatePayload, SchemaUpdateResponse, SchemasResponse,
     },
 };
 use api_sessions::DFSessionId;
@@ -36,9 +36,10 @@ use utoipa::OpenApi;
             SchemaCreatePayload,
             SchemaCreateResponse,
             SchemasResponse,
+            SchemaPayload,
             Schema,
-            TimestampedSchema,
             ErrorResponse,
+            OrderDirection,
         )
     ),
     tags(
@@ -287,7 +288,7 @@ pub async fn list_schemas(
         let updated_at_timestamps = downcast_string_column(&record, "updated_at")
             .map_err(|e| SchemasAPIError::List { source: e })?;
         for i in 0..record.num_rows() {
-            items.push(TimestampedSchema {
+            items.push(Schema {
                 name: schema_names.value(i).to_string(),
                 database: database_names.value(i).to_string(),
                 created_at: created_at_timestamps.value(i).to_string(),

--- a/crates/api-ui/src/schemas/models.rs
+++ b/crates/api-ui/src/schemas/models.rs
@@ -5,14 +5,14 @@ use std::convert::From;
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-pub struct TimestampedSchema {
+pub struct Schema {
     pub name: String,
     pub database: String,
     pub created_at: String,
     pub updated_at: String,
 }
 
-impl From<RwObject<MetastoreSchema>> for TimestampedSchema {
+impl From<RwObject<MetastoreSchema>> for Schema {
     fn from(rw_schema: RwObject<MetastoreSchema>) -> Self {
         Self {
             name: rw_schema.data.ident.schema,
@@ -24,12 +24,12 @@ impl From<RwObject<MetastoreSchema>> for TimestampedSchema {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-pub struct Schema {
+pub struct SchemaPayload {
     pub name: String,
     pub database: String,
 }
 
-impl From<MetastoreSchema> for Schema {
+impl From<MetastoreSchema> for SchemaPayload {
     fn from(rw_schema: MetastoreSchema) -> Self {
         Self {
             name: rw_schema.ident.schema,
@@ -40,7 +40,7 @@ impl From<MetastoreSchema> for Schema {
 
 // TODO: Remove it when found why it can't locate .into() if only From trait implemeted
 #[allow(clippy::from_over_into)]
-impl Into<MetastoreSchema> for Schema {
+impl Into<MetastoreSchema> for SchemaPayload {
     fn into(self) -> MetastoreSchema {
         MetastoreSchema {
             ident: MetastoreSchemaIdent {
@@ -62,32 +62,32 @@ pub struct SchemaCreatePayload {
 #[serde(rename_all = "camelCase")]
 pub struct SchemaUpdatePayload {
     #[serde(flatten)]
-    pub data: Schema,
+    pub data: SchemaPayload,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaUpdateResponse {
     #[serde(flatten)]
-    pub data: TimestampedSchema,
+    pub data: Schema,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaCreateResponse {
     #[serde(flatten)]
-    pub data: TimestampedSchema,
+    pub data: Schema,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaResponse {
     #[serde(flatten)]
-    pub data: TimestampedSchema,
+    pub data: Schema,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemasResponse {
-    pub items: Vec<TimestampedSchema>,
+    pub items: Vec<Schema>,
 }

--- a/crates/api-ui/src/schemas/models.rs
+++ b/crates/api-ui/src/schemas/models.rs
@@ -5,20 +5,35 @@ use std::convert::From;
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-pub struct Schema {
+pub struct TimestampedSchema {
     pub name: String,
     pub database: String,
     pub created_at: String,
     pub updated_at: String,
 }
 
-impl From<RwObject<MetastoreSchema>> for Schema {
+impl From<RwObject<MetastoreSchema>> for TimestampedSchema {
     fn from(rw_schema: RwObject<MetastoreSchema>) -> Self {
         Self {
             name: rw_schema.data.ident.schema,
             database: rw_schema.data.ident.database,
             created_at: rw_schema.created_at.to_string(),
             updated_at: rw_schema.updated_at.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct Schema {
+    pub name: String,
+    pub database: String,
+}
+
+impl From<MetastoreSchema> for Schema {
+    fn from(rw_schema: MetastoreSchema) -> Self {
+        Self {
+            name: rw_schema.ident.schema,
+            database: rw_schema.ident.database,
         }
     }
 }
@@ -68,11 +83,11 @@ pub struct SchemaCreateResponse {
 #[serde(rename_all = "camelCase")]
 pub struct SchemaResponse {
     #[serde(flatten)]
-    pub data: Schema,
+    pub data: TimestampedSchema,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemasResponse {
-    pub items: Vec<Schema>,
+    pub items: Vec<TimestampedSchema>,
 }

--- a/crates/api-ui/src/schemas/models.rs
+++ b/crates/api-ui/src/schemas/models.rs
@@ -69,14 +69,14 @@ pub struct SchemaUpdatePayload {
 #[serde(rename_all = "camelCase")]
 pub struct SchemaUpdateResponse {
     #[serde(flatten)]
-    pub data: Schema,
+    pub data: TimestampedSchema,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaCreateResponse {
     #[serde(flatten)]
-    pub data: Schema,
+    pub data: TimestampedSchema,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]

--- a/crates/api-ui/src/tables/handlers.rs
+++ b/crates/api-ui/src/tables/handlers.rs
@@ -5,11 +5,14 @@ use crate::tables::error::{
     TablesAPIError, TablesResult,
 };
 use crate::tables::models::{
-    TableColumn, TableColumnsResponse, TablePreviewDataColumn, TablePreviewDataParameters,
+    Table, TableColumn, TableColumnsResponse, TablePreviewDataColumn, TablePreviewDataParameters,
     TablePreviewDataResponse, TablePreviewDataRow, TableStatistics, TableStatisticsResponse,
-    TableUploadPayload, TableUploadResponse, TablesResponse, TimestampedTable, UploadParameters,
+    TableUploadPayload, TableUploadResponse, TablesResponse, UploadParameters,
 };
-use crate::{SearchParameters, apply_parameters, downcast_int64_column, downcast_string_column};
+use crate::{
+    OrderDirection, SearchParameters, apply_parameters, downcast_int64_column,
+    downcast_string_column,
+};
 use api_sessions::DFSessionId;
 use axum::extract::Query;
 use axum::{
@@ -49,6 +52,8 @@ use utoipa::OpenApi;
             TableUploadResponse,
             TablesResponse,
             ErrorResponse,
+            OrderDirection,
+            Table,
         )
     ),
     tags(
@@ -356,9 +361,11 @@ pub async fn upload_file(
     params(
         ("databaseName" = String, description = "Database Name"),
         ("schemaName" = String, description = "Schema Name"),
-        ("cursor" = Option<String>, Query, description = "Tables cursor"),
+        ("offset" = Option<usize>, Query, description = "Tables offset"),
         ("limit" = Option<usize>, Query, description = "Tables limit"),
-        ("search" = Option<String>, Query, description = "Tables search (start with)"),
+        ("search" = Option<String>, Query, description = "Tables search"),
+        ("order_by" = Option<String>, Query, description = "Order by: table_name (default), schema_name, database_name, volume_name, table_type, table_format, owner, created_at, updated_at"),
+        ("order_direction" = Option<OrderDirection>, Query, description = "Order direction: ASC, DESC (default)"),
     ),
     operation_id = "getTables",
     tags = ["tables"],
@@ -429,7 +436,7 @@ pub async fn get_tables(
         let updated_at_timestamps = downcast_string_column(&record, "updated_at")
             .map_err(|e| TablesAPIError::Execution { source: e })?;
         for i in 0..record.num_rows() {
-            items.push(TimestampedTable {
+            items.push(Table {
                 name: table_names.value(i).to_string(),
                 schema_name: schema_names.value(i).to_string(),
                 database_name: database_names.value(i).to_string(),

--- a/crates/api-ui/src/tables/handlers.rs
+++ b/crates/api-ui/src/tables/handlers.rs
@@ -5,9 +5,9 @@ use crate::tables::error::{
     TablesAPIError, TablesResult,
 };
 use crate::tables::models::{
-    Table, TableColumn, TableColumnsResponse, TablePreviewDataColumn, TablePreviewDataParameters,
+    TableColumn, TableColumnsResponse, TablePreviewDataColumn, TablePreviewDataParameters,
     TablePreviewDataResponse, TablePreviewDataRow, TableStatistics, TableStatisticsResponse,
-    TableUploadPayload, TableUploadResponse, TablesResponse, UploadParameters,
+    TableUploadPayload, TableUploadResponse, TablesResponse, TimestampedTable, UploadParameters,
 };
 use crate::{SearchParameters, apply_parameters, downcast_int64_column, downcast_string_column};
 use api_sessions::DFSessionId;
@@ -429,7 +429,7 @@ pub async fn get_tables(
         let updated_at_timestamps = downcast_string_column(&record, "updated_at")
             .map_err(|e| TablesAPIError::Execution { source: e })?;
         for i in 0..record.num_rows() {
-            items.push(Table {
+            items.push(TimestampedTable {
                 name: table_names.value(i).to_string(),
                 schema_name: schema_names.value(i).to_string(),
                 database_name: database_names.value(i).to_string(),

--- a/crates/api-ui/src/tables/models.rs
+++ b/crates/api-ui/src/tables/models.rs
@@ -138,11 +138,11 @@ impl Into<Format> for UploadParameters {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TablesResponse {
-    pub items: Vec<Table>,
+    pub items: Vec<TimestampedTable>,
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct Table {
+pub struct TimestampedTable {
     pub name: String,
     pub schema_name: String,
     pub database_name: String,

--- a/crates/api-ui/src/tables/models.rs
+++ b/crates/api-ui/src/tables/models.rs
@@ -138,11 +138,11 @@ impl Into<Format> for UploadParameters {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TablesResponse {
-    pub items: Vec<TimestampedTable>,
+    pub items: Vec<Table>,
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct TimestampedTable {
+pub struct Table {
     pub name: String,
     pub schema_name: String,
     pub database_name: String,

--- a/crates/api-ui/src/tests/dashboard.rs
+++ b/crates/api-ui/src/tests/dashboard.rs
@@ -9,8 +9,8 @@ use crate::tests::common::{Entity, Op, ui_test_op};
 use crate::tests::server::run_test_server;
 use crate::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse};
 use crate::worksheets::models::{WorksheetCreatePayload, WorksheetResponse};
+use core_metastore::VolumeType as MetastoreVolumeType;
 use core_metastore::{Database as MetastoreDatabase, Volume as MetastoreVolume};
-use core_metastore::{RwObject, VolumeType as MetastoreVolumeType};
 use http::Method;
 use serde_json::json;
 
@@ -46,35 +46,35 @@ async fn test_ui_dashboard() {
 
     // Create database, Ok
     let expected1 = DatabaseCreatePayload {
-        data: RwObject::new(MetastoreDatabase {
+        data: MetastoreDatabase {
             ident: "test1".to_string(),
             properties: None,
             volume: volume.data.name.clone(),
-        })
+        }
         .into(),
     };
     let expected2 = DatabaseCreatePayload {
-        data: RwObject::new(MetastoreDatabase {
+        data: MetastoreDatabase {
             ident: "test2".to_string(),
             properties: None,
             volume: volume.data.name.clone(),
-        })
+        }
         .into(),
     };
     let expected3 = DatabaseCreatePayload {
-        data: RwObject::new(MetastoreDatabase {
+        data: MetastoreDatabase {
             ident: "test3".to_string(),
             properties: None,
             volume: volume.data.name.clone(),
-        })
+        }
         .into(),
     };
     let expected4 = DatabaseCreatePayload {
-        data: RwObject::new(MetastoreDatabase {
+        data: MetastoreDatabase {
             ident: "test4".to_string(),
             properties: None,
             volume: volume.data.name.clone(),
-        })
+        }
         .into(),
     };
     //4 DBs

--- a/crates/api-ui/src/tests/dashboard.rs
+++ b/crates/api-ui/src/tests/dashboard.rs
@@ -7,7 +7,7 @@ use crate::schemas::models::SchemaCreatePayload;
 use crate::tests::common::req;
 use crate::tests::common::{Entity, Op, ui_test_op};
 use crate::tests::server::run_test_server;
-use crate::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse};
+use crate::volumes::models::{VolumeCreatePayload, VolumeCreateResponse, VolumePayload};
 use crate::worksheets::models::{WorksheetCreatePayload, WorksheetResponse};
 use core_metastore::VolumeType as MetastoreVolumeType;
 use core_metastore::{Database as MetastoreDatabase, Volume as MetastoreVolume};
@@ -35,7 +35,7 @@ async fn test_ui_dashboard() {
         Op::Create,
         None,
         &Entity::Volume(VolumeCreatePayload {
-            data: Volume::from(MetastoreVolume {
+            data: VolumePayload::from(MetastoreVolume {
                 ident: String::new(),
                 volume: MetastoreVolumeType::Memory,
             }),

--- a/crates/api-ui/src/tests/databases.rs
+++ b/crates/api-ui/src/tests/databases.rs
@@ -6,7 +6,7 @@ use crate::databases::models::{
 use crate::error::ErrorResponse;
 use crate::tests::common::{Entity, Op, req, ui_test_op};
 use crate::tests::server::run_test_server;
-use crate::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse};
+use crate::volumes::models::{VolumeCreatePayload, VolumeCreateResponse, VolumePayload};
 use core_metastore::VolumeType as MetastoreVolumeType;
 use core_metastore::{Database as MetastoreDatabase, Volume as MetastoreVolume};
 use http::Method;
@@ -25,7 +25,7 @@ async fn test_ui_databases_metastore_update_bug() {
         Op::Create,
         None,
         &Entity::Volume(VolumeCreatePayload {
-            data: Volume::from(MetastoreVolume {
+            data: VolumePayload::from(MetastoreVolume {
                 ident: String::from("t"),
                 volume: MetastoreVolumeType::Memory,
             }),
@@ -129,7 +129,7 @@ async fn test_ui_databases() {
         Op::Create,
         None,
         &Entity::Volume(VolumeCreatePayload {
-            data: Volume::from(MetastoreVolume {
+            data: VolumePayload::from(MetastoreVolume {
                 ident: String::new(),
                 volume: MetastoreVolumeType::Memory,
             }),

--- a/crates/api-ui/src/tests/databases.rs
+++ b/crates/api-ui/src/tests/databases.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use crate::databases::models::{DatabaseCreatePayload, DatabaseResponse, DatabasesResponse};
+use crate::databases::models::{
+    DatabaseCreatePayload, DatabaseCreateResponse, DatabaseUpdateResponse, DatabasesResponse,
+};
 use crate::error::ErrorResponse;
 use crate::tests::common::{Entity, Op, req, ui_test_op};
 use crate::tests::server::run_test_server;
@@ -47,7 +49,7 @@ async fn test_ui_databases_metastore_update_bug() {
     let res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected.clone())).await;
     assert_eq!(http::StatusCode::OK, res.status());
     let created_database = res
-        .json::<DatabaseResponse>()
+        .json::<DatabaseCreateResponse>()
         .await
         .expect("Failed to create database");
     assert_eq!(expected.data.name, created_database.data.name);
@@ -73,7 +75,7 @@ async fn test_ui_databases_metastore_update_bug() {
     .await;
     assert_eq!(http::StatusCode::OK, res.status());
     let renamed_database = res
-        .json::<DatabaseResponse>()
+        .json::<DatabaseUpdateResponse>()
         .await
         .expect("Failed to update database");
     assert_eq!(new_database.data.name, renamed_database.data.name); // server confirmed it's renamed
@@ -103,7 +105,7 @@ async fn test_ui_databases_metastore_update_bug() {
         Op::Get,
         None,
         &Entity::Database(DatabaseCreatePayload {
-            data: renamed_database.data.clone(),
+            data: renamed_database.data,
         }),
     )
     .await;
@@ -169,7 +171,7 @@ async fn test_ui_databases() {
     };
     let res = ui_test_op(addr, Op::Create, None, &Entity::Database(expected1.clone())).await;
     assert_eq!(http::StatusCode::OK, res.status());
-    let created_database = res.json::<DatabaseResponse>().await.unwrap();
+    let created_database = res.json::<DatabaseCreateResponse>().await.unwrap();
     assert_eq!(expected1.data.name, created_database.data.name);
     assert_eq!(expected1.data.volume, created_database.data.volume);
 
@@ -213,7 +215,7 @@ async fn test_ui_databases() {
         addr,
         Op::Delete,
         Some(&Entity::Database(DatabaseCreatePayload {
-            data: created_database.data.clone(),
+            data: created_database.data,
         })),
         &stub,
     )

--- a/crates/api-ui/src/tests/databases.rs
+++ b/crates/api-ui/src/tests/databases.rs
@@ -68,7 +68,7 @@ async fn test_ui_databases_metastore_update_bug() {
         addr,
         Op::Update,
         Some(&Entity::Database(DatabaseCreatePayload {
-            data: created_database.data.clone(),
+            data: created_database.data.clone().into(),
         })),
         &Entity::Database(new_database.clone()),
     )
@@ -87,7 +87,7 @@ async fn test_ui_databases_metastore_update_bug() {
         Op::Get,
         None,
         &Entity::Database(DatabaseCreatePayload {
-            data: created_database.data.clone(),
+            data: created_database.data.into(),
         }),
     )
     .await;
@@ -105,7 +105,7 @@ async fn test_ui_databases_metastore_update_bug() {
         Op::Get,
         None,
         &Entity::Database(DatabaseCreatePayload {
-            data: renamed_database.data,
+            data: renamed_database.data.into(),
         }),
     )
     .await;
@@ -215,7 +215,7 @@ async fn test_ui_databases() {
         addr,
         Op::Delete,
         Some(&Entity::Database(DatabaseCreatePayload {
-            data: created_database.data,
+            data: created_database.data.into(),
         })),
         &stub,
     )

--- a/crates/api-ui/src/tests/navigation_trees.rs
+++ b/crates/api-ui/src/tests/navigation_trees.rs
@@ -7,7 +7,7 @@ use crate::schemas::models::SchemaCreatePayload;
 use crate::tests::common::req;
 use crate::tests::common::{Entity, Op, ui_test_op};
 use crate::tests::server::run_test_server;
-use crate::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse};
+use crate::volumes::models::{VolumeCreatePayload, VolumeCreateResponse, VolumePayload};
 use crate::worksheets::models::{WorksheetCreatePayload, WorksheetResponse};
 use core_metastore::VolumeType as MetastoreVolumeType;
 use core_metastore::{Database as MetastoreDatabase, Volume as MetastoreVolume};
@@ -32,7 +32,7 @@ async fn test_ui_databases_navigation() {
         Op::Create,
         None,
         &Entity::Volume(VolumeCreatePayload {
-            data: Volume::from(MetastoreVolume {
+            data: VolumePayload::from(MetastoreVolume {
                 ident: String::new(),
                 volume: MetastoreVolumeType::Memory,
             }),

--- a/crates/api-ui/src/tests/schemas.rs
+++ b/crates/api-ui/src/tests/schemas.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use crate::databases::models::{Database, DatabaseCreatePayload};
+use crate::databases::models::{DatabaseCreatePayload, DatabasePayload};
 use crate::schemas::models::{SchemaCreatePayload, SchemasResponse};
 use crate::tests::common::{Entity, Op, req, ui_test_op};
 use crate::tests::server::run_test_server;
-use crate::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse};
+use crate::volumes::models::{VolumeCreatePayload, VolumeCreateResponse, VolumePayload};
 use core_metastore::{
     Database as MetastoreDatabase, Volume as MetastoreVolume, VolumeType as MetastoreVolumeType,
 };
@@ -23,7 +23,7 @@ async fn test_ui_schemas() {
         Op::Create,
         None,
         &Entity::Volume(VolumeCreatePayload {
-            data: Volume::from(MetastoreVolume {
+            data: VolumePayload::from(MetastoreVolume {
                 ident: String::new(),
                 volume: MetastoreVolumeType::Memory,
             }),
@@ -44,7 +44,7 @@ async fn test_ui_schemas() {
         Op::Create,
         None,
         &Entity::Database(DatabaseCreatePayload {
-            data: Database::from(expected1.clone()),
+            data: DatabasePayload::from(expected1.clone()),
         }),
     )
     .await;

--- a/crates/api-ui/src/tests/volumes.rs
+++ b/crates/api-ui/src/tests/volumes.rs
@@ -27,7 +27,7 @@ async fn test_ui_volumes() {
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     assert_eq!(200, res.status());
     let created = res.json::<VolumeCreateResponse>().await.unwrap();
-    assert_eq!(expected.data, created.data);
+    assert_eq!(expected.data.name, created.data.name);
 
     // memory volume with empty ident create Ok
     let payload = r#"{"name":"embucket2","type": "file", "path":"/tmp/data"}"#;
@@ -36,7 +36,7 @@ async fn test_ui_volumes() {
     // let res = create_test_volume(addr, &expected).await;
     assert_eq!(200, res.status());
     let created = res.json::<VolumeCreateResponse>().await.unwrap();
-    assert_eq!(expected.data, created.data);
+    assert_eq!(expected.data.name, created.data.name);
 
     let expected = VolumeCreatePayload {
         data: Volume::from(MetastoreVolume {
@@ -71,7 +71,7 @@ async fn test_ui_volumes() {
     // let res = create_test_volume(addr, &expected).await;
     assert_eq!(200, res.status());
     let created = res.json::<VolumeCreateResponse>().await.unwrap();
-    assert_eq!(expected.data, created.data);
+    assert_eq!(expected.data.name, created.data.name);
 
     //Get list volumes
     let res = req(
@@ -134,7 +134,7 @@ async fn test_ui_volumes() {
     let res = ui_test_op(addr, Op::Create, None, &Entity::Volume(expected.clone())).await;
     assert_eq!(200, res.status());
     let created = res.json::<VolumeCreateResponse>().await.unwrap();
-    assert_eq!(expected.data, created.data);
+    assert_eq!(expected.data.name, created.data.name);
 
     //Get list volumes
     let res = req(

--- a/crates/api-ui/src/tests/volumes.rs
+++ b/crates/api-ui/src/tests/volumes.rs
@@ -2,7 +2,9 @@
 
 use crate::tests::common::{Entity, Op, req, ui_test_op};
 use crate::tests::server::run_test_server;
-use crate::volumes::models::{Volume, VolumeCreatePayload, VolumeCreateResponse, VolumesResponse};
+use crate::volumes::models::{
+    VolumeCreatePayload, VolumeCreateResponse, VolumePayload, VolumesResponse,
+};
 use core_metastore::Volume as MetastoreVolume;
 use core_metastore::{
     AwsAccessKeyCredentials, AwsCredentials, FileVolume as MetastoreFileVolume,
@@ -19,7 +21,7 @@ async fn test_ui_volumes() {
 
     // memory volume with empty ident create Ok
     let expected = VolumeCreatePayload {
-        data: Volume::from(MetastoreVolume {
+        data: VolumePayload::from(MetastoreVolume {
             ident: "embucket1".to_string(),
             volume: MetastoreVolumeType::Memory,
         }),
@@ -39,7 +41,7 @@ async fn test_ui_volumes() {
     assert_eq!(expected.data.name, created.data.name);
 
     let expected = VolumeCreatePayload {
-        data: Volume::from(MetastoreVolume {
+        data: VolumePayload::from(MetastoreVolume {
             ident: "embucket2".to_string(),
             volume: MetastoreVolumeType::File(MetastoreFileVolume {
                 path: "/tmp/data".to_string(),
@@ -52,7 +54,7 @@ async fn test_ui_volumes() {
 
     // memory volume with empty ident create Ok
     let expected = VolumeCreatePayload {
-        data: Volume::from(MetastoreVolume {
+        data: VolumePayload::from(MetastoreVolume {
             ident: "embucket3".to_string(),
             volume: MetastoreVolumeType::S3(MetastoreS3Volume {
                 region: Some("us-west-1".to_string()),
@@ -126,7 +128,7 @@ async fn test_ui_volumes() {
 
     //Create a volume with diffrent name
     let expected = VolumeCreatePayload {
-        data: Volume::from(MetastoreVolume {
+        data: VolumePayload::from(MetastoreVolume {
             ident: "icebucket1".to_string(),
             volume: MetastoreVolumeType::Memory,
         }),

--- a/crates/api-ui/src/volumes/handlers.rs
+++ b/crates/api-ui/src/volumes/handlers.rs
@@ -94,11 +94,7 @@ pub async fn create_volume(
         .create_volume(&embucket_volume.ident.clone(), embucket_volume)
         .await
         .map_err(|e| VolumesAPIError::Create { source: e })
-        .map(|o| {
-            Json(VolumeCreateResponse {
-                data: o.data.into(),
-            })
-        })
+        .map(|o| Json(VolumeCreateResponse { data: o.into() }))
 }
 
 #[utoipa::path(
@@ -208,11 +204,7 @@ pub async fn update_volume(
         .update_volume(&volume_name, volume)
         .await
         .map_err(|e| VolumesAPIError::Update { source: e })
-        .map(|o| {
-            Json(VolumeUpdateResponse {
-                data: o.data.into(),
-            })
-        })
+        .map(|o| Json(VolumeUpdateResponse { data: o.into() }))
 }
 
 #[utoipa::path(

--- a/crates/api-ui/src/volumes/handlers.rs
+++ b/crates/api-ui/src/volumes/handlers.rs
@@ -4,9 +4,9 @@ use crate::{
     error::ErrorResponse,
     volumes::error::{VolumesAPIError, VolumesResult},
     volumes::models::{
-        FileVolume, S3TablesVolume, S3Volume, TimestampedVolume, Volume, VolumeCreatePayload,
-        VolumeCreateResponse, VolumeResponse, VolumeType, VolumeUpdatePayload,
-        VolumeUpdateResponse, VolumesResponse,
+        FileVolume, S3TablesVolume, S3Volume, Volume, VolumeCreatePayload, VolumeCreateResponse,
+        VolumePayload, VolumeResponse, VolumeType, VolumeUpdatePayload, VolumeUpdateResponse,
+        VolumesResponse,
     },
 };
 use api_sessions::DFSessionId;
@@ -34,8 +34,8 @@ use validator::Validate;
         schemas(
             VolumeCreatePayload,
             VolumeCreateResponse,
+            VolumePayload,
             Volume,
-            TimestampedVolume,
             VolumeType,
             S3Volume,
             S3TablesVolume,
@@ -45,6 +45,7 @@ use validator::Validate;
             VolumeResponse,
             VolumesResponse,
             ErrorResponse,
+            OrderDirection,
         )
     ),
     tags(
@@ -255,7 +256,7 @@ pub async fn list_volumes(
         let updated_at_timestamps = downcast_string_column(&record, "updated_at")
             .map_err(|e| VolumesAPIError::List { source: e })?;
         for i in 0..record.num_rows() {
-            items.push(TimestampedVolume {
+            items.push(Volume {
                 name: volume_names.value(i).to_string(),
                 r#type: volume_types.value(i).to_string(),
                 created_at: created_at_timestamps.value(i).to_string(),

--- a/crates/api-ui/src/volumes/handlers.rs
+++ b/crates/api-ui/src/volumes/handlers.rs
@@ -4,7 +4,7 @@ use crate::{
     error::ErrorResponse,
     volumes::error::{VolumesAPIError, VolumesResult},
     volumes::models::{
-        FileVolume, S3TablesVolume, S3Volume, SimpleVolume, Volume, VolumeCreatePayload,
+        FileVolume, S3TablesVolume, S3Volume, TimestampedVolume, Volume, VolumeCreatePayload,
         VolumeCreateResponse, VolumeResponse, VolumeType, VolumeUpdatePayload,
         VolumeUpdateResponse, VolumesResponse,
     },
@@ -35,7 +35,7 @@ use validator::Validate;
             VolumeCreatePayload,
             VolumeCreateResponse,
             Volume,
-            SimpleVolume,
+            TimestampedVolume,
             VolumeType,
             S3Volume,
             S3TablesVolume,
@@ -263,7 +263,7 @@ pub async fn list_volumes(
         let updated_at_timestamps = downcast_string_column(&record, "updated_at")
             .map_err(|e| VolumesAPIError::List { source: e })?;
         for i in 0..record.num_rows() {
-            items.push(SimpleVolume {
+            items.push(TimestampedVolume {
                 name: volume_names.value(i).to_string(),
                 r#type: volume_types.value(i).to_string(),
                 created_at: created_at_timestamps.value(i).to_string(),

--- a/crates/api-ui/src/volumes/models.rs
+++ b/crates/api-ui/src/volumes/models.rs
@@ -41,13 +41,13 @@ pub enum VolumeType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Eq, PartialEq)]
-pub struct Volume {
+pub struct VolumePayload {
     pub name: String,
     #[serde(flatten)]
     pub volume: VolumeType,
 }
 
-impl From<MetastoreVolume> for Volume {
+impl From<MetastoreVolume> for VolumePayload {
     fn from(volume: MetastoreVolume) -> Self {
         Self {
             name: volume.ident,
@@ -77,7 +77,7 @@ impl From<MetastoreVolume> for Volume {
 
 // TODO: Remove it when found why it can't locate .into() if only From trait implemeted
 #[allow(clippy::from_over_into)]
-impl Into<MetastoreVolume> for Volume {
+impl Into<MetastoreVolume> for VolumePayload {
     fn into(self) -> MetastoreVolume {
         MetastoreVolume {
             ident: self.name,
@@ -113,47 +113,47 @@ impl Into<MetastoreVolume> for Volume {
 #[serde(rename_all = "camelCase")]
 pub struct VolumeCreatePayload {
     #[serde(flatten)]
-    pub data: Volume,
+    pub data: VolumePayload,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumeUpdatePayload {
     #[serde(flatten)]
-    pub data: Volume,
+    pub data: VolumePayload,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumeCreateResponse {
     #[serde(flatten)]
-    pub data: TimestampedVolume,
+    pub data: Volume,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumeUpdateResponse {
     #[serde(flatten)]
-    pub data: TimestampedVolume,
+    pub data: Volume,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumeResponse {
     #[serde(flatten)]
-    pub data: TimestampedVolume,
+    pub data: Volume,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct TimestampedVolume {
+pub struct Volume {
     pub name: String,
     pub r#type: String,
     pub created_at: String,
     pub updated_at: String,
 }
 
-impl From<RwObject<MetastoreVolume>> for TimestampedVolume {
+impl From<RwObject<MetastoreVolume>> for Volume {
     fn from(value: RwObject<MetastoreVolume>) -> Self {
         Self {
             name: value.data.ident,
@@ -167,5 +167,5 @@ impl From<RwObject<MetastoreVolume>> for TimestampedVolume {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumesResponse {
-    pub items: Vec<TimestampedVolume>,
+    pub items: Vec<Volume>,
 }

--- a/crates/api-ui/src/volumes/models.rs
+++ b/crates/api-ui/src/volumes/models.rs
@@ -141,19 +141,19 @@ pub struct VolumeUpdateResponse {
 #[serde(rename_all = "camelCase")]
 pub struct VolumeResponse {
     #[serde(flatten)]
-    pub data: SimpleVolume,
+    pub data: TimestampedVolume,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SimpleVolume {
+pub struct TimestampedVolume {
     pub name: String,
     pub r#type: String,
     pub created_at: String,
     pub updated_at: String,
 }
 
-impl From<RwObject<MetastoreVolume>> for SimpleVolume {
+impl From<RwObject<MetastoreVolume>> for TimestampedVolume {
     fn from(value: RwObject<MetastoreVolume>) -> Self {
         Self {
             name: value.data.ident,
@@ -167,5 +167,5 @@ impl From<RwObject<MetastoreVolume>> for SimpleVolume {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumesResponse {
-    pub items: Vec<SimpleVolume>,
+    pub items: Vec<TimestampedVolume>,
 }

--- a/crates/api-ui/src/volumes/models.rs
+++ b/crates/api-ui/src/volumes/models.rs
@@ -127,14 +127,14 @@ pub struct VolumeUpdatePayload {
 #[serde(rename_all = "camelCase")]
 pub struct VolumeCreateResponse {
     #[serde(flatten)]
-    pub data: Volume,
+    pub data: TimestampedVolume,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct VolumeUpdateResponse {
     #[serde(flatten)]
-    pub data: Volume,
+    pub data: TimestampedVolume,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
Closes #851 & #848

- Implemented `From<>` trait for both `Metastore` structs and `RwObject<>`
- There are now `Timestamped` variants of the previous structs (`SimpleVolume` renamed) for schemas, tables & databases
- As was discussed, we decided to change only the get and list handlers to return such structs
- Create & Update (which is not used right now) is unchanged