### PR TITLE
Add MetastoreObjectType enum for object type handling in Metastore

### DIFF
--- a/crates/core-metastore/src/metastore.rs
+++ b/crates/core-metastore/src/metastore.rs
@@ -16,24 +16,15 @@ use object_store::{ObjectStore, PutPayload, path::Path};
 use serde::de::DeserializeOwned;
 use snafu::ResultExt;
 use uuid::Uuid;
+use strum::Display;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
+#[strum(serialize_all = "lowercase")]
 pub enum MetastoreObjectType {
     Volume,
     Database,
     Schema,
     Table,
-}
-
-impl MetastoreObjectType {
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Volume => "volume",
-            Self::Database => "database",
-            Self::Schema => "schema",
-            Self::Table => "table",
-        }
-    }
 }
 
 #[async_trait]
@@ -190,7 +181,7 @@ impl SlateDBMetastore {
             Ok(rwobject)
         } else {
             Err(metastore_error::MetastoreError::ObjectAlreadyExists {
-                type_name: object_type.as_str().to_owned(),
+                type_name: object_type.to_string(),
                 name: key.to_string(),
             })
         }

--- a/crates/core-metastore/src/metastore.rs
+++ b/crates/core-metastore/src/metastore.rs
@@ -15,8 +15,8 @@ use iceberg_rust_spec::table_metadata::{FormatVersion, TableMetadataBuilder};
 use object_store::{ObjectStore, PutPayload, path::Path};
 use serde::de::DeserializeOwned;
 use snafu::ResultExt;
-use uuid::Uuid;
 use strum::Display;
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
 #[strum(serialize_all = "lowercase")]
@@ -349,7 +349,8 @@ impl Metastore for SlateDBMetastore {
             },
         )?;
         let key = format!("{KEY_DATABASE}/{name}");
-        self.create_object(&key, MetastoreObjectType::Database, database).await
+        self.create_object(&key, MetastoreObjectType::Database, database)
+            .await
     }
 
     async fn get_database(
@@ -406,7 +407,8 @@ impl Metastore for SlateDBMetastore {
     ) -> MetastoreResult<RwObject<Schema>> {
         let key = format!("{KEY_SCHEMA}/{}/{}", ident.database, ident.schema);
         if self.get_database(&ident.database).await?.is_some() {
-            self.create_object(&key, MetastoreObjectType::Schema, schema).await
+            self.create_object(&key, MetastoreObjectType::Schema, schema)
+                .await
         } else {
             Err(metastore_error::MetastoreError::DatabaseNotFound {
                 db: ident.database.clone(),
@@ -555,7 +557,9 @@ impl Metastore for SlateDBMetastore {
                 is_temporary: table.is_temporary.unwrap_or_default(),
                 format: table_format,
             };
-            let rwo_table = self.create_object(&key, MetastoreObjectType::Table, table.clone()).await?;
+            let rwo_table = self
+                .create_object(&key, MetastoreObjectType::Table, table.clone())
+                .await?;
 
             let object_store = self.table_object_store(ident).await?.ok_or(
                 metastore_error::MetastoreError::TableObjectStoreNotFound {


### PR DESCRIPTION
Introduce a new enum:
`MetastoreObjectType`:  to represent different types of metastore objects (Volume, Database, Schema, Table). 

Updated the `create_object` method to accept this enum instead of a string, enhancing type safety and clarity in object creation across the `Metastore` implementation.