### PR TITLE
Add current_session()

### DIFF
--- a/crates/core-executor/src/datafusion/rewriters/session_context.rs
+++ b/crates/core-executor/src/datafusion/rewriters/session_context.rs
@@ -1,7 +1,7 @@
 use datafusion::arrow::array::{ListArray, ListBuilder, StringBuilder};
 use datafusion::logical_expr::{Expr, LogicalPlan};
+use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
 use datafusion_common::{Result, ScalarValue};
-use datafusion_expr::expr::Alias;
 use std::sync::Arc;
 
 pub struct SessionContextExprRewriter {
@@ -9,56 +9,16 @@ pub struct SessionContextExprRewriter {
     pub schema: String,
     pub schemas: Vec<String>,
     pub warehouse: String,
+    pub session_id: String,
 }
 
 impl SessionContextExprRewriter {
     fn rewrite_expr(&self, expr: Expr) -> Expr {
-        match expr {
-            Expr::Alias(alias) => {
-                let rewritten_inner = self.rewrite_expr(*alias.expr);
-                Expr::Alias(Alias {
-                    expr: Box::new(rewritten_inner),
-                    relation: alias.relation,
-                    name: alias.name,
-                    metadata: alias.metadata,
-                })
-            }
-            Expr::ScalarFunction(fun) if fun.name().to_lowercase() == "current_database" => {
-                Expr::Literal(self.database.clone().into()).alias(fun.name())
-            }
-            Expr::ScalarFunction(fun) if fun.name().to_lowercase() == "current_schema" => {
-                Expr::Literal(self.schema.clone().into()).alias(fun.name())
-            }
-            Expr::ScalarFunction(fun) if fun.name().to_lowercase() == "current_schemas" => {
-                let mut builder = ListBuilder::new(StringBuilder::new());
-                let values_builder = builder.values();
-
-                for schema in &self.schemas {
-                    values_builder.append_value(schema);
-                }
-                builder.append(true);
-                let list_scalar = ScalarValue::List(Arc::new(ListArray::from(builder.finish())));
-                Expr::Literal(list_scalar).alias(fun.name())
-            }
-            Expr::ScalarFunction(fun) if fun.name().to_lowercase() == "current_warehouse" => {
-                Expr::Literal(self.warehouse.clone().into()).alias(fun.name())
-            }
-            Expr::ScalarFunction(fun) if fun.name().to_lowercase() == "current_role_type" => {
-                Expr::Literal("ROLE".into()).alias(fun.name())
-            }
-            Expr::ScalarFunction(fun) if fun.name().to_lowercase() == "current_role" => {
-                Expr::Literal("default".into()).alias(fun.name())
-            }
-            Expr::ScalarFunction(fun) if fun.name().to_lowercase() == "current_version" => {
-                let version = env!("CARGO_PKG_VERSION");
-                Expr::Literal(version.into()).alias(fun.name())
-            }
-            Expr::ScalarFunction(fun) if fun.name().to_lowercase() == "current_client" => {
-                let version = format!("Embucket {}", env!("CARGO_PKG_VERSION"));
-                Expr::Literal(version.into()).alias(fun.name())
-            }
-            _ => expr,
-        }
+        let mut rewriter = ExprRewriter { ctx: self };
+        expr.clone()
+            .rewrite(&mut rewriter)
+            .map(|t| t.data)
+            .unwrap_or(expr)
     }
 
     pub fn rewrite_plan(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
@@ -73,5 +33,59 @@ impl SessionContextExprRewriter {
             .map(|p| (*p).clone())
             .collect::<Vec<_>>();
         plan.with_new_exprs(new_exprs, inputs)
+    }
+}
+struct ExprRewriter<'a> {
+    ctx: &'a SessionContextExprRewriter,
+}
+
+impl TreeNodeRewriter for ExprRewriter<'_> {
+    type Node = Expr;
+
+    fn f_up(&mut self, expr: Expr) -> Result<Transformed<Expr>> {
+        let replacement = match &expr {
+            Expr::ScalarFunction(fun) => {
+                let name = fun.name().to_lowercase();
+                let value = match name.as_str() {
+                    "current_database" => Some(ScalarValue::Utf8(Some(self.ctx.database.clone()))),
+                    "current_schema" => Some(ScalarValue::Utf8(Some(self.ctx.schema.clone()))),
+                    "current_warehouse" => {
+                        Some(ScalarValue::Utf8(Some(self.ctx.warehouse.clone())))
+                    }
+                    "current_role_type" => Some(ScalarValue::Utf8(Some("ROLE".to_string()))),
+                    "current_role" => Some(ScalarValue::Utf8(Some("default".to_string()))),
+                    "current_version" => Some(ScalarValue::Utf8(Some(
+                        env!("CARGO_PKG_VERSION").to_string(),
+                    ))),
+                    "current_client" => Some(ScalarValue::Utf8(Some(format!(
+                        "Embucket {}",
+                        env!("CARGO_PKG_VERSION")
+                    )))),
+                    "current_session" => {
+                        Some(ScalarValue::Utf8(Some(self.ctx.session_id.to_string())))
+                    }
+                    "current_schemas" => {
+                        let mut builder = ListBuilder::new(StringBuilder::new());
+                        let values_builder = builder.values();
+                        for schema in &self.ctx.schemas {
+                            values_builder.append_value(schema);
+                        }
+                        builder.append(true);
+                        let array = builder.finish();
+                        Some(ScalarValue::List(Arc::new(ListArray::from(array))))
+                    }
+                    _ => None,
+                };
+
+                if let Some(val) = value {
+                    Ok(Transformed::yes(Expr::Literal(val).alias(fun.name())))
+                } else {
+                    Ok(Transformed::no(expr))
+                }
+            }
+            _ => Ok(Transformed::no(expr)),
+        };
+
+        replacement
     }
 }

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -177,6 +177,7 @@ impl UserQuery {
             schema: self.current_schema(),
             schemas,
             warehouse: "default".to_string(),
+            session_id: self.session.ctx.session_id(),
         }
     }
 

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -565,6 +565,12 @@ test_query!(
     "SELECT CURRENT_ROLE_TYPE(), CURRENT_ROLE()",
     snapshot_path = "session"
 );
+test_query!(
+    session_current_session,
+    // Check only length of session id since it is dynamic uuid
+    "SELECT length(CURRENT_SESSION())",
+    snapshot_path = "session"
+);
 
 // TRUNCATE TABLE
 test_query!(truncate_table, "TRUNCATE TABLE employee_table");

--- a/crates/core-executor/src/tests/snapshots/session/query_session_current_session.snap
+++ b/crates/core-executor/src/tests/snapshots/session/query_session_current_session.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT length(CURRENT_SESSION())\""
+snapshot_kind: text
+---
+Ok(
+    [
+        "+-----------------------------------+",
+        "| character_length(current_session) |",
+        "+-----------------------------------+",
+        "| 36                                |",
+        "+-----------------------------------+",
+    ],
+)

--- a/crates/df-builtins/src/session/mod.rs
+++ b/crates/df-builtins/src/session/mod.rs
@@ -74,6 +74,11 @@ fn current_role_udf() -> ScalarUDF {
     create_session_context_udf!("current_role", "default")
 }
 
+/// Returns a unique system identifier for the Embucket session corresponding to the present connection.
+fn current_session_udf() -> ScalarUDF {
+    create_session_context_udf!("current_session", "default")
+}
+
 pub fn register_session_context_udfs(registry: &mut dyn FunctionRegistry) -> Result<()> {
     registry.register_udf(current_database_udf().into())?;
     registry.register_udf(current_schema_udf().into())?;
@@ -83,5 +88,6 @@ pub fn register_session_context_udfs(registry: &mut dyn FunctionRegistry) -> Res
     registry.register_udf(current_client_udf().into())?;
     registry.register_udf(current_role_type_udf().into())?;
     registry.register_udf(current_role_udf().into())?;
+    registry.register_udf(current_session_udf().into())?;
     Ok(())
 }

--- a/crates/df-builtins/src/tests/query.rs
+++ b/crates/df-builtins/src/tests/query.rs
@@ -21,3 +21,8 @@ test_query!(
     "SELECT CURRENT_ROLE_TYPE(), CURRENT_ROLE()",
     snapshot_path = "session"
 );
+test_query!(
+    session_current_session,
+    "SELECT CURRENT_SESSION()",
+    snapshot_path = "session"
+);

--- a/crates/df-builtins/src/tests/snapshots/session/query_session_current_session.snap
+++ b/crates/df-builtins/src/tests/snapshots/session/query_session_current_session.snap
@@ -1,0 +1,14 @@
+---
+source: crates/df-builtins/src/tests/query.rs
+description: "\"SELECT CURRENT_SESSION()\""
+snapshot_kind: text
+---
+Ok(
+    [
+        "+-------------------+",
+        "| current_session() |",
+        "+-------------------+",
+        "| default           |",
+        "+-------------------+",
+    ],
+)


### PR DESCRIPTION
🛠 Pull Request: Add support for current_session() and improve plan rewriting

✨ Changes included:
- Added support for current_session() as a scalar UDF, enabling access to the current session UUID at query runtime.
- Implemented SessionContextExprRewriter to replace specific scalar function expressions (e.g., current_session, current_database, etc.) with corresponding session values during logical plan rewriting.
- Fixed an issue where scalar functions (like current_session) used within downstream expressions (e.g., LENGTH(current_session())) would return incorrect or empty results due to missing alias handling or improper expression substitution.
- Improved handling of Expr::Alias nodes to ensure correct rewriting of nested expressions while preserving metadata and naming.

✅ Example usage:
```sql
SELECT CURRENT_SESSION(), LENGTH(CURRENT_SESSION());
```
Now correctly returns the session UUID and its length (e.g., 36 for a UUID).

Closes #933 