### PR TITLE
add embucket query planner

### DIFF
--- a/crates/core-executor/src/datafusion/extension_planner.rs
+++ b/crates/core-executor/src/datafusion/extension_planner.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+use datafusion::physical_planner::ExtensionPlanner;
+
+#[derive(Debug, Default)]
+pub struct EmbucketExtensionPlanner {}
+
+#[async_trait]
+impl ExtensionPlanner for EmbucketExtensionPlanner {
+    async fn plan_extension(
+        &self,
+        _planner: &dyn datafusion::physical_planner::PhysicalPlanner,
+        _node: &dyn datafusion_expr::UserDefinedLogicalNode,
+        _logical_inputs: &[&datafusion_expr::LogicalPlan],
+        _physical_inputs: &[std::sync::Arc<dyn datafusion_physical_plan::ExecutionPlan>],
+        _session_state: &datafusion::execution::SessionState,
+    ) -> datafusion_common::Result<
+        Option<std::sync::Arc<dyn datafusion_physical_plan::ExecutionPlan>>,
+    > {
+        Ok(None)
+    }
+}

--- a/crates/core-executor/src/datafusion/extension_planner.rs
+++ b/crates/core-executor/src/datafusion/extension_planner.rs
@@ -2,10 +2,10 @@ use async_trait::async_trait;
 use datafusion::physical_planner::ExtensionPlanner;
 
 #[derive(Debug, Default)]
-pub struct EmbucketExtensionPlanner {}
+pub struct CustomExtensionPlanner {}
 
 #[async_trait]
-impl ExtensionPlanner for EmbucketExtensionPlanner {
+impl ExtensionPlanner for CustomExtensionPlanner {
     async fn plan_extension(
         &self,
         _planner: &dyn datafusion::physical_planner::PhysicalPlanner,

--- a/crates/core-executor/src/datafusion/mod.rs
+++ b/crates/core-executor/src/datafusion/mod.rs
@@ -2,8 +2,10 @@
 //pub mod error;
 pub mod analyzer;
 pub mod error;
+pub mod extension_planner;
 pub mod physical_optimizer;
 pub mod planner;
+pub mod query_planner;
 pub mod rewriters;
 pub mod type_planner;
 pub mod visitors;

--- a/crates/core-executor/src/datafusion/query_planner.rs
+++ b/crates/core-executor/src/datafusion/query_planner.rs
@@ -5,20 +5,20 @@ use datafusion::{
 };
 use std::{fmt, sync::Arc};
 
-use super::extension_planner::EmbucketExtensionPlanner;
+use super::extension_planner::CustomExtensionPlanner;
 
-pub struct EmbucketQueryPlanner(DefaultPhysicalPlanner);
+pub struct CustomQueryPlanner(DefaultPhysicalPlanner);
 
-impl Default for EmbucketQueryPlanner {
+impl Default for CustomQueryPlanner {
     fn default() -> Self {
         Self(DefaultPhysicalPlanner::with_extension_planners(vec![
-            Arc::new(EmbucketExtensionPlanner::default()),
+            Arc::new(CustomExtensionPlanner::default()),
         ]))
     }
 }
 
 #[async_trait]
-impl QueryPlanner for EmbucketQueryPlanner {
+impl QueryPlanner for CustomQueryPlanner {
     async fn create_physical_plan(
         &self,
         logical_plan: &datafusion_expr::LogicalPlan,
@@ -31,7 +31,7 @@ impl QueryPlanner for EmbucketQueryPlanner {
     }
 }
 
-impl fmt::Debug for EmbucketQueryPlanner {
+impl fmt::Debug for CustomQueryPlanner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "EmbucketQueryPlanner")
     }

--- a/crates/core-executor/src/datafusion/query_planner.rs
+++ b/crates/core-executor/src/datafusion/query_planner.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+use datafusion::{
+    execution::context::QueryPlanner,
+    physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner},
+};
+use std::{fmt, sync::Arc};
+
+use super::extension_planner::EmbucketExtensionPlanner;
+
+pub struct EmbucketQueryPlanner(DefaultPhysicalPlanner);
+
+impl Default for EmbucketQueryPlanner {
+    fn default() -> Self {
+        Self(DefaultPhysicalPlanner::with_extension_planners(vec![
+            Arc::new(EmbucketExtensionPlanner::default()),
+        ]))
+    }
+}
+
+#[async_trait]
+impl QueryPlanner for EmbucketQueryPlanner {
+    async fn create_physical_plan(
+        &self,
+        logical_plan: &datafusion_expr::LogicalPlan,
+        session_state: &datafusion::execution::SessionState,
+    ) -> datafusion_common::Result<std::sync::Arc<dyn datafusion_physical_plan::ExecutionPlan>>
+    {
+        self.0
+            .create_physical_plan(logical_plan, session_state)
+            .await
+    }
+}
+
+impl fmt::Debug for EmbucketQueryPlanner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "EmbucketQueryPlanner")
+    }
+}

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -10,6 +10,7 @@ use crate::datafusion::analyzer::IcebergTypesAnalyzer;
 // TODO: We need to fix this after geodatafusion is updated to datafusion 47
 //use geodatafusion::udf::native::register_native as register_geo_native;
 use crate::datafusion::physical_optimizer::physical_optimizer_rules;
+use crate::datafusion::query_planner::EmbucketQueryPlanner;
 use crate::models::QueryContext;
 use crate::query::UserQuery;
 use crate::utils::Config;
@@ -27,7 +28,6 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion::sql::planner::IdentNormalizer;
 use datafusion_functions_json::register_all as register_json_udfs;
 use datafusion_iceberg::catalog::catalog::IcebergCatalog as DataFusionIcebergCatalog;
-use datafusion_iceberg::planner::IcebergQueryPlanner;
 use df_builtins::register_udafs;
 use df_catalog::catalog_list::{DEFAULT_CATALOG, EmbucketCatalogList};
 use df_catalog::information_schema::session_params::{SessionParams, SessionProperty};
@@ -80,7 +80,7 @@ impl UserSession {
             .with_default_features()
             .with_runtime_env(Arc::new(runtime_config))
             .with_catalog_list(catalog_list_impl.clone())
-            .with_query_planner(Arc::new(IcebergQueryPlanner::new()))
+            .with_query_planner(Arc::new(EmbucketQueryPlanner::default()))
             .with_type_planner(Arc::new(CustomTypePlanner {}))
             .with_analyzer_rule(Arc::new(IcebergTypesAnalyzer {}))
             .with_physical_optimizer_rules(physical_optimizer_rules())

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -10,7 +10,7 @@ use crate::datafusion::analyzer::IcebergTypesAnalyzer;
 // TODO: We need to fix this after geodatafusion is updated to datafusion 47
 //use geodatafusion::udf::native::register_native as register_geo_native;
 use crate::datafusion::physical_optimizer::physical_optimizer_rules;
-use crate::datafusion::query_planner::EmbucketQueryPlanner;
+use crate::datafusion::query_planner::CustomQueryPlanner;
 use crate::models::QueryContext;
 use crate::query::UserQuery;
 use crate::utils::Config;
@@ -80,7 +80,7 @@ impl UserSession {
             .with_default_features()
             .with_runtime_env(Arc::new(runtime_config))
             .with_catalog_list(catalog_list_impl.clone())
-            .with_query_planner(Arc::new(EmbucketQueryPlanner::default()))
+            .with_query_planner(Arc::new(CustomQueryPlanner::default()))
             .with_type_planner(Arc::new(CustomTypePlanner {}))
             .with_analyzer_rule(Arc::new(IcebergTypesAnalyzer {}))
             .with_physical_optimizer_rules(physical_optimizer_rules())


### PR DESCRIPTION
This PR introduces a new "EmbucketQueryPlanner" which can be used in the future with custom embucket LogicalPlans and PhysicalPlans.

It currently doesn't provide much functionality but provides the basis for further developments.