### PR TITLE
History schema (Worksheets and Queries DF Views)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,7 @@ dependencies = [
  "aws-credential-types",
  "bytes",
  "chrono",
+ "core-history",
  "core-metastore",
  "core-utils",
  "dashmap",

--- a/crates/api-ui/src/databases/handlers.rs
+++ b/crates/api-ui/src/databases/handlers.rs
@@ -230,7 +230,7 @@ pub async fn list_databases(
     State(state): State<AppState>,
 ) -> DatabasesResult<Json<DatabasesResponse>> {
     let context = QueryContext::default();
-    let sql_string = "SELECT * FROM slatedb.public.databases".to_string();
+    let sql_string = "SELECT * FROM slatedb.meta.databases".to_string();
     let sql_string = apply_parameters(&sql_string, parameters, &["database_name", "volume_name"]);
     let QueryResult { records, .. } = state
         .execution_svc

--- a/crates/api-ui/src/schemas/handlers.rs
+++ b/crates/api-ui/src/schemas/handlers.rs
@@ -267,7 +267,7 @@ pub async fn list_schemas(
 ) -> SchemasResult<Json<SchemasResponse>> {
     let context = QueryContext::new(Some(database_name.clone()), None, None);
     let sql_string = format!(
-        "SELECT * FROM slatedb.public.schemas WHERE database_name = '{}'",
+        "SELECT * FROM slatedb.meta.schemas WHERE database_name = '{}'",
         database_name.clone()
     );
     let sql_string = apply_parameters(&sql_string, parameters, &["schema_name", "database_name"]);

--- a/crates/api-ui/src/tables/handlers.rs
+++ b/crates/api-ui/src/tables/handlers.rs
@@ -392,7 +392,7 @@ pub async fn get_tables(
 ) -> TablesResult<Json<TablesResponse>> {
     let context = QueryContext::new(Some(database_name.clone()), None, None);
     let sql_string = format!(
-        "SELECT * FROM slatedb.public.tables WHERE schema_name = '{}' AND database_name = '{}'",
+        "SELECT * FROM slatedb.meta.tables WHERE schema_name = '{}' AND database_name = '{}'",
         schema_name.clone(),
         database_name.clone()
     );

--- a/crates/api-ui/src/volumes/handlers.rs
+++ b/crates/api-ui/src/volumes/handlers.rs
@@ -237,7 +237,7 @@ pub async fn list_volumes(
     State(state): State<AppState>,
 ) -> VolumesResult<Json<VolumesResponse>> {
     let context = QueryContext::default();
-    let sql_string = "SELECT * FROM slatedb.public.volumes".to_string();
+    let sql_string = "SELECT * FROM slatedb.meta.volumes".to_string();
     let sql_string = apply_parameters(&sql_string, parameters, &["volume_name", "volume_type"]);
     let QueryResult { records, .. } = state
         .execution_svc

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -56,7 +56,7 @@ impl UserSession {
         let sql_parser_dialect =
             env::var("SQL_PARSER_DIALECT").unwrap_or_else(|_| "snowflake".to_string());
 
-        let catalog_list_impl = Arc::new(EmbucketCatalogList::new(metastore.clone()));
+        let catalog_list_impl = Arc::new(EmbucketCatalogList::new(metastore.clone(), history_store.clone()));
 
         let runtime_config = RuntimeEnvBuilder::new()
             .with_object_store_registry(catalog_list_impl.clone())

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -56,7 +56,10 @@ impl UserSession {
         let sql_parser_dialect =
             env::var("SQL_PARSER_DIALECT").unwrap_or_else(|_| "snowflake".to_string());
 
-        let catalog_list_impl = Arc::new(EmbucketCatalogList::new(metastore.clone(), history_store.clone()));
+        let catalog_list_impl = Arc::new(EmbucketCatalogList::new(
+            metastore.clone(),
+            history_store.clone(),
+        ));
 
         let runtime_config = RuntimeEnvBuilder::new()
             .with_object_store_registry(catalog_list_impl.clone())

--- a/crates/core-history/src/entities/query.rs
+++ b/crates/core-history/src/entities/query.rs
@@ -1,4 +1,3 @@
-use std::fmt::Display;
 use crate::WorksheetId;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -6,6 +5,7 @@ use core_utils::iterable::IterableEntity;
 #[cfg(test)]
 use mockall::automock;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -18,11 +18,11 @@ pub enum QueryStatus {
 impl Display for QueryStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            QueryStatus::Running => write!(f, "Running"),
-            QueryStatus::Successful => write!(f, "Successful"),
-            QueryStatus::Failed => write!(f, "Failed"),
+            Self::Running => write!(f, "Running"),
+            Self::Successful => write!(f, "Successful"),
+            Self::Failed => write!(f, "Failed"),
         }
-    }   
+    }
 }
 
 pub type QueryRecordId = i64;

--- a/crates/core-history/src/entities/query.rs
+++ b/crates/core-history/src/entities/query.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use crate::WorksheetId;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -12,6 +13,16 @@ pub enum QueryStatus {
     Running,
     Successful,
     Failed,
+}
+
+impl Display for QueryStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryStatus::Running => write!(f, "Running"),
+            QueryStatus::Successful => write!(f, "Successful"),
+            QueryStatus::Failed => write!(f, "Failed"),
+        }
+    }   
 }
 
 pub type QueryRecordId = i64;

--- a/crates/df-catalog/Cargo.toml
+++ b/crates/df-catalog/Cargo.toml
@@ -7,6 +7,7 @@ license-file.workspace = true
 [dependencies]
 core-utils = { path = "../core-utils" }
 core-metastore = { path = "../core-metastore" }
+core-history = { path = "../core-history" }
 async-trait = { workspace = true }
 aws-config = { workspace = true }
 aws-credential-types = { workspace = true }

--- a/crates/df-catalog/src/catalog_list.rs
+++ b/crates/df-catalog/src/catalog_list.rs
@@ -8,6 +8,7 @@ use crate::table::CachingTable;
 use aws_config::{BehaviorVersion, Region, SdkConfig};
 use aws_credential_types::Credentials;
 use aws_credential_types::provider::SharedCredentialsProvider;
+use core_history::HistoryStore;
 use core_metastore::{AwsCredentials, Metastore, VolumeType as MetastoreVolumeType};
 use core_utils::scan_iterator::ScanIterator;
 use dashmap::DashMap;
@@ -27,7 +28,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::interval;
 use url::Url;
-use core_history::HistoryStore;
 
 pub const DEFAULT_CATALOG: &str = "embucket";
 
@@ -101,8 +101,10 @@ impl EmbucketCatalogList {
 
     #[must_use]
     pub fn slatedb_catalog(&self) -> CachingCatalog {
-        let catalog: Arc<dyn CatalogProvider> =
-            Arc::new(SlateDBCatalog::new(self.metastore.clone(), self.history_store.clone()));
+        let catalog: Arc<dyn CatalogProvider> = Arc::new(SlateDBCatalog::new(
+            self.metastore.clone(),
+            self.history_store.clone(),
+        ));
         CachingCatalog::new(catalog, SLATEDB_CATALOG.to_string())
     }
 

--- a/crates/df-catalog/src/catalogs/slatedb/catalog.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/catalog.rs
@@ -1,19 +1,24 @@
-use crate::catalogs::slatedb::schema::SlateDBViewSchemaProvider;
+use crate::catalogs::slatedb::metastore_schema::MetastoreViewSchemaProvider;
 use core_metastore::Metastore;
 use datafusion::catalog::{CatalogProvider, SchemaProvider};
 use std::{any::Any, sync::Arc};
+use core_history::HistoryStore;
+use crate::catalogs::slatedb::history_store_schema::HistoryStoreViewSchemaProvider;
 
 pub const SLATEDB_CATALOG: &str = "slatedb";
-pub const SLATEDB_SCHEMA: &str = "public";
+pub const METASTORE_SCHEMA: &str = "meta";
+pub const HISTORY_STORE_SCHEMA: &str = "history";
+pub const SLATEDB_SCHEMAS: &[&str] = &[METASTORE_SCHEMA, HISTORY_STORE_SCHEMA];
 
 #[derive(Clone, Debug)]
 pub struct SlateDBCatalog {
     pub metastore: Arc<dyn Metastore>,
+    pub history_store: Arc<dyn HistoryStore>,
 }
 
 impl SlateDBCatalog {
-    pub fn new(metastore: Arc<dyn Metastore>) -> Self {
-        Self { metastore }
+    pub fn new(metastore: Arc<dyn Metastore>, history_store: Arc<dyn HistoryStore>) -> Self {
+        Self { metastore, history_store }
     }
 }
 
@@ -22,17 +27,18 @@ impl CatalogProvider for SlateDBCatalog {
         self
     }
 
-    fn schema_names(&self) -> Vec<String> {
-        vec![SLATEDB_SCHEMA.to_string()]
-    }
+    fn schema_names(&self) -> Vec<String> { SLATEDB_SCHEMAS.iter().map(ToString::to_string).collect() }
 
     #[allow(clippy::as_conversions)]
     fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
-        if name != SLATEDB_SCHEMA {
-            return None;
+        match name {
+            METASTORE_SCHEMA => Some(Arc::new(MetastoreViewSchemaProvider::new(Arc::clone(
+                &self.metastore,
+            )))),
+            HISTORY_STORE_SCHEMA => Some(Arc::new(HistoryStoreViewSchemaProvider::new(Arc::clone(
+                &self.history_store,
+            )))),
+            _ => None
         }
-        Some(Arc::new(SlateDBViewSchemaProvider::new(Arc::clone(
-            &self.metastore,
-        ))))
     }
 }

--- a/crates/df-catalog/src/catalogs/slatedb/catalog.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/catalog.rs
@@ -1,9 +1,9 @@
+use crate::catalogs::slatedb::history_store_schema::HistoryStoreViewSchemaProvider;
 use crate::catalogs::slatedb::metastore_schema::MetastoreViewSchemaProvider;
+use core_history::HistoryStore;
 use core_metastore::Metastore;
 use datafusion::catalog::{CatalogProvider, SchemaProvider};
 use std::{any::Any, sync::Arc};
-use core_history::HistoryStore;
-use crate::catalogs::slatedb::history_store_schema::HistoryStoreViewSchemaProvider;
 
 pub const SLATEDB_CATALOG: &str = "slatedb";
 pub const METASTORE_SCHEMA: &str = "meta";
@@ -18,7 +18,10 @@ pub struct SlateDBCatalog {
 
 impl SlateDBCatalog {
     pub fn new(metastore: Arc<dyn Metastore>, history_store: Arc<dyn HistoryStore>) -> Self {
-        Self { metastore, history_store }
+        Self {
+            metastore,
+            history_store,
+        }
     }
 }
 
@@ -27,7 +30,9 @@ impl CatalogProvider for SlateDBCatalog {
         self
     }
 
-    fn schema_names(&self) -> Vec<String> { SLATEDB_SCHEMAS.iter().map(ToString::to_string).collect() }
+    fn schema_names(&self) -> Vec<String> {
+        SLATEDB_SCHEMAS.iter().map(ToString::to_string).collect()
+    }
 
     #[allow(clippy::as_conversions)]
     fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
@@ -35,10 +40,10 @@ impl CatalogProvider for SlateDBCatalog {
             METASTORE_SCHEMA => Some(Arc::new(MetastoreViewSchemaProvider::new(Arc::clone(
                 &self.metastore,
             )))),
-            HISTORY_STORE_SCHEMA => Some(Arc::new(HistoryStoreViewSchemaProvider::new(Arc::clone(
-                &self.history_store,
-            )))),
-            _ => None
+            HISTORY_STORE_SCHEMA => Some(Arc::new(HistoryStoreViewSchemaProvider::new(
+                Arc::clone(&self.history_store),
+            ))),
+            _ => None,
         }
     }
 }

--- a/crates/df-catalog/src/catalogs/slatedb/databases.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/databases.rs
@@ -1,4 +1,4 @@
-use crate::catalogs::slatedb::config::SlateDBViewConfig;
+use crate::catalogs::slatedb::metastore_config::MetastoreViewConfig;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::{
     array::StringBuilder,
@@ -16,11 +16,11 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct DatabasesView {
     schema: SchemaRef,
-    config: SlateDBViewConfig,
+    config: MetastoreViewConfig,
 }
 
 impl DatabasesView {
-    pub(crate) fn new(config: SlateDBViewConfig) -> Self {
+    pub(crate) fn new(config: MetastoreViewConfig) -> Self {
         let schema = Arc::new(Schema::new(vec![
             Field::new("database_name", DataType::Utf8, false),
             Field::new("volume_name", DataType::Utf8, false),

--- a/crates/df-catalog/src/catalogs/slatedb/history_store_config.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/history_store_config.rs
@@ -1,8 +1,8 @@
-use datafusion_common::DataFusionError;
-use std::sync::Arc;
-use core_history::{GetQueriesParams, HistoryStore};
 use crate::catalogs::slatedb::queries::QueriesViewBuilder;
 use crate::catalogs::slatedb::worksheets::WorksheetsViewBuilder;
+use core_history::{GetQueriesParams, HistoryStore};
+use datafusion_common::DataFusionError;
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct HistoryStoreViewConfig {
@@ -15,11 +15,10 @@ impl HistoryStoreViewConfig {
         &self,
         builder: &mut WorksheetsViewBuilder,
     ) -> datafusion_common::Result<(), DataFusionError> {
-        let worksheets = self
-            .history_store
-            .get_worksheets()
-            .await
-            .map_err(|e| DataFusionError::Execution(format!("failed to get worksheets: {e}")))?;
+        let worksheets =
+            self.history_store.get_worksheets().await.map_err(|e| {
+                DataFusionError::Execution(format!("failed to get worksheets: {e}"))
+            })?;
         for worksheet in worksheets {
             builder.add_worksheet(
                 worksheet.id,
@@ -60,7 +59,7 @@ impl HistoryStoreViewConfig {
                 query.result_count,
                 query.result,
                 query.status.to_string(),
-                query.error
+                query.error,
             );
         }
         Ok(())

--- a/crates/df-catalog/src/catalogs/slatedb/history_store_config.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/history_store_config.rs
@@ -20,21 +20,7 @@ impl HistoryStoreViewConfig {
                 DataFusionError::Execution(format!("failed to get worksheets: {e}"))
             })?;
         for worksheet in worksheets {
-            builder.add_worksheet(
-                worksheet.id,
-                if worksheet.name.is_empty() {
-                    None
-                } else {
-                    Some(worksheet.name)
-                },
-                if worksheet.content.is_empty() {
-                    None
-                } else {
-                    Some(worksheet.content)
-                },
-                worksheet.created_at.to_string(),
-                worksheet.updated_at.to_string(),
-            );
+            builder.add_worksheet(worksheet);
         }
         Ok(())
     }
@@ -49,18 +35,7 @@ impl HistoryStoreViewConfig {
             .await
             .map_err(|e| DataFusionError::Execution(format!("failed to get queries: {e}")))?;
         for query in queries {
-            builder.add_query(
-                query.id,
-                query.worksheet_id,
-                query.query,
-                query.start_time.to_string(),
-                query.end_time.to_string(),
-                query.duration_ms,
-                query.result_count,
-                query.result,
-                query.status.to_string(),
-                query.error,
-            );
+            builder.add_query(query);
         }
         Ok(())
     }

--- a/crates/df-catalog/src/catalogs/slatedb/history_store_config.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/history_store_config.rs
@@ -1,0 +1,68 @@
+use datafusion_common::DataFusionError;
+use std::sync::Arc;
+use core_history::{GetQueriesParams, HistoryStore};
+use crate::catalogs::slatedb::queries::QueriesViewBuilder;
+use crate::catalogs::slatedb::worksheets::WorksheetsViewBuilder;
+
+#[derive(Clone, Debug)]
+pub struct HistoryStoreViewConfig {
+    pub database: String,
+    pub history_store: Arc<dyn HistoryStore>,
+}
+
+impl HistoryStoreViewConfig {
+    pub async fn make_worksheets(
+        &self,
+        builder: &mut WorksheetsViewBuilder,
+    ) -> datafusion_common::Result<(), DataFusionError> {
+        let worksheets = self
+            .history_store
+            .get_worksheets()
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("failed to get worksheets: {e}")))?;
+        for worksheet in worksheets {
+            builder.add_worksheet(
+                worksheet.id,
+                if worksheet.name.is_empty() {
+                    None
+                } else {
+                    Some(worksheet.name)
+                },
+                if worksheet.content.is_empty() {
+                    None
+                } else {
+                    Some(worksheet.content)
+                },
+                worksheet.created_at.to_string(),
+                worksheet.updated_at.to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn make_queries(
+        &self,
+        builder: &mut QueriesViewBuilder,
+    ) -> datafusion_common::Result<(), DataFusionError> {
+        let queries = self
+            .history_store
+            .get_queries(GetQueriesParams::default())
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("failed to get queries: {e}")))?;
+        for query in queries {
+            builder.add_query(
+                query.id,
+                query.worksheet_id,
+                query.query,
+                query.start_time.to_string(),
+                query.end_time.to_string(),
+                query.duration_ms,
+                query.result_count,
+                query.result,
+                query.status.to_string(),
+                query.error
+            );
+        }
+        Ok(())
+    }
+}

--- a/crates/df-catalog/src/catalogs/slatedb/history_store_schema.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/history_store_schema.rs
@@ -1,15 +1,15 @@
 use super::catalog::SLATEDB_CATALOG;
+use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
+use crate::catalogs::slatedb::queries::QueriesView;
+use crate::catalogs::slatedb::worksheets::WorksheetsView;
 use async_trait::async_trait;
+use core_history::HistoryStore;
 use datafusion::catalog::streaming::StreamingTable;
 use datafusion::catalog::{SchemaProvider, TableProvider};
 use datafusion_common::DataFusionError;
 use datafusion_physical_plan::streaming::PartitionStream;
 use std::any::Any;
 use std::sync::Arc;
-use core_history::HistoryStore;
-use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
-use crate::catalogs::slatedb::queries::QueriesView;
-use crate::catalogs::slatedb::worksheets::WorksheetsView;
 
 pub const WORKSHEETS: &str = "worksheets";
 pub const QUERIES: &str = "queries";
@@ -44,7 +44,10 @@ impl SchemaProvider for HistoryStoreViewSchemaProvider {
     }
 
     fn table_names(&self) -> Vec<String> {
-        HISTORY_STORE_VIEW_TABLES.iter().map(ToString::to_string).collect()
+        HISTORY_STORE_VIEW_TABLES
+            .iter()
+            .map(ToString::to_string)
+            .collect()
     }
 
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {

--- a/crates/df-catalog/src/catalogs/slatedb/history_store_schema.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/history_store_schema.rs
@@ -1,0 +1,67 @@
+use super::catalog::SLATEDB_CATALOG;
+use async_trait::async_trait;
+use datafusion::catalog::streaming::StreamingTable;
+use datafusion::catalog::{SchemaProvider, TableProvider};
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::streaming::PartitionStream;
+use std::any::Any;
+use std::sync::Arc;
+use core_history::HistoryStore;
+use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
+use crate::catalogs::slatedb::queries::QueriesView;
+use crate::catalogs::slatedb::worksheets::WorksheetsView;
+
+pub const WORKSHEETS: &str = "worksheets";
+pub const QUERIES: &str = "queries";
+pub const HISTORY_STORE_VIEW_TABLES: &[&str] = &[WORKSHEETS, QUERIES];
+
+pub struct HistoryStoreViewSchemaProvider {
+    config: HistoryStoreViewConfig,
+}
+
+impl HistoryStoreViewSchemaProvider {
+    pub fn new(history_store: Arc<dyn HistoryStore>) -> Self {
+        Self {
+            config: HistoryStoreViewConfig {
+                database: SLATEDB_CATALOG.to_string(),
+                history_store,
+            },
+        }
+    }
+}
+
+#[allow(clippy::missing_fields_in_debug)]
+impl std::fmt::Debug for HistoryStoreViewSchemaProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HistoryStoreSchema").finish()
+    }
+}
+
+#[async_trait]
+impl SchemaProvider for HistoryStoreViewSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        HISTORY_STORE_VIEW_TABLES.iter().map(ToString::to_string).collect()
+    }
+
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
+        let config = self.config.clone();
+        let table: Arc<dyn PartitionStream> = match name.to_ascii_lowercase().as_str() {
+            WORKSHEETS => Arc::new(WorksheetsView::new(config)),
+            QUERIES => Arc::new(QueriesView::new(config)),
+            _ => return Ok(None),
+        };
+
+        Ok(Some(Arc::new(StreamingTable::try_new(
+            Arc::clone(table.schema()),
+            vec![table],
+        )?)))
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        HISTORY_STORE_VIEW_TABLES.contains(&name.to_ascii_lowercase().as_str())
+    }
+}

--- a/crates/df-catalog/src/catalogs/slatedb/metastore_config.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/metastore_config.rs
@@ -8,12 +8,12 @@ use datafusion_common::DataFusionError;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
-pub struct SlateDBViewConfig {
+pub struct MetastoreViewConfig {
     pub database: String,
     pub metastore: Arc<dyn Metastore>,
 }
 
-impl SlateDBViewConfig {
+impl MetastoreViewConfig {
     pub async fn make_volumes(
         &self,
         builder: &mut VolumesViewBuilder,

--- a/crates/df-catalog/src/catalogs/slatedb/metastore_schema.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/metastore_schema.rs
@@ -1,6 +1,6 @@
 use super::catalog::SLATEDB_CATALOG;
-use crate::catalogs::slatedb::metastore_config::MetastoreViewConfig;
 use crate::catalogs::slatedb::databases::DatabasesView;
+use crate::catalogs::slatedb::metastore_config::MetastoreViewConfig;
 use crate::catalogs::slatedb::schemas::SchemasView;
 use crate::catalogs::slatedb::tables::TablesView;
 use crate::catalogs::slatedb::volumes::VolumesView;
@@ -49,7 +49,10 @@ impl SchemaProvider for MetastoreViewSchemaProvider {
     }
 
     fn table_names(&self) -> Vec<String> {
-        METASTORE_VIEW_TABLES.iter().map(ToString::to_string).collect()
+        METASTORE_VIEW_TABLES
+            .iter()
+            .map(ToString::to_string)
+            .collect()
     }
 
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {

--- a/crates/df-catalog/src/catalogs/slatedb/metastore_schema.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/metastore_schema.rs
@@ -1,5 +1,5 @@
 use super::catalog::SLATEDB_CATALOG;
-use crate::catalogs::slatedb::config::SlateDBViewConfig;
+use crate::catalogs::slatedb::metastore_config::MetastoreViewConfig;
 use crate::catalogs::slatedb::databases::DatabasesView;
 use crate::catalogs::slatedb::schemas::SchemasView;
 use crate::catalogs::slatedb::tables::TablesView;
@@ -18,16 +18,16 @@ pub const VOLUMES: &str = "volumes";
 pub const SCHEMAS: &str = "schemas";
 pub const TABLES: &str = "tables";
 
-pub const VIEW_TABLES: &[&str] = &[TABLES, SCHEMAS, DATABASES, VOLUMES];
+pub const METASTORE_VIEW_TABLES: &[&str] = &[TABLES, SCHEMAS, DATABASES, VOLUMES];
 
-pub struct SlateDBViewSchemaProvider {
-    config: SlateDBViewConfig,
+pub struct MetastoreViewSchemaProvider {
+    config: MetastoreViewConfig,
 }
 
-impl SlateDBViewSchemaProvider {
+impl MetastoreViewSchemaProvider {
     pub fn new(metastore: Arc<dyn Metastore>) -> Self {
         Self {
-            config: SlateDBViewConfig {
+            config: MetastoreViewConfig {
                 database: SLATEDB_CATALOG.to_string(),
                 metastore,
             },
@@ -36,20 +36,20 @@ impl SlateDBViewSchemaProvider {
 }
 
 #[allow(clippy::missing_fields_in_debug)]
-impl std::fmt::Debug for SlateDBViewSchemaProvider {
+impl std::fmt::Debug for MetastoreViewSchemaProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SlateDBSchema").finish()
+        f.debug_struct("MetastoreSchema").finish()
     }
 }
 
 #[async_trait]
-impl SchemaProvider for SlateDBViewSchemaProvider {
+impl SchemaProvider for MetastoreViewSchemaProvider {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
     fn table_names(&self) -> Vec<String> {
-        VIEW_TABLES.iter().map(ToString::to_string).collect()
+        METASTORE_VIEW_TABLES.iter().map(ToString::to_string).collect()
     }
 
     async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
@@ -69,6 +69,6 @@ impl SchemaProvider for SlateDBViewSchemaProvider {
     }
 
     fn table_exist(&self, name: &str) -> bool {
-        VIEW_TABLES.contains(&name.to_ascii_lowercase().as_str())
+        METASTORE_VIEW_TABLES.contains(&name.to_ascii_lowercase().as_str())
     }
 }

--- a/crates/df-catalog/src/catalogs/slatedb/mod.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/mod.rs
@@ -1,11 +1,11 @@
 pub mod catalog;
-pub mod metastore_config;
 pub mod databases;
+pub mod history_store_config;
+pub mod history_store_schema;
+pub mod metastore_config;
 pub mod metastore_schema;
+pub mod queries;
 pub mod schemas;
 pub mod tables;
 pub mod volumes;
-pub mod history_store_schema;
-pub mod history_store_config;
 pub mod worksheets;
-pub mod queries;

--- a/crates/df-catalog/src/catalogs/slatedb/mod.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/mod.rs
@@ -1,7 +1,11 @@
 pub mod catalog;
-pub mod config;
+pub mod metastore_config;
 pub mod databases;
-pub mod schema;
+pub mod metastore_schema;
 pub mod schemas;
 pub mod tables;
 pub mod volumes;
+pub mod history_store_schema;
+pub mod history_store_config;
+pub mod worksheets;
+pub mod queries;

--- a/crates/df-catalog/src/catalogs/slatedb/queries.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/queries.rs
@@ -1,4 +1,5 @@
 use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
+use core_history::QueryRecord;
 use datafusion::arrow::array::Int64Builder;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::{
@@ -91,30 +92,22 @@ pub struct QueriesViewBuilder {
 
 impl QueriesViewBuilder {
     #[allow(clippy::too_many_arguments)]
-    pub fn add_query(
-        &mut self,
-        query_id: i64,
-        worksheet_id: Option<i64>,
-        query: impl AsRef<str>,
-        start_time: impl AsRef<str>,
-        end_time: impl AsRef<str>,
-        duration_ms: i64,
-        result_count: i64,
-        result: Option<impl AsRef<str>>,
-        status: impl AsRef<str>,
-        error: Option<impl AsRef<str>>,
-    ) {
+    pub fn add_query(&mut self, query_record: QueryRecord) {
         // Note: append_value is actually infallible.
-        self.query_ids.append_value(query_id);
-        self.worksheet_ids.append_option(worksheet_id);
-        self.queries.append_value(query.as_ref());
-        self.start_time_timestamps.append_value(start_time.as_ref());
-        self.end_time_timestamps.append_value(end_time.as_ref());
-        self.duration_ms_values.append_value(duration_ms);
-        self.result_count_values.append_value(result_count);
-        self.results.append_option(result);
-        self.statuses.append_value(status.as_ref());
-        self.errors.append_option(error);
+        self.query_ids.append_value(query_record.id);
+        self.worksheet_ids.append_option(query_record.worksheet_id);
+        self.queries.append_value(query_record.query);
+        self.start_time_timestamps
+            .append_value(query_record.start_time.to_string());
+        self.end_time_timestamps
+            .append_value(query_record.end_time.to_string());
+        self.duration_ms_values
+            .append_value(query_record.duration_ms);
+        self.result_count_values
+            .append_value(query_record.result_count);
+        self.results.append_option(query_record.result);
+        self.statuses.append_value(query_record.status.to_string());
+        self.errors.append_option(query_record.error);
     }
 
     fn finish(&mut self) -> Result<RecordBatch, ArrowError> {

--- a/crates/df-catalog/src/catalogs/slatedb/queries.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/queries.rs
@@ -1,0 +1,137 @@
+use crate::catalogs::slatedb::metastore_config::MetastoreViewConfig;
+use datafusion::arrow::error::ArrowError;
+use datafusion::arrow::{
+    array::StringBuilder,
+    datatypes::{DataType, Field, Schema, SchemaRef},
+    record_batch::RecordBatch,
+};
+use datafusion::execution::TaskContext;
+use datafusion_common::DataFusionError;
+use datafusion_physical_plan::SendableRecordBatchStream;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::streaming::PartitionStream;
+use std::fmt::Debug;
+use std::sync::Arc;
+use datafusion::arrow::array::Int64Builder;
+use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
+
+#[derive(Debug)]
+pub struct QueriesView {
+    schema: SchemaRef,
+    config: HistoryStoreViewConfig,
+}
+
+impl QueriesView {
+    pub(crate) fn new(config: HistoryStoreViewConfig) -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("worksheet_id", DataType::Int64, true),
+            Field::new("query", DataType::Utf8, false),
+            Field::new("start_time", DataType::Utf8, false),
+            Field::new("end_time", DataType::Utf8, false),
+            Field::new("duration_ms", DataType::Int64, false),
+            Field::new("result_count", DataType::Int64, false),
+            Field::new("result", DataType::Utf8, true),
+            Field::new("status", DataType::Utf8, false),
+            Field::new("error", DataType::Utf8, true),
+        ]));
+
+        Self { schema, config }
+    }
+
+    fn builder(&self) -> QueriesViewBuilder {
+        QueriesViewBuilder {
+            query_ids: Int64Builder::new(),
+            worksheet_ids: Int64Builder::new(),
+            queries: StringBuilder::new(),
+            start_time_timestamps: StringBuilder::new(),
+            end_time_timestamps: StringBuilder::new(),
+            duration_ms_values: Int64Builder::new(),
+            result_count_values: Int64Builder::new(),
+            results: StringBuilder::new(),
+            statuses: StringBuilder::new(),
+            errors: StringBuilder::new(),
+            schema: Arc::clone(&self.schema),
+        }
+    }
+}
+
+impl PartitionStream for QueriesView {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut builder = self.builder();
+        let config = self.config.clone();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            futures::stream::once(async move {
+                config.make_queries(&mut builder).await?;
+                builder
+                    .finish()
+                    .map_err(|e| DataFusionError::ArrowError(e, None))
+            }),
+        ))
+    }
+}
+
+pub struct QueriesViewBuilder {
+    schema: SchemaRef,
+    query_ids: Int64Builder,
+    worksheet_ids: Int64Builder,
+    queries: StringBuilder,
+    start_time_timestamps: StringBuilder,
+    end_time_timestamps: StringBuilder,
+    duration_ms_values: Int64Builder,
+    result_count_values: Int64Builder,
+    results: StringBuilder,
+    statuses: StringBuilder,
+    errors: StringBuilder,
+}
+
+impl QueriesViewBuilder {
+    pub fn add_query(
+        &mut self,
+        query_id: i64,
+        worksheet_id: Option<i64>,
+        query: impl AsRef<str>,
+        start_time: impl AsRef<str>,
+        end_time: impl AsRef<str>,
+        duration_ms: i64,
+        result_count: i64,
+        result: Option<impl AsRef<str>>,
+        status: impl AsRef<str>,
+        error: Option<impl AsRef<str>>,
+    ) {
+        // Note: append_value is actually infallible.
+        self.query_ids.append_value(query_id);
+        self.worksheet_ids.append_option(worksheet_id);
+        self.queries.append_value(query.as_ref());
+        self.start_time_timestamps.append_value(start_time.as_ref());
+        self.end_time_timestamps.append_value(end_time.as_ref());
+        self.duration_ms_values.append_value(duration_ms);
+        self.result_count_values.append_value(result_count);
+        self.results.append_option(result);
+        self.statuses.append_value(status.as_ref());
+        self.errors.append_option(error);
+    }
+
+    fn finish(&mut self) -> Result<RecordBatch, ArrowError> {
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(self.query_ids.finish()),
+                Arc::new(self.worksheet_ids.finish()),
+                Arc::new(self.queries.finish()),
+                Arc::new(self.start_time_timestamps.finish()),
+                Arc::new(self.end_time_timestamps.finish()),
+                Arc::new(self.duration_ms_values.finish()),
+                Arc::new(self.result_count_values.finish()),
+                Arc::new(self.results.finish()),
+                Arc::new(self.statuses.finish()),
+                Arc::new(self.errors.finish()),
+            ],
+        )
+    }
+}

--- a/crates/df-catalog/src/catalogs/slatedb/queries.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/queries.rs
@@ -1,4 +1,5 @@
-use crate::catalogs::slatedb::metastore_config::MetastoreViewConfig;
+use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
+use datafusion::arrow::array::Int64Builder;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::{
     array::StringBuilder,
@@ -12,8 +13,6 @@ use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::streaming::PartitionStream;
 use std::fmt::Debug;
 use std::sync::Arc;
-use datafusion::arrow::array::Int64Builder;
-use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
 
 #[derive(Debug)]
 pub struct QueriesView {
@@ -91,6 +90,7 @@ pub struct QueriesViewBuilder {
 }
 
 impl QueriesViewBuilder {
+    #[allow(clippy::too_many_arguments)]
     pub fn add_query(
         &mut self,
         query_id: i64,

--- a/crates/df-catalog/src/catalogs/slatedb/tables.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/tables.rs
@@ -1,4 +1,4 @@
-use crate::catalogs::slatedb::config::SlateDBViewConfig;
+use crate::catalogs::slatedb::metastore_config::MetastoreViewConfig;
 use datafusion::arrow::array::Int64Builder;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::{
@@ -17,11 +17,11 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct TablesView {
     schema: SchemaRef,
-    config: SlateDBViewConfig,
+    config: MetastoreViewConfig,
 }
 
 impl TablesView {
-    pub(crate) fn new(config: SlateDBViewConfig) -> Self {
+    pub(crate) fn new(config: MetastoreViewConfig) -> Self {
         let schema = Arc::new(Schema::new(vec![
             Field::new("table_name", DataType::Utf8, false),
             Field::new("schema_name", DataType::Utf8, false),

--- a/crates/df-catalog/src/catalogs/slatedb/volumes.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/volumes.rs
@@ -1,4 +1,4 @@
-use crate::catalogs::slatedb::config::SlateDBViewConfig;
+use crate::catalogs::slatedb::metastore_config::MetastoreViewConfig;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::{
     array::StringBuilder,
@@ -16,11 +16,11 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct VolumesView {
     schema: SchemaRef,
-    config: SlateDBViewConfig,
+    config: MetastoreViewConfig,
 }
 
 impl VolumesView {
-    pub(crate) fn new(config: SlateDBViewConfig) -> Self {
+    pub(crate) fn new(config: MetastoreViewConfig) -> Self {
         let schema = Arc::new(Schema::new(vec![
             Field::new("volume_name", DataType::Utf8, false),
             Field::new("volume_type", DataType::Utf8, false),

--- a/crates/df-catalog/src/catalogs/slatedb/worksheets.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/worksheets.rs
@@ -1,4 +1,5 @@
 use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
+use core_history::Worksheet;
 use datafusion::arrow::array::Int64Builder;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::{
@@ -75,20 +76,25 @@ pub struct WorksheetsViewBuilder {
 }
 
 impl WorksheetsViewBuilder {
-    pub fn add_worksheet(
-        &mut self,
-        worksheet_id: i64,
-        worksheet_name: Option<impl AsRef<str>>,
-        content: Option<impl AsRef<str>>,
-        created_at: impl AsRef<str>,
-        updated_at: impl AsRef<str>,
-    ) {
+    pub fn add_worksheet(&mut self, worksheet: Worksheet) {
         // Note: append_value is actually infallible.
-        self.worksheet_ids.append_value(worksheet_id);
-        self.worksheet_names.append_option(worksheet_name);
-        self.content_values.append_option(content);
-        self.created_at_timestamps.append_value(created_at.as_ref());
-        self.updated_at_timestamps.append_value(updated_at.as_ref());
+        self.worksheet_ids.append_value(worksheet.id);
+        self.worksheet_names
+            .append_option(if worksheet.name.is_empty() {
+                None
+            } else {
+                Some(worksheet.name)
+            });
+        self.content_values
+            .append_option(if worksheet.content.is_empty() {
+                None
+            } else {
+                Some(worksheet.content)
+            });
+        self.created_at_timestamps
+            .append_value(worksheet.created_at.to_string());
+        self.updated_at_timestamps
+            .append_value(worksheet.updated_at.to_string());
     }
 
     fn finish(&mut self) -> Result<RecordBatch, ArrowError> {

--- a/crates/df-catalog/src/catalogs/slatedb/worksheets.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/worksheets.rs
@@ -1,4 +1,3 @@
-use crate::catalogs::slatedb::metastore_config::MetastoreViewConfig;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::{
     array::StringBuilder,
@@ -12,18 +11,21 @@ use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::streaming::PartitionStream;
 use std::fmt::Debug;
 use std::sync::Arc;
+use datafusion::arrow::array::Int64Builder;
+use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
 
 #[derive(Debug)]
-pub struct SchemasView {
+pub struct WorksheetsView {
     schema: SchemaRef,
-    config: MetastoreViewConfig,
+    config: HistoryStoreViewConfig,
 }
 
-impl SchemasView {
-    pub(crate) fn new(config: MetastoreViewConfig) -> Self {
+impl WorksheetsView {
+    pub(crate) fn new(config: HistoryStoreViewConfig) -> Self {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("schema_name", DataType::Utf8, false),
-            Field::new("database_name", DataType::Utf8, false),
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("content", DataType::Utf8, true),
             Field::new("created_at", DataType::Utf8, false),
             Field::new("updated_at", DataType::Utf8, false),
         ]));
@@ -31,10 +33,11 @@ impl SchemasView {
         Self { schema, config }
     }
 
-    fn builder(&self) -> SchemasViewBuilder {
-        SchemasViewBuilder {
-            schema_names: StringBuilder::new(),
-            database_names: StringBuilder::new(),
+    fn builder(&self) -> WorksheetsViewBuilder {
+        WorksheetsViewBuilder {
+            worksheet_ids: Int64Builder::new(),
+            worksheet_names: StringBuilder::new(),
+            content_values: StringBuilder::new(),
             created_at_timestamps: StringBuilder::new(),
             updated_at_timestamps: StringBuilder::new(),
             schema: Arc::clone(&self.schema),
@@ -42,7 +45,7 @@ impl SchemasView {
     }
 }
 
-impl PartitionStream for SchemasView {
+impl PartitionStream for WorksheetsView {
     fn schema(&self) -> &SchemaRef {
         &self.schema
     }
@@ -53,7 +56,7 @@ impl PartitionStream for SchemasView {
         Box::pin(RecordBatchStreamAdapter::new(
             Arc::clone(&self.schema),
             futures::stream::once(async move {
-                config.make_schemas(&mut builder).await?;
+                config.make_worksheets(&mut builder).await?;
                 builder
                     .finish()
                     .map_err(|e| DataFusionError::ArrowError(e, None))
@@ -62,25 +65,28 @@ impl PartitionStream for SchemasView {
     }
 }
 
-pub struct SchemasViewBuilder {
+pub struct WorksheetsViewBuilder {
     schema: SchemaRef,
-    schema_names: StringBuilder,
-    database_names: StringBuilder,
+    worksheet_ids: Int64Builder,
+    worksheet_names: StringBuilder,
+    content_values: StringBuilder,
     created_at_timestamps: StringBuilder,
     updated_at_timestamps: StringBuilder,
 }
 
-impl SchemasViewBuilder {
-    pub fn add_schema(
+impl WorksheetsViewBuilder {
+    pub fn add_worksheet(
         &mut self,
-        schema_name: impl AsRef<str>,
-        database_name: impl AsRef<str>,
+        worksheet_id: i64,
+        worksheet_name: Option<impl AsRef<str>>,
+        content: Option<impl AsRef<str>>,
         created_at: impl AsRef<str>,
         updated_at: impl AsRef<str>,
     ) {
         // Note: append_value is actually infallible.
-        self.schema_names.append_value(schema_name.as_ref());
-        self.database_names.append_value(database_name.as_ref());
+        self.worksheet_ids.append_value(worksheet_id);
+        self.worksheet_names.append_option(worksheet_name);
+        self.content_values.append_option(content);
         self.created_at_timestamps.append_value(created_at.as_ref());
         self.updated_at_timestamps.append_value(updated_at.as_ref());
     }
@@ -89,8 +95,9 @@ impl SchemasViewBuilder {
         RecordBatch::try_new(
             Arc::clone(&self.schema),
             vec![
-                Arc::new(self.schema_names.finish()),
-                Arc::new(self.database_names.finish()),
+                Arc::new(self.worksheet_ids.finish()),
+                Arc::new(self.worksheet_names.finish()),
+                Arc::new(self.content_values.finish()),
                 Arc::new(self.created_at_timestamps.finish()),
                 Arc::new(self.updated_at_timestamps.finish()),
             ],

--- a/crates/df-catalog/src/catalogs/slatedb/worksheets.rs
+++ b/crates/df-catalog/src/catalogs/slatedb/worksheets.rs
@@ -1,3 +1,5 @@
+use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
+use datafusion::arrow::array::Int64Builder;
 use datafusion::arrow::error::ArrowError;
 use datafusion::arrow::{
     array::StringBuilder,
@@ -11,8 +13,6 @@ use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_physical_plan::streaming::PartitionStream;
 use std::fmt::Debug;
 use std::sync::Arc;
-use datafusion::arrow::array::Int64Builder;
-use crate::catalogs::slatedb::history_store_config::HistoryStoreViewConfig;
 
 #[derive(Debug)]
 pub struct WorksheetsView {

--- a/crates/df-catalog/src/tests/information_schema.rs
+++ b/crates/df-catalog/src/tests/information_schema.rs
@@ -8,11 +8,13 @@ use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::context::SessionContext;
 use datafusion::prelude::SessionConfig;
 use std::sync::Arc;
+use core_history::SlateDBHistoryStore;
 
 #[allow(clippy::unwrap_used)]
 async fn create_session_context() -> Arc<SessionContext> {
     let metastore = SlateDBMetastore::new_in_memory().await;
-    let catalog_list_impl = Arc::new(EmbucketCatalogList::new(metastore.clone()));
+    let history_store = SlateDBHistoryStore::new_in_memory().await;
+    let catalog_list_impl = Arc::new(EmbucketCatalogList::new(metastore.clone(), history_store.clone()));
 
     let state = SessionStateBuilder::new()
         .with_config(

--- a/crates/df-catalog/src/tests/information_schema.rs
+++ b/crates/df-catalog/src/tests/information_schema.rs
@@ -3,18 +3,21 @@ use crate::information_schema::information_schema::{
     INFORMATION_SCHEMA, InformationSchemaProvider,
 };
 use crate::test_utils::sort_record_batch_by_sortable_columns;
+use core_history::SlateDBHistoryStore;
 use core_metastore::SlateDBMetastore;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::context::SessionContext;
 use datafusion::prelude::SessionConfig;
 use std::sync::Arc;
-use core_history::SlateDBHistoryStore;
 
 #[allow(clippy::unwrap_used)]
 async fn create_session_context() -> Arc<SessionContext> {
     let metastore = SlateDBMetastore::new_in_memory().await;
     let history_store = SlateDBHistoryStore::new_in_memory().await;
-    let catalog_list_impl = Arc::new(EmbucketCatalogList::new(metastore.clone(), history_store.clone()));
+    let catalog_list_impl = Arc::new(EmbucketCatalogList::new(
+        metastore.clone(),
+        history_store.clone(),
+    ));
 
     let state = SessionStateBuilder::new()
         .with_config(


### PR DESCRIPTION
Closes #828, #829 & #902

- Added a **core-history** to the **df-catalog** for `history_store`
- Made a `HistorySchema` with it's own `config` and `Views`
- Renamed some Metastore related SlateDb catalog functionality
- After this pr will follow the PR with changes to handlers
- SlateDb is slow even with such a low number of queries for a full scan (0.606s) with just one filter:
![image](https://github.com/user-attachments/assets/91bc0ffd-1a10-4b1c-9058-c35873375205)
- Now we have: 
  - `slatedb.meta` for `.tables`, `.schemas`, `.databases` & `.volumes`.
  - `slatedb.history` for `.worksheets` & `.queries`
