### PR TITLE
WIP Streamline error handling 1st attempt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,8 @@ name = "api-iceberg-rest"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "common-error",
+ "common-proc",
  "core-metastore",
  "core-utils",
  "http 1.3.1",
@@ -1669,6 +1671,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-error"
+version = "0.1.0"
+
+[[package]]
+name = "common-proc"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +1756,8 @@ dependencies = [
  "aws-credential-types",
  "bytes",
  "chrono",
+ "common-error",
+ "common-proc",
  "core-metastore",
  "core-utils",
  "datafusion",
@@ -1830,6 +1847,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "common-error",
+ "common-proc",
  "core-utils",
  "dashmap",
  "futures",
@@ -1857,6 +1876,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "common-error",
+ "common-proc",
  "futures",
  "iceberg",
  "insta",
@@ -2735,6 +2756,8 @@ dependencies = [
  "aws-credential-types",
  "bytes",
  "chrono",
+ "common-error",
+ "common-proc",
  "core-metastore",
  "core-utils",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
   "crates/core-history",
   "crates/core-metastore",
   "crates/core-utils",
-  "crates/api-sessions",
+  "crates/api-sessions", "crates/common-error", "crates/common-proc",
 ]
 resolver = "2"
 package.license-file = "LICENSE"

--- a/crates/api-iceberg-rest/Cargo.toml
+++ b/crates/api-iceberg-rest/Cargo.toml
@@ -7,6 +7,8 @@ license-file.workspace = true
 [dependencies]
 core-metastore = { path = "../core-metastore" }
 core-utils = { path = "../core-utils" }
+common-proc = { path = "../common-proc" }
+common-error = { path = "../common-error" }
 
 axum = { workspace = true }
 http = { workspace = true }

--- a/crates/api-iceberg-rest/src/error.rs
+++ b/crates/api-iceberg-rest/src/error.rs
@@ -1,34 +1,109 @@
 use axum::{Json, response::IntoResponse};
+use common_proc::stack_trace_debug;
 use core_metastore::error::MetastoreError;
+use core_utils::Error as CoreError;
 use http;
+use object_store::Error as ObjectStoreError;
 use serde::{Deserialize, Serialize};
+use serde_json::Error as SerdeError;
+use snafu::Location;
 use snafu::prelude::*;
+use validator::ValidationErrors;
 
-#[derive(Debug, Snafu)]
+#[derive(Snafu)]
 #[snafu(visibility(pub))]
+#[stack_trace_debug]
 pub enum IcebergAPIError {
-    #[snafu(display("Metastore error: {source}"))]
-    Metastore {
-        #[snafu(source(from(MetastoreError, Box::new)))]
-        source: Box<MetastoreError>,
+    #[snafu(display("Create namespace error: {source}"))]
+    CreateNamespace {
+        source: MetastoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Get namespace error: {source}"))]
+    GetNamespace {
+        source: MetastoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Delete namespace error: {source}"))]
+    DeleteNamespace {
+        source: MetastoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("List namespaces error: {source}"))]
+    ListNamespaces {
+        source: CoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Get table error: {source}"))]
+    GetTable {
+        source: MetastoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Delete table error: {source}"))]
+    DeleteTable {
+        source: MetastoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("List tables error: {source}"))]
+    ListTables {
+        source: CoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Create table error: {source}"))]
+    CreateTable {
+        source: MetastoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Commit table error: {source}"))]
+    CommitTable {
+        source: MetastoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    // TODO: Make following errors more specific and contextually appropriate
+    #[snafu(display("Object store error: {error}"))]
+    ObjectStore {
+        #[snafu(source)]
+        error: ObjectStoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Serde error: {error}"))]
+    Serde {
+        #[snafu(source)]
+        error: SerdeError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Validation error: {error}"))]
+    Validation {
+        #[snafu(source)]
+        error: ValidationErrors,
+        #[snafu(implicit)]
+        location: Location,
     },
 }
 
 pub type IcebergAPIResult<T> = Result<T, IcebergAPIError>;
-
-impl From<MetastoreError> for IcebergAPIError {
-    fn from(error: MetastoreError) -> Self {
-        Self::Metastore {
-            source: Box::new(error),
-        }
-    }
-}
-
-impl From<Box<MetastoreError>> for IcebergAPIError {
-    fn from(error: Box<MetastoreError>) -> Self {
-        Self::Metastore { source: error }
-    }
-}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorResponse {
@@ -53,7 +128,7 @@ impl IntoResponse for IcebergAPIError {
             | MetastoreError::VolumeInUse { .. } => http::StatusCode::CONFLICT,
             MetastoreError::TableRequirementFailed { .. } => http::StatusCode::UNPROCESSABLE_ENTITY,
             MetastoreError::VolumeValidationFailed { .. }
-            | MetastoreError::VolumeMissingCredentials
+            | MetastoreError::VolumeMissingCredentials { .. }
             | MetastoreError::Validation { .. } => http::StatusCode::BAD_REQUEST,
             MetastoreError::CloudProviderNotImplemented { .. } => {
                 http::StatusCode::PRECONDITION_FAILED
@@ -62,7 +137,7 @@ impl IntoResponse for IcebergAPIError {
             | MetastoreError::DatabaseNotFound { .. }
             | MetastoreError::SchemaNotFound { .. }
             | MetastoreError::TableNotFound { .. }
-            | MetastoreError::ObjectNotFound => http::StatusCode::NOT_FOUND,
+            | MetastoreError::ObjectNotFound { .. } => http::StatusCode::NOT_FOUND,
             MetastoreError::ObjectStore { .. }
             | MetastoreError::ObjectStorePath { .. }
             | MetastoreError::CreateDirectory { .. }

--- a/crates/common-error/Cargo.toml
+++ b/crates/common-error/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "common-error"
+version = "0.1.0"
+edition = "2024"
+license-file.workspace = true
+
+[dependencies]
+
+
+[lints]
+workspace = true

--- a/crates/common-error/src/lib.rs
+++ b/crates/common-error/src/lib.rs
@@ -1,0 +1,62 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+pub trait StackError: std::error::Error {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>);
+
+    fn next(&self) -> Option<&dyn StackError>;
+
+    fn last(&self) -> &dyn StackError
+    where
+        Self: Sized,
+    {
+        let Some(mut result) = self.next() else {
+            return self;
+        };
+        while let Some(err) = result.next() {
+            result = err;
+        }
+        result
+    }
+
+    /// Indicates whether this error is "transparent", that it delegates its "display" and "source"
+    /// to the underlying error. Could be useful when you are just wrapping some external error,
+    /// **AND** can not or would not provide meaningful contextual info. For example, the
+    /// `DataFusionError`.
+    fn transparent(&self) -> bool {
+        false
+    }
+}
+
+impl<T: ?Sized + StackError> StackError for Arc<T> {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+        self.as_ref().debug_fmt(layer, buf)
+    }
+
+    fn next(&self) -> Option<&dyn StackError> {
+        self.as_ref().next()
+    }
+}
+
+impl<T: StackError> StackError for Box<T> {
+    fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+        self.as_ref().debug_fmt(layer, buf)
+    }
+
+    fn next(&self) -> Option<&dyn StackError> {
+        self.as_ref().next()
+    }
+}

--- a/crates/common-proc/Cargo.toml
+++ b/crates/common-proc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "common-proc"
+version = "0.1.0"
+edition = "2024"
+license-file.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2.0"
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[lints]
+workspace = true

--- a/crates/common-proc/src/lib.rs
+++ b/crates/common-proc/src/lib.rs
@@ -1,0 +1,9 @@
+mod stack;
+
+use proc_macro::TokenStream;
+use stack::stack_trace_style_impl;
+
+#[proc_macro_attribute]
+pub fn stack_trace_debug(args: TokenStream, input: TokenStream) -> TokenStream {
+    stack_trace_style_impl(args.into(), input.into()).into()
+}

--- a/crates/common-proc/src/stack.rs
+++ b/crates/common-proc/src/stack.rs
@@ -1,0 +1,320 @@
+use proc_macro2::{Literal, Span, TokenStream as TokenStream2, TokenTree};
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{Attribute, Ident, ItemEnum, Variant, parenthesized};
+
+pub fn stack_trace_style_impl(args: TokenStream2, input: TokenStream2) -> TokenStream2 {
+    let input_cloned: TokenStream2 = input.clone();
+
+    #[allow(clippy::unwrap_used)]
+    let error_enum_definition: ItemEnum = syn::parse2(input_cloned).unwrap();
+    let enum_name = error_enum_definition.ident;
+
+    let mut variants = vec![];
+
+    for error_variant in error_enum_definition.variants {
+        let variant = ErrorVariant::from_enum_variant(error_variant);
+        variants.push(variant);
+    }
+
+    let transparent_fn = build_transparent_fn(enum_name.clone(), &variants);
+    let debug_fmt_fn = build_debug_fmt_impl(enum_name.clone(), variants.clone());
+    let next_fn = build_next_impl(enum_name.clone(), variants);
+    let debug_impl = build_debug_impl(enum_name.clone());
+
+    quote! {
+        #args
+        #input
+
+        impl ::common_error::StackError for #enum_name {
+            #debug_fmt_fn
+            #next_fn
+            #transparent_fn
+        }
+
+        #debug_impl
+    }
+}
+
+/// Generate `debug_fmt` fn.
+///
+/// The generated fn will be like:
+/// ```rust, ignore
+/// fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>);
+/// ```
+fn build_debug_fmt_impl(enum_name: Ident, variants: Vec<ErrorVariant>) -> TokenStream2 {
+    let match_arms = variants
+        .iter()
+        .map(|v| v.to_debug_match_arm())
+        .collect::<Vec<_>>();
+
+    quote! {
+        fn debug_fmt(&self, layer: usize, buf: &mut Vec<String>) {
+            use #enum_name::*;
+            match self {
+                #(#match_arms)*
+            }
+        }
+    }
+}
+
+/// Generate `next` fn.
+///
+/// The generated fn will be like:
+/// ```rust, ignore
+/// fn next(&self) -> Option<&dyn ::common_error::ext::StackError>;
+/// ```
+fn build_next_impl(enum_name: Ident, variants: Vec<ErrorVariant>) -> TokenStream2 {
+    let match_arms = variants
+        .iter()
+        .map(|v| v.to_next_match_arm())
+        .collect::<Vec<_>>();
+
+    quote! {
+        fn next(&self) -> Option<&dyn ::common_error::StackError> {
+            use #enum_name::*;
+            match self {
+                #(#match_arms)*
+            }
+        }
+    }
+}
+
+/// Implement [std::fmt::Debug] via `debug_fmt`
+fn build_debug_impl(enum_name: Ident) -> TokenStream2 {
+    quote! {
+        impl std::fmt::Debug for #enum_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                use ::common_error::StackError;
+                let mut buf = vec![];
+                self.debug_fmt(0, &mut buf);
+                write!(f, "{}", buf.join("\n"))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ErrorVariant {
+    name: Ident,
+    fields: Vec<Ident>,
+    has_location: bool,
+    has_source: bool,
+    has_external_cause: bool,
+    display: TokenStream2,
+    transparent: bool,
+    span: Span,
+    cfg_attr: Option<Attribute>,
+}
+
+impl ErrorVariant {
+    /// Construct self from [Variant]
+    fn from_enum_variant(variant: Variant) -> Self {
+        let span = variant.span();
+        let mut has_location = false;
+        let mut has_source = false;
+        let mut has_external_cause = false;
+
+        for field in &variant.fields {
+            if let Some(ident) = &field.ident {
+                if ident == "location" {
+                    has_location = true;
+                } else if ident == "source" {
+                    has_source = true;
+                } else if ident == "error" {
+                    has_external_cause = true;
+                }
+            }
+        }
+
+        let mut display = None;
+        let mut transparent = false;
+        let mut cfg_attr = None;
+        for attr in variant.attrs {
+            if attr.path().is_ident("snafu") {
+                attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("display") {
+                        let content;
+                        parenthesized!(content in meta.input);
+                        let display_ts: TokenStream2 = content.parse()?;
+                        display = Some(display_ts);
+                        Ok(())
+                    } else if meta.path.is_ident("transparent") {
+                        display = Some(TokenStream2::from(TokenTree::Literal(Literal::string(
+                            "<transparent>",
+                        ))));
+                        transparent = true;
+                        Ok(())
+                    } else {
+                        Err(meta.error("unrecognized repr"))
+                    }
+                })
+                .unwrap_or_else(|e| panic!("{e}"));
+            }
+
+            if attr.path().is_ident("cfg") {
+                cfg_attr = Some(attr);
+            }
+        }
+        let display = display.unwrap_or_else(|| {
+            panic!(
+                r#"Error "{}" must be annotated with attribute "display" or "transparent"."#,
+                variant.ident,
+            )
+        });
+
+        let field_ident = variant
+            .fields
+            .iter()
+            .map(|f| f.ident.clone().unwrap_or_else(|| Ident::new("_", f.span())))
+            .collect();
+
+        Self {
+            name: variant.ident,
+            fields: field_ident,
+            has_location,
+            has_source,
+            has_external_cause,
+            display,
+            transparent,
+            span,
+            cfg_attr,
+        }
+    }
+
+    /// Convert self into an match arm that will be used in [build_debug_impl].
+    ///
+    /// The generated match arm will be like:
+    /// ```rust, ignore
+    ///     ErrorKindWithSource { source, .. } => {
+    ///         debug_fmt(source, layer + 1, buf);
+    ///     },
+    ///     ErrorKindWithoutSource { .. } => {
+    ///        buf.push(format!("{layer}: {}, at {}", format!(#display), location)));
+    ///     }
+    /// ```
+    ///
+    /// The generated code assumes fn `debug_fmt`, var `layer`, var `buf` are in scope.
+    fn to_debug_match_arm(&self) -> TokenStream2 {
+        let name = &self.name;
+        let fields = &self.fields;
+        let display = &self.display;
+        let cfg = if let Some(cfg) = &self.cfg_attr {
+            quote_spanned!(cfg.span() => #cfg)
+        } else {
+            quote! {}
+        };
+
+        match (self.has_location, self.has_source, self.has_external_cause) {
+            (true, true, _) => quote_spanned! {
+               self.span => #cfg #[allow(unused_variables)] #name { #(#fields),*, } => {
+                    buf.push(format!("{layer}: {}, at {}", format!(#display), location));
+                    source.debug_fmt(layer + 1, buf);
+                },
+            },
+            (true, false, true) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}, at {}", format!(#display), location));
+                    buf.push(format!("{}: {:?}", layer + 1, error));
+                },
+            },
+            (true, false, false) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}, at {}", format!(#display), location));
+                },
+            },
+            (false, true, _) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}", format!(#display)));
+                    source.debug_fmt(layer + 1, buf);
+                },
+            },
+            (false, false, true) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}", format!(#display)));
+                    buf.push(format!("{}: {:?}", layer + 1, error));
+                },
+            },
+            (false, false, false) => quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    buf.push(format!("{layer}: {}", format!(#display)));
+                },
+            },
+        }
+    }
+
+    /// Convert self into an match arm that will be used in [build_next_impl].
+    ///
+    /// The generated match arm will be like:
+    /// ```rust, ignore
+    ///     ErrorKindWithSource { source, .. } => {
+    ///         Some(source)
+    ///     },
+    ///     ErrorKindWithoutSource { .. } => {
+    ///        None
+    ///     }
+    /// ```
+    fn to_next_match_arm(&self) -> TokenStream2 {
+        let name = &self.name;
+        let fields = &self.fields;
+        let cfg = if let Some(cfg) = &self.cfg_attr {
+            quote_spanned!(cfg.span() => #cfg)
+        } else {
+            quote! {}
+        };
+
+        if self.has_source {
+            quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    Some(source)
+                },
+            }
+        } else {
+            quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } =>{
+                    None
+                }
+            }
+        }
+    }
+
+    fn build_transparent_match_arm(&self) -> TokenStream2 {
+        let cfg = if let Some(cfg) = &self.cfg_attr {
+            quote_spanned!(cfg.span() => #cfg)
+        } else {
+            quote! {}
+        };
+        let name = &self.name;
+        let fields = &self.fields;
+
+        if self.transparent {
+            quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } => {
+                    true
+                },
+            }
+        } else {
+            quote_spanned! {
+                self.span => #cfg #[allow(unused_variables)] #name { #(#fields),* } =>{
+                    false
+                }
+            }
+        }
+    }
+}
+
+fn build_transparent_fn(enum_name: Ident, variants: &[ErrorVariant]) -> TokenStream2 {
+    let match_arms = variants
+        .iter()
+        .map(|v| v.build_transparent_match_arm())
+        .collect::<Vec<_>>();
+
+    quote! {
+        fn transparent(&self) -> bool {
+            use #enum_name::*;
+            match self {
+                #(#match_arms)*
+            }
+        }
+    }
+}

--- a/crates/core-executor/Cargo.toml
+++ b/crates/core-executor/Cargo.toml
@@ -9,6 +9,8 @@ core-utils = { path = "../core-utils" }
 core-metastore = { path = "../core-metastore" }
 df-builtins = { path = "../df-builtins" }
 df-catalog = { path = "../df-catalog" }
+common-error = { path = "../common-error" }
+common-proc = { path = "../common-proc" }
 
 async-trait = { workspace = true }
 aws-config = { workspace = true }

--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -1,120 +1,263 @@
-use std::backtrace::Backtrace;
-
+use common_proc::stack_trace_debug;
 use datafusion_common::DataFusionError;
 use df_catalog::error::Error as CatalogError;
 use iceberg_rust::error::Error as IcebergError;
 use iceberg_s3tables_catalog::error::Error as S3tablesError;
+use snafu::Location;
 use snafu::prelude::*;
 
-#[derive(Debug, Snafu)]
+#[derive(Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[stack_trace_debug]
 pub enum ExecutionError {
-    #[snafu(display("Cannot register UDF functions"))]
-    RegisterUDF { source: DataFusionError },
-
-    #[snafu(display("Cannot register UDAF functions"))]
-    RegisterUDAF { source: DataFusionError },
-
-    #[snafu(display("DataFusion error: {source}"))]
-    DataFusion { source: DataFusionError },
-
-    #[snafu(display("Invalid table identifier: {ident}"))]
-    InvalidTableIdentifier { ident: String },
-
-    #[snafu(display("Invalid schema identifier: {ident}"))]
-    InvalidSchemaIdentifier { ident: String },
-
-    #[snafu(display("Invalid file path: {path}"))]
-    InvalidFilePath { path: String },
-
-    #[snafu(display("Invalid bucket identifier: {ident}"))]
-    InvalidBucketIdentifier { ident: String },
-
-    #[snafu(display("Arrow error: {source}"))]
-    Arrow {
-        source: datafusion::arrow::error::ArrowError,
+    // === External Library Errors (from crates outside workspace) ===
+    #[snafu(display("DataFusion error: {error}"))]
+    DataFusion {
+        #[snafu(source)]
+        error: DataFusionError,
+        #[snafu(implicit)]
+        location: Location,
     },
 
-    #[snafu(display("No Table Provider found for table: {table_name}"))]
-    TableProviderNotFound { table_name: String },
-
-    #[snafu(display("Missing DataFusion session for id {id}"))]
-    MissingDataFusionSession { id: String },
-
-    #[snafu(display("DataFusion query error: {source}, query: {query}"))]
+    #[snafu(display("DataFusion query execution failed: {error}, query: {query}"))]
     DataFusionQuery {
-        #[snafu(source(from(DataFusionError, Box::new)))]
-        source: Box<DataFusionError>,
+        #[snafu(source)]
+        error: DataFusionError,
         query: String,
+        #[snafu(implicit)]
+        location: Location,
     },
 
-    #[snafu(display("Error encoding UTF8 string: {source}"))]
-    Utf8 { source: std::string::FromUtf8Error },
+    #[snafu(display("Arrow error: {error}"))]
+    Arrow {
+        #[snafu(source)]
+        error: datafusion::arrow::error::ArrowError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
+    #[snafu(display("Cannot register UDF functions: {error}"))]
+    RegisterUDF {
+        #[snafu(source)]
+        error: DataFusionError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Cannot register UDAF functions: {error}"))]
+    RegisterUDAF {
+        #[snafu(source)]
+        error: DataFusionError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Object store error: {error}"))]
+    ObjectStore {
+        #[snafu(source)]
+        error: object_store::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Iceberg error: {error}"))]
+    Iceberg {
+        #[snafu(source)]
+        error: IcebergError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("S3Tables error: {error}"))]
+    S3Tables {
+        #[snafu(source)]
+        error: S3tablesError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("UTF-8 encoding error: {error}"))]
+    Utf8 {
+        #[snafu(source)]
+        error: std::string::FromUtf8Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("URL parsing error: {error}"))]
+    UrlParse {
+        #[snafu(source)]
+        error: url::ParseError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    // === Internal Workspace Crate Errors ===
     #[snafu(display("Metastore error: {source}"))]
     Metastore {
-        source: Box<core_metastore::error::MetastoreError>,
+        source: core_metastore::error::MetastoreError,
+        #[snafu(implicit)]
+        location: Location,
     },
-
-    #[snafu(display("Database {db} not found"))]
-    DatabaseNotFound { db: String },
-
-    #[snafu(display("Table {table} not found"))]
-    TableNotFound { table: String },
-
-    #[snafu(display("Schema {schema} not found"))]
-    SchemaNotFound { schema: String },
-
-    #[snafu(display("Volume {volume} not found"))]
-    VolumeNotFound { volume: String },
-
-    #[snafu(display("Object store error: {source}"))]
-    ObjectStore { source: object_store::Error },
-
-    #[snafu(display("Object of type {type_name} with name {name} already exists"))]
-    ObjectAlreadyExists { type_name: String, name: String },
-
-    #[snafu(display("Unsupported file format {format}"))]
-    UnsupportedFileFormat { format: String },
 
     #[snafu(display("Cannot refresh catalog list: {source}"))]
-    RefreshCatalogList { source: CatalogError },
-
-    #[snafu(display("Catalog {catalog} cannot be downcasted"))]
-    CatalogDownCast { catalog: String },
-
-    #[snafu(display("Catalog {catalog} not found"))]
-    CatalogNotFound { catalog: String },
-
-    #[snafu(display("S3Tables error: {source}"))]
-    S3Tables {
-        #[snafu(source(from(S3tablesError, Box::new)))]
-        source: Box<S3tablesError>,
+    RefreshCatalogList {
+        source: CatalogError,
+        #[snafu(implicit)]
+        location: Location,
     },
-
-    #[snafu(display("Iceberg error: {source}"))]
-    Iceberg {
-        #[snafu(source(from(IcebergError, Box::new)))]
-        source: Box<IcebergError>,
-    },
-
-    #[snafu(display("URL Parsing error: {source}"))]
-    UrlParse { source: url::ParseError },
-
-    #[snafu(display("Threaded Job error: {source}: {backtrace}"))]
-    JobError {
-        source: crate::dedicated_executor::JobError,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("Failed to upload file: {message}"))]
-    UploadFailed { message: String },
-
-    #[snafu(display("CatalogList failed"))]
-    CatalogListDowncast,
 
     #[snafu(display("Failed to register catalog: {source}"))]
-    RegisterCatalog { source: CatalogError },
+    RegisterCatalog {
+        source: CatalogError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Threaded job error: {error}"))]
+    JobError {
+        #[snafu(source)]
+        error: crate::dedicated_executor::JobError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    // === Internal Application Errors (no external source) ===
+    #[snafu(display("Missing DataFusion session for id: {id}"))]
+    MissingDataFusionSession {
+        id: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Database '{db}' not found"))]
+    DatabaseNotFound {
+        db: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Schema '{schema}' not found"))]
+    SchemaNotFound {
+        schema: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Table '{table}' not found"))]
+    TableNotFound {
+        table: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Volume '{volume}' not found"))]
+    VolumeNotFound {
+        volume: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Catalog '{catalog}' not found"))]
+    CatalogNotFound {
+        catalog: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Table provider not found for table: {table_name}"))]
+    TableProviderNotFound {
+        table_name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Invalid table identifier: {ident}"))]
+    InvalidTableIdentifier {
+        ident: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Invalid schema identifier: {ident}"))]
+    InvalidSchemaIdentifier {
+        ident: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Invalid bucket identifier: {ident}"))]
+    InvalidBucketIdentifier {
+        ident: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Invalid file path: {path}"))]
+    InvalidFilePath {
+        path: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Unsupported file format: {format}"))]
+    UnsupportedFileFormat {
+        format: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Object of type '{type_name}' with name '{name}' already exists"))]
+    ObjectAlreadyExists {
+        type_name: String,
+        name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Catalog '{catalog}' cannot be downcasted"))]
+    CatalogDownCast {
+        catalog: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Catalog list downcast failed"))]
+    CatalogListDowncast {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("File upload failed: {message}"))]
+    UploadFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Core utils error: {source}"))]
+    CoreUtils {
+        source: core_utils::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    // User query errors
+    #[snafu(display("User query error: {message}"))]
+    UserQuery {
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    // Not yet implemented / supported statements
+    #[snafu(display("Not yet implemented / supported statement: {statement}, message: {message}"))]
+    NotYetImplemented {
+        statement: String,
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type ExecutionResult<T> = std::result::Result<T, ExecutionError>;

--- a/crates/core-executor/src/service.rs
+++ b/crates/core-executor/src/service.rs
@@ -11,7 +11,7 @@ use datafusion::datasource::memory::MemTable;
 use datafusion_common::TableReference;
 use snafu::ResultExt;
 
-use super::error::{self as ex_error, ExecutionError, ExecutionResult};
+use super::error::{self as ex_error, ExecutionResult};
 use super::{models::QueryResult, query::QueryContext, session::UserSession};
 use core_metastore::{Metastore, SlateDBMetastore, TableIdent as MetastoreTableIdent};
 use core_utils::Db;
@@ -92,8 +92,11 @@ impl ExecutionService for CoreExecutionService {
             let sessions = self.df_sessions.read().await;
             sessions
                 .get(session_id)
-                .ok_or(ExecutionError::MissingDataFusionSession {
-                    id: session_id.to_string(),
+                .ok_or_else(|| {
+                    ex_error::MissingDataFusionSessionSnafu {
+                        id: session_id.to_string(),
+                    }
+                    .build()
                 })?
                 .clone()
         };
@@ -124,8 +127,11 @@ impl ExecutionService for CoreExecutionService {
             let sessions = self.df_sessions.read().await;
             sessions
                 .get(session_id)
-                .ok_or(ExecutionError::MissingDataFusionSession {
-                    id: session_id.to_string(),
+                .ok_or_else(|| {
+                    ex_error::MissingDataFusionSessionSnafu {
+                        id: session_id.to_string(),
+                    }
+                    .build()
                 })?
                 .clone()
         };
@@ -165,7 +171,7 @@ impl ExecutionService for CoreExecutionService {
         } else {
             let (schema, _) = format
                 .infer_schema(data.clone().reader(), None)
-                .map_err(|e| ExecutionError::DataFusion { source: e.into() })?;
+                .context(ex_error::ArrowSnafu)?;
             schema
         };
         let schema = Arc::new(schema);

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -3,7 +3,7 @@ use super::datafusion::functions::register_udfs;
 use super::datafusion::type_planner::CustomTypePlanner;
 use super::dedicated_executor::DedicatedExecutor;
 use super::error::{
-    self as ex_error, ExecutionError, ExecutionResult, RefreshCatalogListSnafu,
+    self as ex_error, CoreUtilsSnafu, ExecutionResult, RefreshCatalogListSnafu,
     RegisterCatalogSnafu,
 };
 use super::query::{QueryContext, UserQuery};
@@ -14,7 +14,6 @@ use crate::datafusion::physical_optimizer::physical_optimizer_rules;
 use aws_config::{BehaviorVersion, Region, SdkConfig};
 use aws_credential_types::Credentials;
 use aws_credential_types::provider::SharedCredentialsProvider;
-use core_metastore::error::MetastoreError;
 use core_metastore::{AwsCredentials, Metastore, VolumeType as MetastoreVolumeType};
 use core_utils::scan_iterator::ScanIterator;
 use datafusion::catalog::CatalogProvider;
@@ -110,9 +109,7 @@ impl UserSession {
             .iter_volumes()
             .collect()
             .await
-            .map_err(|e| ExecutionError::Metastore {
-                source: Box::new(MetastoreError::UtilSlateDB { source: e }),
-            })?
+            .context(CoreUtilsSnafu)?
             .into_iter()
             .filter_map(|volume| {
                 if let MetastoreVolumeType::S3Tables(s3_volume) = volume.volume.clone() {

--- a/crates/core-metastore/Cargo.toml
+++ b/crates/core-metastore/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license-file = { workspace = true }
 
 [dependencies]
+common-error = { path = "../common-error" }
+common-proc = { path = "../common-proc" }
+
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }

--- a/crates/core-metastore/src/error.rs
+++ b/crates/core-metastore/src/error.rs
@@ -1,73 +1,153 @@
+use common_proc::stack_trace_debug;
 use iceberg_rust_spec::table_metadata::TableMetadataBuilderError;
+use snafu::Location;
 use snafu::prelude::*;
 
-#[derive(Snafu, Debug)]
+#[derive(Snafu)]
 #[snafu(visibility(pub))]
+#[stack_trace_debug]
 pub enum MetastoreError {
-    #[snafu(display("Table data already exists at that location: {location}"))]
-    TableDataExists { location: String },
+    #[snafu(display("Table data already exists at that location: {path}"))]
+    TableDataExists {
+        path: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Table requirement failed: {message}"))]
-    TableRequirementFailed { message: String },
+    TableRequirementFailed {
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Volume: Validation failed. Reason: {reason}"))]
-    VolumeValidationFailed { reason: String },
+    VolumeValidationFailed {
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Volume: Missing credentials"))]
-    VolumeMissingCredentials,
+    VolumeMissingCredentials {
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Cloud provider not implemented"))]
-    CloudProviderNotImplemented { provider: String },
+    CloudProviderNotImplemented {
+        provider: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("ObjectStore: {source}"))]
-    ObjectStore { source: object_store::Error },
+    #[snafu(display("ObjectStore: {error}"))]
+    ObjectStore {
+        #[snafu(source)]
+        error: object_store::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("ObjectStore path: {source}"))]
-    ObjectStorePath { source: object_store::path::Error },
+    #[snafu(display("ObjectStore path: {error}"))]
+    ObjectStorePath {
+        #[snafu(source)]
+        error: object_store::path::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display(
-        "Unable to create directory for File ObjectStore path {path}, error: {source}"
+        "Unable to create directory for File ObjectStore path {path}, error: {error}"
     ))]
     CreateDirectory {
         path: String,
-        source: std::io::Error,
+        #[snafu(source)]
+        error: std::io::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("SlateDB error: {error}"))]
+    SlateDB {
+        #[snafu(source)]
+        error: slatedb::SlateDBError,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display("SlateDB error: {source}"))]
-    SlateDB { source: slatedb::SlateDBError },
-
-    #[snafu(display("SlateDB error: {source}"))]
-    UtilSlateDB { source: core_utils::Error },
+    UtilSlateDB {
+        source: core_utils::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Metastore object of type {type_name} with name {name} already exists"))]
-    ObjectAlreadyExists { type_name: String, name: String },
+    ObjectAlreadyExists {
+        type_name: String,
+        name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Metastore object not found"))]
-    ObjectNotFound,
+    ObjectNotFound {
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Volume {volume} already exists"))]
-    VolumeAlreadyExists { volume: String },
+    VolumeAlreadyExists {
+        volume: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Volume {volume} not found"))]
-    VolumeNotFound { volume: String },
+    VolumeNotFound {
+        volume: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Database {db} already exists"))]
-    DatabaseAlreadyExists { db: String },
+    DatabaseAlreadyExists {
+        db: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Database {db} not found"))]
-    DatabaseNotFound { db: String },
+    DatabaseNotFound {
+        db: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Schema {schema} already exists in database {db}"))]
-    SchemaAlreadyExists { schema: String, db: String },
+    SchemaAlreadyExists {
+        schema: String,
+        db: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Schema {schema} not found in database {db}"))]
-    SchemaNotFound { schema: String, db: String },
+    SchemaNotFound {
+        schema: String,
+        db: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Table {table} already exists in schema {schema} in database {db}"))]
     TableAlreadyExists {
         table: String,
         schema: String,
         db: String,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display("Table {table} not found in schema {schema} in database {db}"))]
@@ -75,6 +155,8 @@ pub enum MetastoreError {
         table: String,
         schema: String,
         db: String,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display(
@@ -84,31 +166,56 @@ pub enum MetastoreError {
         table: String,
         schema: String,
         db: String,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display("Volume in use by database(s): {database}"))]
-    VolumeInUse { database: String },
+    VolumeInUse {
+        database: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("Iceberg error: {source}"))]
-    Iceberg { source: iceberg_rust::error::Error },
+    #[snafu(display("Iceberg error: {error}"))]
+    Iceberg {
+        #[snafu(source)]
+        error: iceberg_rust::error::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("TableMetadataBuilder error: {source}"))]
-    TableMetadataBuilder { source: TableMetadataBuilderError },
+    #[snafu(display("TableMetadataBuilder error: {error}"))]
+    TableMetadataBuilder {
+        #[snafu(source)]
+        error: TableMetadataBuilderError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("Serialization error: {source}"))]
-    Serde { source: serde_json::Error },
+    #[snafu(display("Serialization error: {error}"))]
+    Serde {
+        #[snafu(source)]
+        error: serde_json::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("Validation Error: {source}"))]
-    Validation { source: validator::ValidationErrors },
+    #[snafu(display("Validation Error: {error}"))]
+    Validation {
+        #[snafu(source)]
+        error: validator::ValidationErrors,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("UrlParse Error: {source}"))]
-    UrlParse { source: url::ParseError },
+    #[snafu(display("UrlParse Error: {error}"))]
+    UrlParse {
+        #[snafu(source)]
+        error: url::ParseError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
-pub type MetastoreResult<T> = std::result::Result<T, Box<MetastoreError>>;
-
-impl From<validator::ValidationErrors> for MetastoreError {
-    fn from(source: validator::ValidationErrors) -> Self {
-        Self::Validation { source }
-    }
-}
+pub type MetastoreResult<T> = std::result::Result<T, MetastoreError>;

--- a/crates/core-metastore/src/models/volumes.rs
+++ b/crates/core-metastore/src/models/volumes.rs
@@ -184,7 +184,6 @@ impl Volume {
                     .build()
                     .map(|s3| Arc::new(s3) as Arc<dyn ObjectStore>)
                     .context(metastore_error::ObjectStoreSnafu)
-                    .map_err(Box::new)
             }
             VolumeType::S3Tables(volume) => {
                 let s3_builder = volume.s3_builder();
@@ -192,7 +191,6 @@ impl Volume {
                     .build()
                     .map(|s3| Arc::new(s3) as Arc<dyn ObjectStore>)
                     .context(metastore_error::ObjectStoreSnafu)
-                    .map_err(Box::new)
             }
             VolumeType::File(_) => Ok(Arc::new(
                 object_store::local::LocalFileSystem::new().with_automatic_cleanup(true),
@@ -260,8 +258,7 @@ impl Volume {
         object_store
             .get(&Path::from(self.prefix()))
             .await
-            .context(metastore_error::ObjectStoreSnafu)
-            .map_err(Box::new)?;
+            .context(metastore_error::ObjectStoreSnafu)?;
         Ok(())
     }
 }

--- a/crates/core-utils/Cargo.toml
+++ b/crates/core-utils/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license-file = { workspace = true }
 
 [dependencies]
+common-proc = { path = "../common-proc" }
+common-error = { path = "../common-error" }
+
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }

--- a/crates/df-catalog/Cargo.toml
+++ b/crates/df-catalog/Cargo.toml
@@ -7,6 +7,9 @@ license-file.workspace = true
 [dependencies]
 core-utils = { path = "../core-utils" }
 core-metastore = { path = "../core-metastore" }
+common-error = { path = "../common-error" }
+common-proc = { path = "../common-proc" }
+
 async-trait = { workspace = true }
 aws-config = { workspace = true }
 aws-credential-types = { workspace = true }

--- a/crates/df-catalog/src/error.rs
+++ b/crates/df-catalog/src/error.rs
@@ -1,23 +1,44 @@
+use common_proc::stack_trace_debug;
 use core_metastore::error::MetastoreError;
 use core_utils::Error as CoreError;
 use datafusion_common::DataFusionError;
 use iceberg_s3tables_catalog::error::Error as S3TablesError;
+use snafu::Location;
 use snafu::prelude::*;
 
-#[derive(Debug, Snafu)]
+#[derive(Snafu)]
 #[snafu(visibility(pub(crate)))]
+#[stack_trace_debug]
 pub enum Error {
     #[snafu(display("Metastore error: {source}"))]
-    Metastore { source: Box<MetastoreError> },
+    Metastore {
+        source: MetastoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Core error: {source}"))]
-    Core { source: CoreError },
+    Core {
+        source: CoreError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("DataFusion error: {source}"))]
-    DataFusion { source: DataFusionError },
+    #[snafu(display("DataFusion error: {error}"))]
+    DataFusion {
+        #[snafu(source)]
+        error: DataFusionError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
-    #[snafu(display("S3Tables error: {source}"))]
-    S3Tables { source: Box<S3TablesError> },
+    #[snafu(display("S3Tables error: {error}"))]
+    S3Tables {
+        #[snafu(source)]
+        error: S3TablesError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
First attempt to address #866. **Collecting early feedback.**

Introduce common error trait (stacked one, inspired by greptimedb).
Fixing meanwhile #964 - ideally this is isolated in a dedicated PR.

This is my current approach - by no means it is finished - but at least all crates affected compile (there are still 3 api crates to fix).

I would like to collect early feedback, especially on `pub enum IcebergAPIError {`. There was previously only `Metastore` option, I am not sure this is good approach in snafu (and stacked errors) philosophy.  