### PR TITLE
Add last_query_id

### DIFF
--- a/crates/core-executor/src/datafusion/rewriters/session_context.rs
+++ b/crates/core-executor/src/datafusion/rewriters/session_context.rs
@@ -1,7 +1,11 @@
+use crate::models::QueryContext;
+use core_history::{GetQueriesParams, HistoryStore};
 use datafusion::arrow::array::{ListArray, ListBuilder, StringBuilder};
 use datafusion::logical_expr::{Expr, LogicalPlan};
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
-use datafusion_common::{Result, ScalarValue};
+use datafusion_common::{DataFusionError, Result, ScalarValue};
+use df_catalog::block_in_new_runtime;
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 pub struct SessionContextExprRewriter {
@@ -11,6 +15,8 @@ pub struct SessionContextExprRewriter {
     pub warehouse: String,
     pub session_id: String,
     pub version: String,
+    pub query_context: QueryContext,
+    pub history_store: Arc<dyn HistoryStore>,
 }
 
 impl SessionContextExprRewriter {
@@ -35,6 +41,29 @@ impl SessionContextExprRewriter {
             .collect::<Vec<_>>();
         plan.with_new_exprs(new_exprs, inputs)
     }
+
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn last_query_id(&self, index: i64) -> Result<ScalarValue> {
+        let history_store = self.history_store.clone();
+        let worksheet_id = self.query_context.worksheet_id;
+
+        let id = block_in_new_runtime(async move {
+            let mut params = GetQueriesParams::default();
+            if let Some(id) = worksheet_id {
+                params = params.with_worksheet_id(id);
+            }
+            let queries = history_store
+                .get_queries(params)
+                .await
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+                .into_iter()
+                .map(|q| q.id.to_string())
+                .collect::<Vec<_>>();
+            let query_id = get_query_by_index(&queries, index).unwrap_or_default();
+            Ok::<String, DataFusionError>(query_id)
+        })??;
+        Ok(utf8_val(&id))
+    }
 }
 struct ExprRewriter<'a> {
     rewriter: &'a SessionContextExprRewriter,
@@ -55,10 +84,16 @@ impl TreeNodeRewriter for ExprRewriter<'_> {
                 "current_version" => Some(utf8_val(&self.rewriter.version)),
                 "current_client" => Some(utf8_val(format!("Embucket {}", &self.rewriter.version))),
                 "current_session" => Some(utf8_val(&self.rewriter.session_id)),
+                "last_query_id" => {
+                    let index = match fun.args.first() {
+                        Some(Expr::Literal(value)) => value.clone().try_into().unwrap_or(-1),
+                        _ => -1,
+                    };
+                    Some(self.rewriter.last_query_id(index)?)
+                }
                 "current_schemas" => Some(list_val(&self.rewriter.schemas)),
                 _ => None,
             };
-
             if let Some(value) = scalar_value {
                 return Ok(Transformed::yes(Expr::Literal(value).alias(fun.name())));
             }
@@ -81,4 +116,21 @@ fn list_val(items: &[String]) -> ScalarValue {
     builder.append(true);
     let array = builder.finish();
     ScalarValue::List(Arc::new(ListArray::from(array)))
+}
+
+// #[allow(clippy::cast_sign_loss)]
+fn get_query_by_index(queries: &[String], index: i64) -> Option<String> {
+    match index {
+        i if i < 0 => {
+            let abs = i.checked_abs()?.checked_sub(1)?;
+            let abs_usize = usize::try_from(abs).ok()?;
+            queries.get(abs_usize).cloned()
+        }
+        i if i > 0 => {
+            let len = queries.len();
+            let rev_index = usize::try_from(i).ok()?;
+            queries.get(len.checked_sub(rev_index)?).cloned()
+        }
+        _ => None,
+    }
 }

--- a/crates/core-executor/src/datafusion/rewriters/session_context.rs
+++ b/crates/core-executor/src/datafusion/rewriters/session_context.rs
@@ -118,7 +118,6 @@ fn list_val(items: &[String]) -> ScalarValue {
     ScalarValue::List(Arc::new(ListArray::from(array)))
 }
 
-// #[allow(clippy::cast_sign_loss)]
 fn get_query_by_index(queries: &[String], index: i64) -> Option<String> {
     match index {
         i if i < 0 => {

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -159,6 +159,8 @@ impl UserQuery {
             warehouse: "default".to_string(),
             session_id: self.session.ctx.session_id(),
             version: self.session.config.embucket_version.clone(),
+            query_context: self.query_context.clone(),
+            history_store: self.history_store.clone(),
         }
     }
 

--- a/crates/core-executor/src/tests/snapshots/session/query_session_last_query_id.snap
+++ b/crates/core-executor/src/tests/snapshots/session/query_session_last_query_id.snap
@@ -1,0 +1,15 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT\n        length(LAST_QUERY_ID()) > 0 as last,\n        length(LAST_QUERY_ID(-1)) > 0 as last_index,\n        length(LAST_QUERY_ID(2)) > 0  as second,\n        length(LAST_QUERY_ID(100)) = 0 as empty\""
+info: "Setup queries: SET v1 = 'test'; SET v2 = 1; SET v3 = true"
+snapshot_kind: text
+---
+Ok(
+    [
+        "+------+------------+--------+-------+",
+        "| last | last_index | second | empty |",
+        "+------+------------+--------+-------+",
+        "| true | true       | true   | true  |",
+        "+------+------------+--------+-------+",
+    ],
+)

--- a/crates/core-history/Cargo.toml
+++ b/crates/core-history/Cargo.toml
@@ -16,10 +16,10 @@ slatedb = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
+mockall = "0.13.1"
 
 [dev-dependencies]
 tokio = { workspace = true }
-mockall = "0.13.1"
 
 [lints]
 workspace = true

--- a/crates/core-history/src/history_store.rs
+++ b/crates/core-history/src/history_store.rs
@@ -66,6 +66,7 @@ impl GetQueriesParams {
     }
 }
 
+#[mockall::automock]
 #[async_trait]
 pub trait HistoryStore: std::fmt::Debug + Send + Sync {
     async fn add_worksheet(&self, worksheet: Worksheet) -> HistoryStoreResult<Worksheet>;

--- a/crates/core-history/src/lib.rs
+++ b/crates/core-history/src/lib.rs
@@ -6,3 +6,6 @@ pub mod store;
 pub use entities::*;
 pub use history_store::*;
 pub use store::*;
+
+#[cfg(test)]
+pub use history_store::MockHistoryStore;

--- a/crates/df-builtins/src/session/last_query_id.rs
+++ b/crates/df-builtins/src/session/last_query_id.rs
@@ -1,0 +1,57 @@
+use datafusion::arrow::datatypes::DataType;
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::TypeSignature;
+use datafusion_common::ScalarValue;
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use std::any::Any;
+
+/// Returns the ID of a specified query in the current session.
+/// If no query is specified, the most recently-executed query is returned.
+#[derive(Debug)]
+pub struct LastQueryId {
+    signature: Signature,
+}
+
+impl Default for LastQueryId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LastQueryId {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature {
+                type_signature: TypeSignature::OneOf(vec![
+                    TypeSignature::VariadicAny,
+                    TypeSignature::Nullary,
+                ]),
+                volatility: Volatility::Volatile,
+            },
+        }
+    }
+}
+
+impl ScalarUDFImpl for LastQueryId {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "last_query_id"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))
+    }
+}
+
+crate::macros::make_udf_function!(LastQueryId);

--- a/crates/df-builtins/src/tests/query.rs
+++ b/crates/df-builtins/src/tests/query.rs
@@ -26,3 +26,8 @@ test_query!(
     "SELECT CURRENT_SESSION()",
     snapshot_path = "session"
 );
+test_query!(
+    session_last_query_id,
+    "SELECT LAST_QUERY_ID(), LAST_QUERY_ID(-1), LAST_QUERY_ID(2)",
+    snapshot_path = "session"
+);

--- a/crates/df-builtins/src/tests/snapshots/session/query_session_last_query_id.snap
+++ b/crates/df-builtins/src/tests/snapshots/session/query_session_last_query_id.snap
@@ -1,0 +1,14 @@
+---
+source: crates/df-builtins/src/tests/query.rs
+description: "\"SELECT LAST_QUERY_ID(), LAST_QUERY_ID(-1), LAST_QUERY_ID(2)\""
+snapshot_kind: text
+---
+Ok(
+    [
+        "+-----------------+--------------------------+-------------------------+",
+        "| last_query_id() | last_query_id(Int64(-1)) | last_query_id(Int64(2)) |",
+        "+-----------------+--------------------------+-------------------------+",
+        "|                 |                          |                         |",
+        "+-----------------+--------------------------+-------------------------+",
+    ],
+)

--- a/crates/df-catalog/src/catalogs/embucket/catalog.rs
+++ b/crates/df-catalog/src/catalogs/embucket/catalog.rs
@@ -1,5 +1,5 @@
 use super::schema::EmbucketSchema;
-use crate::catalogs::embucket::block_in_new_runtime;
+use crate::block_in_new_runtime;
 use core_metastore::{Metastore, SchemaIdent};
 use core_utils::scan_iterator::ScanIterator;
 use datafusion::catalog::{CatalogProvider, SchemaProvider};

--- a/crates/df-catalog/src/catalogs/embucket/mod.rs
+++ b/crates/df-catalog/src/catalogs/embucket/mod.rs
@@ -1,27 +1,3 @@
-use datafusion_common::DataFusionError;
-use std::future::Future;
-use tokio::runtime::Builder;
-
 pub mod catalog;
 pub mod iceberg_catalog;
 pub mod schema;
-
-pub fn block_in_new_runtime<F, R>(future: F) -> Result<R, DataFusionError>
-where
-    F: Future<Output = R> + Send + 'static,
-    R: Send + 'static,
-{
-    std::thread::spawn(move || {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|_| DataFusionError::Execution("Failed to create Tokio runtime".to_string()))
-            .map(|rt| rt.block_on(future))
-    })
-    .join()
-    .unwrap_or_else(|_| {
-        Err(DataFusionError::Execution(
-            "Thread panicked while executing future".to_string(),
-        ))
-    })
-}

--- a/crates/df-catalog/src/catalogs/embucket/schema.rs
+++ b/crates/df-catalog/src/catalogs/embucket/schema.rs
@@ -1,4 +1,4 @@
-use crate::catalogs::embucket::block_in_new_runtime;
+use crate::block_in_new_runtime;
 use async_trait::async_trait;
 use core_metastore::error::MetastoreError;
 use core_metastore::{Metastore, SchemaIdent, TableIdent};

--- a/crates/df-catalog/src/lib.rs
+++ b/crates/df-catalog/src/lib.rs
@@ -1,3 +1,6 @@
+use datafusion_common::DataFusionError;
+use tokio::runtime::Builder;
+
 #[allow(clippy::module_inception)]
 pub mod catalog;
 pub mod catalog_list;
@@ -9,6 +12,26 @@ pub mod table;
 
 #[cfg(test)]
 pub mod tests;
+
+pub fn block_in_new_runtime<F, R>(future: F) -> Result<R, DataFusionError>
+where
+    F: Future<Output = R> + Send + 'static,
+    R: Send + 'static,
+{
+    std::thread::spawn(move || {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|_| DataFusionError::Execution("Failed to create Tokio runtime".to_string()))
+            .map(|rt| rt.block_on(future))
+    })
+    .join()
+    .unwrap_or_else(|_| {
+        Err(DataFusionError::Execution(
+            "Thread panicked while executing future".to_string(),
+        ))
+    })
+}
 
 pub mod test_utils {
     use datafusion::arrow::array::{ArrayRef, RecordBatch};

--- a/test/sql/sql-reference-functions/Context/last_query_id.slt
+++ b/test/sql/sql-reference-functions/Context/last_query_id.slt
@@ -1,9 +1,9 @@
-query I
+query T
 SELECT LAST_QUERY_ID()
 ----
 <REGEX>:['\"]?(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|\d{1,20})['\"]?|NULL
 
-query I
+query T
 SELECT LAST_QUERY_ID(1)
 ----
 <REGEX>:['\"]?(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|\d{1,20})['\"]?|NULL

--- a/test/sql/sql-reference-functions/Context/last_query_id.slt
+++ b/test/sql/sql-reference-functions/Context/last_query_id.slt
@@ -1,8 +1,9 @@
-query T
+query I
 SELECT LAST_QUERY_ID()
 ----
 <REGEX>:['\"]?(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|\d{1,20})['\"]?|NULL
-query T
+
+query I
 SELECT LAST_QUERY_ID(1)
 ----
 <REGEX>:['\"]?(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|\d{1,20})['\"]?|NULL

--- a/test/sql/sql-reference-functions/Context/last_query_id.slt
+++ b/test/sql/sql-reference-functions/Context/last_query_id.slt
@@ -1,10 +1,9 @@
 query T
 SELECT LAST_QUERY_ID()
 ----
-<REGEX>:['\"]?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}['\"]?|NULL
-
+<REGEX>:['\"]?(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|\d{1,20})['\"]?|NULL
 query T
 SELECT LAST_QUERY_ID(1)
 ----
-<REGEX>:['\"]?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}['\"]?
+<REGEX>:['\"]?(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|\d{1,20})['\"]?|NULL
 


### PR DESCRIPTION
- Added last_query_id function to session handling.
https://docs.snowflake.com/en/sql-reference/functions/last_query_id

This new function returns the ID of the last successfully executed query within a session. It enables clients to retrieve and reference the most recent query for purposes such as result tracking, follow-up analysis, or UI updates.
Closes #594 