### PR TITLE
Add TOP clause support

### DIFF
--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -44,8 +44,8 @@ use df_catalog::catalog::CachingCatalog;
 use df_catalog::information_schema::session_params::SessionProperty;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::visitors::{
-    copy_into_identifiers, functions_rewriter, inline_aliases_in_query, json_element, top_limit,
-    select_expr_aliases, table_result_scan,
+    copy_into_identifiers, functions_rewriter, inline_aliases_in_query, json_element,
+    select_expr_aliases, table_result_scan, top_limit,
     unimplemented::functions_checker::visit as unimplemented_functions_checker,
 };
 use iceberg_rust::catalog::Catalog;

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -44,7 +44,7 @@ use df_catalog::catalog::CachingCatalog;
 use df_catalog::information_schema::session_params::SessionProperty;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::visitors::{
-    copy_into_identifiers, functions_rewriter, inline_aliases_in_query, json_element,
+    copy_into_identifiers, functions_rewriter, inline_aliases_in_query, json_element, top_limit,
     select_expr_aliases, table_result_scan,
     unimplemented::functions_checker::visit as unimplemented_functions_checker,
 };
@@ -182,6 +182,7 @@ impl UserQuery {
         if let DFStatement::Statement(value) = statement {
             json_element::visit(value);
             functions_rewriter::visit(value);
+            top_limit::visit(value);
             unimplemented_functions_checker(value)
                 // Can't use context here since underlying Error require handling
                 .map_err(|e| {

--- a/crates/core-executor/src/tests/sql/commands/mod.rs
+++ b/crates/core-executor/src/tests/sql/commands/mod.rs
@@ -1,3 +1,3 @@
 mod pivot;
-mod unpivot;
 mod top;
+mod unpivot;

--- a/crates/core-executor/src/tests/sql/commands/mod.rs
+++ b/crates/core-executor/src/tests/sql/commands/mod.rs
@@ -1,2 +1,3 @@
 mod pivot;
 mod unpivot;
+mod top;

--- a/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_basic.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_basic.snap
@@ -1,0 +1,17 @@
+---
+source: crates/embucket-functions/src/tests/sql/commands/top.rs
+description: "\"SELECT TOP 4 c1 FROM testtable\""
+info: "Setup queries: CREATE OR REPLACE TABLE testtable (c1 STRING); INSERT INTO testtable (c1) VALUES ('1'), ('2'), ('3'), ('20'), ('19'), ('18'), ('1'), ('2'), ('3'), ('4'), (NULL), ('30'), (NULL)"
+---
+Ok(
+    [
+        "+----+",
+        "| c1 |",
+        "+----+",
+        "| 1  |",
+        "| 2  |",
+        "| 3  |",
+        "| 20 |",
+        "+----+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_in_cte.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_in_cte.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/core-executor/src/tests/sql/commands/top.rs
-description: "\"SELECT TOP 4 c1 FROM testtable ORDER BY c1\""
+description: "\"WITH cte AS (SELECT TOP 2 c1 FROM testtable ORDER BY c1) SELECT * FROM cte ORDER BY c1\""
 info: "Setup queries: CREATE OR REPLACE TABLE testtable (c1 STRING); INSERT INTO testtable (c1) VALUES ('1'), ('2'), ('3'), ('20'), ('19'), ('18'), ('1'), ('2'), ('3'), ('4'), (NULL), ('30'), (NULL)"
 ---
 Ok(
@@ -10,8 +10,6 @@ Ok(
         "+----+",
         "| 1  |",
         "| 1  |",
-        "| 18 |",
-        "| 19 |",
         "+----+",
     ],
 )

--- a/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_in_subquery.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_in_subquery.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/core-executor/src/tests/sql/commands/top.rs
-description: "\"SELECT TOP 4 c1 FROM testtable ORDER BY c1\""
+description: "\"SELECT c1 FROM (SELECT TOP 3 c1 FROM testtable ORDER BY c1) sub ORDER BY c1 DESC\""
 info: "Setup queries: CREATE OR REPLACE TABLE testtable (c1 STRING); INSERT INTO testtable (c1) VALUES ('1'), ('2'), ('3'), ('20'), ('19'), ('18'), ('1'), ('2'), ('3'), ('4'), (NULL), ('30'), (NULL)"
 ---
 Ok(
@@ -8,10 +8,9 @@ Ok(
         "+----+",
         "| c1 |",
         "+----+",
-        "| 1  |",
-        "| 1  |",
         "| 18 |",
-        "| 19 |",
+        "| 1  |",
+        "| 1  |",
         "+----+",
     ],
 )

--- a/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_in_union.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_in_union.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/core-executor/src/tests/sql/commands/top.rs
-description: "\"SELECT c1 FROM (SELECT TOP 1 c1 FROM testtable ORDER BY c1 ASC) UNION ALL (SELECT TOP 1 c1 FROM testtable ORDER BY c1 DESC)\""
+description: "\"SELECT c1 FROM (SELECT TOP 1 c1 FROM testtable ORDER BY c1 ASC) UNION ALL (SELECT TOP 1 c1 FROM testtable ORDER BY c1 DESC) ORDER BY c1\""
 info: "Setup queries: CREATE OR REPLACE TABLE testtable (c1 STRING); INSERT INTO testtable (c1) VALUES ('1'), ('2'), ('3'), ('20'), ('19'), ('18'), ('1'), ('2'), ('3'), ('4'), (NULL), ('30'), (NULL)"
 ---
 Ok(
@@ -8,8 +8,8 @@ Ok(
         "+----+",
         "| c1 |",
         "+----+",
-        "|    |",
         "| 1  |",
+        "|    |",
         "+----+",
     ],
 )

--- a/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_in_union.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_in_union.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/core-executor/src/tests/sql/commands/top.rs
-description: "\"SELECT TOP 4 c1 FROM testtable ORDER BY c1\""
+description: "\"SELECT c1 FROM (SELECT TOP 1 c1 FROM testtable ORDER BY c1 ASC) UNION ALL (SELECT TOP 1 c1 FROM testtable ORDER BY c1 DESC)\""
 info: "Setup queries: CREATE OR REPLACE TABLE testtable (c1 STRING); INSERT INTO testtable (c1) VALUES ('1'), ('2'), ('3'), ('20'), ('19'), ('18'), ('1'), ('2'), ('3'), ('4'), (NULL), ('30'), (NULL)"
 ---
 Ok(
@@ -8,10 +8,8 @@ Ok(
         "+----+",
         "| c1 |",
         "+----+",
+        "|    |",
         "| 1  |",
-        "| 1  |",
-        "| 18 |",
-        "| 19 |",
         "+----+",
     ],
 )

--- a/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_with_limit.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_with_limit.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/core-executor/src/tests/sql/commands/top.rs
-description: "\"SELECT TOP 4 c1 FROM testtable ORDER BY c1\""
+description: "\"SELECT TOP 2 c1 FROM (SELECT TOP 4 c1 FROM testtable ORDER BY c1) sub ORDER BY c1\""
 info: "Setup queries: CREATE OR REPLACE TABLE testtable (c1 STRING); INSERT INTO testtable (c1) VALUES ('1'), ('2'), ('3'), ('20'), ('19'), ('18'), ('1'), ('2'), ('3'), ('4'), (NULL), ('30'), (NULL)"
 ---
 Ok(
@@ -10,8 +10,6 @@ Ok(
         "+----+",
         "| 1  |",
         "| 1  |",
-        "| 18 |",
-        "| 19 |",
         "+----+",
     ],
 )

--- a/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_with_no_order.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_with_no_order.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/core-executor/src/tests/sql/commands/top.rs
-description: "\"SELECT TOP 4 c1 FROM testtable ORDER BY c1\""
+description: "\"SELECT TOP 5 c1 FROM testtable\""
 info: "Setup queries: CREATE OR REPLACE TABLE testtable (c1 STRING); INSERT INTO testtable (c1) VALUES ('1'), ('2'), ('3'), ('20'), ('19'), ('18'), ('1'), ('2'), ('3'), ('4'), (NULL), ('30'), (NULL)"
 ---
 Ok(
@@ -9,8 +9,9 @@ Ok(
         "| c1 |",
         "+----+",
         "| 1  |",
-        "| 1  |",
-        "| 18 |",
+        "| 2  |",
+        "| 3  |",
+        "| 20 |",
         "| 19 |",
         "+----+",
     ],

--- a/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_with_no_order.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/top/query_top_with_no_order.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/core-executor/src/tests/sql/commands/top.rs
-description: "\"SELECT TOP 5 c1 FROM testtable\""
+description: "\"SELECT TOP 5 c1 FROM testtable ORDER BY c1\""
 info: "Setup queries: CREATE OR REPLACE TABLE testtable (c1 STRING); INSERT INTO testtable (c1) VALUES ('1'), ('2'), ('3'), ('20'), ('19'), ('18'), ('1'), ('2'), ('3'), ('4'), (NULL), ('30'), (NULL)"
 ---
 Ok(
@@ -9,10 +9,10 @@ Ok(
         "| c1 |",
         "+----+",
         "| 1  |",
-        "| 2  |",
-        "| 3  |",
-        "| 20 |",
+        "| 1  |",
+        "| 18 |",
         "| 19 |",
+        "| 2  |",
         "+----+",
     ],
 )

--- a/crates/core-executor/src/tests/sql/commands/top.rs
+++ b/crates/core-executor/src/tests/sql/commands/top.rs
@@ -7,7 +7,42 @@ const SETUP_QUERY: [&str; 2] = [
 
 test_query!(
     top_basic,
-    "SELECT TOP 4 c1 FROM testtable",
+    "SELECT TOP 4 c1 FROM testtable ORDER BY c1",
     setup_queries = [SETUP_QUERY[0], SETUP_QUERY[1]],
-    snapshot_path = "top",
+    snapshot_path = "top"
+);
+
+test_query!(
+    top_in_subquery,
+    "SELECT c1 FROM (SELECT TOP 3 c1 FROM testtable ORDER BY c1) sub ORDER BY c1 DESC",
+    setup_queries = [SETUP_QUERY[0], SETUP_QUERY[1]],
+    snapshot_path = "top"
+);
+
+test_query!(
+    top_in_cte,
+    "WITH cte AS (SELECT TOP 2 c1 FROM testtable ORDER BY c1) SELECT * FROM cte ORDER BY c1",
+    setup_queries = [SETUP_QUERY[0], SETUP_QUERY[1]],
+    snapshot_path = "top"
+);
+
+test_query!(
+    top_in_union,
+    "SELECT c1 FROM (SELECT TOP 1 c1 FROM testtable ORDER BY c1 ASC) UNION ALL (SELECT TOP 1 c1 FROM testtable ORDER BY c1 DESC)",
+    setup_queries = [SETUP_QUERY[0], SETUP_QUERY[1]],
+    snapshot_path = "top"
+);
+
+test_query!(
+    top_with_no_order,
+    "SELECT TOP 5 c1 FROM testtable",
+    setup_queries = [SETUP_QUERY[0], SETUP_QUERY[1]],
+    snapshot_path = "top"
+);
+
+test_query!(
+    top_with_limit,
+    "SELECT TOP 2 c1 FROM (SELECT TOP 4 c1 FROM testtable ORDER BY c1) sub ORDER BY c1",
+    setup_queries = [SETUP_QUERY[0], SETUP_QUERY[1]],
+    snapshot_path = "top"
 );

--- a/crates/core-executor/src/tests/sql/commands/top.rs
+++ b/crates/core-executor/src/tests/sql/commands/top.rs
@@ -1,0 +1,13 @@
+use crate::test_query;
+
+const SETUP_QUERY: [&str; 2] = [
+    "CREATE OR REPLACE TABLE testtable (c1 STRING)",
+    "INSERT INTO testtable (c1) VALUES ('1'), ('2'), ('3'), ('20'), ('19'), ('18'), ('1'), ('2'), ('3'), ('4'), (NULL), ('30'), (NULL)",
+];
+
+test_query!(
+    top_basic,
+    "SELECT TOP 4 c1 FROM testtable",
+    setup_queries = [SETUP_QUERY[0], SETUP_QUERY[1]],
+    snapshot_path = "top",
+);

--- a/crates/core-executor/src/tests/sql/commands/top.rs
+++ b/crates/core-executor/src/tests/sql/commands/top.rs
@@ -28,14 +28,14 @@ test_query!(
 
 test_query!(
     top_in_union,
-    "SELECT c1 FROM (SELECT TOP 1 c1 FROM testtable ORDER BY c1 ASC) UNION ALL (SELECT TOP 1 c1 FROM testtable ORDER BY c1 DESC)",
+    "SELECT c1 FROM (SELECT TOP 1 c1 FROM testtable ORDER BY c1 ASC) UNION ALL (SELECT TOP 1 c1 FROM testtable ORDER BY c1 DESC) ORDER BY c1",
     setup_queries = [SETUP_QUERY[0], SETUP_QUERY[1]],
     snapshot_path = "top"
 );
 
 test_query!(
     top_with_no_order,
-    "SELECT TOP 5 c1 FROM testtable",
+    "SELECT TOP 5 c1 FROM testtable ORDER BY c1",
     setup_queries = [SETUP_QUERY[0], SETUP_QUERY[1]],
     snapshot_path = "top"
 );

--- a/crates/embucket-functions/src/visitors/mod.rs
+++ b/crates/embucket-functions/src/visitors/mod.rs
@@ -5,3 +5,5 @@ pub mod json_element;
 pub mod select_expr_aliases;
 pub mod table_result_scan;
 pub mod unimplemented;
+
+pub mod top_limit;

--- a/crates/embucket-functions/src/visitors/top_limit.rs
+++ b/crates/embucket-functions/src/visitors/top_limit.rs
@@ -15,11 +15,17 @@ impl TopLimitVisitor {
             }
         }
 
-        fn process_set_expr(this: &mut TopLimitVisitor, set_expr: &mut SetExpr, outer_limit: &mut Option<Expr>) {
+        fn process_set_expr(
+            this: &mut TopLimitVisitor,
+            set_expr: &mut SetExpr,
+            outer_limit: &mut Option<Expr>,
+        ) {
             match set_expr {
                 SetExpr::Select(select) => {
                     for table_with_joins in &mut select.from {
-                        if let TableFactor::Derived { subquery, .. } = &mut table_with_joins.relation {
+                        if let TableFactor::Derived { subquery, .. } =
+                            &mut table_with_joins.relation
+                        {
                             this.process_query(subquery);
                         }
                     }
@@ -29,7 +35,9 @@ impl TopLimitVisitor {
                             if outer_limit.is_none() {
                                 if let Some(expr) = top.quantity.map(|q| match q {
                                     TopQuantity::Expr(expr) => expr,
-                                    TopQuantity::Constant(n) => Expr::Value(Value::Number(n.to_string(), false).with_empty_span()),
+                                    TopQuantity::Constant(n) => Expr::Value(
+                                        Value::Number(n.to_string(), false).with_empty_span(),
+                                    ),
                                 }) {
                                     *outer_limit = Some(expr);
                                 }
@@ -67,4 +75,3 @@ impl VisitorMut for TopLimitVisitor {
 pub fn visit(stmt: &mut Statement) {
     let _ = stmt.visit(&mut TopLimitVisitor::default());
 }
-

--- a/crates/embucket-functions/src/visitors/top_limit.rs
+++ b/crates/embucket-functions/src/visitors/top_limit.rs
@@ -58,7 +58,6 @@ impl VisitorMut for TopLimitVisitor {
     fn pre_visit_statement(&mut self, stmt: &mut Statement) -> ControlFlow<Self::Break> {
         match stmt {
             Statement::Query(query) => self.process_query(query),
-            Statement::CreateTable { query: Some(q), .. } => self.process_query(q),
             _ => {}
         }
         ControlFlow::Continue(())

--- a/crates/embucket-functions/src/visitors/top_limit.rs
+++ b/crates/embucket-functions/src/visitors/top_limit.rs
@@ -8,6 +8,41 @@ use std::ops::ControlFlow;
 pub struct TopLimitVisitor;
 
 impl TopLimitVisitor {
+    fn process_set_expr(&mut self, set_expr: &mut SetExpr, outer_limit: &mut Option<Expr>) {
+        match set_expr {
+            SetExpr::Select(select) => {
+                for table_with_joins in &mut select.from {
+                    if let TableFactor::Derived { subquery, .. } = &mut table_with_joins.relation {
+                        self.process_query(subquery);
+                    }
+                }
+
+                if let Some(top) = select.top.take() {
+                    if !top.percent && !top.with_ties {
+                        if outer_limit.is_none() {
+                            if let Some(expr) = top.quantity.map(|q| match q {
+                                TopQuantity::Expr(expr) => expr,
+                                TopQuantity::Constant(n) => Expr::Value(
+                                    Value::Number(n.to_string(), false).with_empty_span(),
+                                ),
+                            }) {
+                                *outer_limit = Some(expr);
+                            }
+                        }
+                    } else {
+                        select.top = Some(top);
+                    }
+                }
+            }
+            SetExpr::Query(q) => self.process_query(q),
+            SetExpr::SetOperation { left, right, .. } => {
+                self.process_set_expr(left, outer_limit);
+                self.process_set_expr(right, outer_limit);
+            }
+            _ => {}
+        }
+    }
+
     fn process_query(&mut self, query: &mut Query) {
         if let Some(with) = query.with.as_mut() {
             for cte in &mut with.cte_tables {
@@ -15,48 +50,7 @@ impl TopLimitVisitor {
             }
         }
 
-        fn process_set_expr(
-            this: &mut TopLimitVisitor,
-            set_expr: &mut SetExpr,
-            outer_limit: &mut Option<Expr>,
-        ) {
-            match set_expr {
-                SetExpr::Select(select) => {
-                    for table_with_joins in &mut select.from {
-                        if let TableFactor::Derived { subquery, .. } =
-                            &mut table_with_joins.relation
-                        {
-                            this.process_query(subquery);
-                        }
-                    }
-
-                    if let Some(top) = select.top.take() {
-                        if !top.percent && !top.with_ties {
-                            if outer_limit.is_none() {
-                                if let Some(expr) = top.quantity.map(|q| match q {
-                                    TopQuantity::Expr(expr) => expr,
-                                    TopQuantity::Constant(n) => Expr::Value(
-                                        Value::Number(n.to_string(), false).with_empty_span(),
-                                    ),
-                                }) {
-                                    *outer_limit = Some(expr);
-                                }
-                            }
-                        } else {
-                            select.top = Some(top);
-                        }
-                    }
-                }
-                SetExpr::Query(q) => this.process_query(q),
-                SetExpr::SetOperation { left, right, .. } => {
-                    process_set_expr(this, left, outer_limit);
-                    process_set_expr(this, right, outer_limit);
-                }
-                _ => {}
-            }
-        }
-
-        process_set_expr(self, &mut query.body, &mut query.limit);
+        self.process_set_expr(&mut query.body, &mut query.limit);
     }
 }
 
@@ -64,14 +58,13 @@ impl VisitorMut for TopLimitVisitor {
     type Break = ();
 
     fn pre_visit_statement(&mut self, stmt: &mut Statement) -> ControlFlow<Self::Break> {
-        match stmt {
-            Statement::Query(query) => self.process_query(query),
-            _ => {}
+        if let Statement::Query(query) = stmt {
+            self.process_query(query);
         }
         ControlFlow::Continue(())
     }
 }
 
 pub fn visit(stmt: &mut Statement) {
-    let _ = stmt.visit(&mut TopLimitVisitor::default());
+    let _ = stmt.visit(&mut TopLimitVisitor);
 }

--- a/crates/embucket-functions/src/visitors/top_limit.rs
+++ b/crates/embucket-functions/src/visitors/top_limit.rs
@@ -1,0 +1,71 @@
+use datafusion_expr::sqlparser::ast::VisitMut;
+use datafusion_expr::sqlparser::ast::{
+    Expr, Query, SetExpr, Statement, TableFactor, TopQuantity, Value, VisitorMut,
+};
+use std::ops::ControlFlow;
+
+#[derive(Debug, Default)]
+pub struct TopLimitVisitor;
+
+impl TopLimitVisitor {
+    fn process_query(&mut self, query: &mut Query) {
+        if let Some(with) = query.with.as_mut() {
+            for cte in &mut with.cte_tables {
+                self.process_query(&mut cte.query);
+            }
+        }
+
+        fn process_set_expr(this: &mut TopLimitVisitor, set_expr: &mut SetExpr, outer_limit: &mut Option<Expr>) {
+            match set_expr {
+                SetExpr::Select(select) => {
+                    for table_with_joins in &mut select.from {
+                        if let TableFactor::Derived { subquery, .. } = &mut table_with_joins.relation {
+                            this.process_query(subquery);
+                        }
+                    }
+
+                    if let Some(top) = select.top.take() {
+                        if !top.percent && !top.with_ties {
+                            if outer_limit.is_none() {
+                                if let Some(expr) = top.quantity.map(|q| match q {
+                                    TopQuantity::Expr(expr) => expr,
+                                    TopQuantity::Constant(n) => Expr::Value(Value::Number(n.to_string(), false).with_empty_span()),
+                                }) {
+                                    *outer_limit = Some(expr);
+                                }
+                            }
+                        } else {
+                            select.top = Some(top);
+                        }
+                    }
+                }
+                SetExpr::Query(q) => this.process_query(q),
+                SetExpr::SetOperation { left, right, .. } => {
+                    process_set_expr(this, left, outer_limit);
+                    process_set_expr(this, right, outer_limit);
+                }
+                _ => {}
+            }
+        }
+
+        process_set_expr(self, &mut query.body, &mut query.limit);
+    }
+}
+
+impl VisitorMut for TopLimitVisitor {
+    type Break = ();
+
+    fn pre_visit_statement(&mut self, stmt: &mut Statement) -> ControlFlow<Self::Break> {
+        match stmt {
+            Statement::Query(query) => self.process_query(query),
+            Statement::CreateTable { query: Some(q), .. } => self.process_query(q),
+            _ => {}
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+pub fn visit(stmt: &mut Statement) {
+    let _ = stmt.visit(&mut TopLimitVisitor::default());
+}
+


### PR DESCRIPTION
## Summary
- rewrite TOP clauses into LIMIT via a visitor
- apply the new visitor during SQL post-processing
- add snapshot tests for TOP queries

## Testing
- `cargo test -p core-executor --quiet` *(fails: heavy build, terminated)*
- `python3 test/slt_runner_targeted.py test/sql/sql-reference-commands/Query_syntax/top_n.slt` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68416cb0f4348322ad51489716fd8c94