### PR TITLE
Fix result_scan columns for empty records batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,9 @@ name = "arrow-schema"
 version = "55.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73a47aa0c771b5381de2b7f16998d351a6f4eb839f1e13d48353e17e873d969b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "arrow-select"
@@ -1845,6 +1848,7 @@ dependencies = [
 name = "core-executor"
 version = "0.1.0"
 dependencies = [
+ "arrow-schema 55.1.0",
  "async-trait",
  "aws-config",
  "aws-credential-types",
@@ -2922,6 +2926,7 @@ name = "embucket-functions"
 version = "0.1.0"
 dependencies = [
  "ahash 0.8.12",
+ "arrow-schema 55.1.0",
  "base64 0.22.1",
  "bytes",
  "chrono",

--- a/crates/core-executor/Cargo.toml
+++ b/crates/core-executor/Cargo.toml
@@ -10,6 +10,7 @@ core-metastore = { path = "../core-metastore" }
 core-history = {  path = "../core-history" }
 df-catalog = { path = "../df-catalog" }
 embucket-functions = { path = "../embucket-functions" }
+arrow-schema = { version = "55", features = ["serde"] }
 async-trait = { workspace = true }
 aws-config = { workspace = true }
 aws-credential-types = { workspace = true }

--- a/crates/core-executor/src/models.rs
+++ b/crates/core-executor/src/models.rs
@@ -69,7 +69,7 @@ impl QueryResult {
 
     #[must_use]
     pub fn column_info(&self) -> Vec<ColumnInfo> {
-        ColumnInfo::from_batch(&self.schema)
+        ColumnInfo::from_schema(&self.schema)
     }
 }
 
@@ -108,7 +108,7 @@ impl ColumnInfo {
     }
 
     #[must_use]
-    pub fn from_batch(schema: &Arc<Schema>) -> Vec<Self> {
+    pub fn from_schema(schema: &Arc<Schema>) -> Vec<Self> {
         let mut column_infos = Vec::new();
         for field in schema.fields() {
             column_infos.push(Self::from_field(field));

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -1322,7 +1322,7 @@ impl UserQuery {
                     let is_table_func = self
                         .session
                         .ctx
-                        .table_function(table_name.to_string().as_str())
+                        .table_function(table_name.to_string().to_lowercase().as_str())
                         .is_ok();
                     if !cte_names.contains(&table_name.to_string()) && !is_table_func {
                         match self.resolve_table_object_name(table_name.0.clone()) {

--- a/crates/core-executor/src/utils.rs
+++ b/crates/core-executor/src/utils.rs
@@ -518,10 +518,13 @@ pub fn query_result_to_result_set(query_result: &QueryResult) -> ExecutionResult
         })
         .collect();
 
+    // Serialize original Schema into a JSON string
+    let schema = serde_json::to_string(&query_result.schema).context(SerdeParseSnafu)?;
     Ok(ResultSet {
         columns,
         rows,
         data_format: data_format.to_string(),
+        schema,
     })
 }
 

--- a/crates/core-history/src/entities/result_set.rs
+++ b/crates/core-history/src/entities/result_set.rs
@@ -22,4 +22,5 @@ pub struct ResultSet {
     pub columns: Vec<Column>,
     pub rows: Vec<Row>,
     pub data_format: String,
+    pub schema: String,
 }

--- a/crates/embucket-functions/Cargo.toml
+++ b/crates/embucket-functions/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license-file.workspace = true
 
 [dependencies]
+arrow-schema = { version = "55", features = ["serde"] }
 chrono = { workspace = true }
 core-history = { path = "../core-history" }
 datafusion = { workspace = true }

--- a/crates/embucket-functions/src/table/result_scan.rs
+++ b/crates/embucket-functions/src/table/result_scan.rs
@@ -149,7 +149,7 @@ fn utf8_val(val: impl Into<String>) -> ScalarValue {
     ScalarValue::Utf8(Some(val.into()))
 }
 
-pub fn convert_resultset_to_arrow_json_lines(
+fn convert_resultset_to_arrow_json_lines(
     result_set: &ResultSet,
 ) -> Result<String, DataFusionError> {
     let mut lines = String::new();

--- a/crates/embucket-functions/src/table/result_scan.rs
+++ b/crates/embucket-functions/src/table/result_scan.rs
@@ -4,12 +4,13 @@ use core_history::{GetQueriesParams, HistoryStore, QueryRecord};
 use datafusion::arrow;
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::json::reader::{ReaderBuilder, infer_json_schema};
+use datafusion::arrow::json::StructMode;
+use datafusion::arrow::json::reader::ReaderBuilder;
 use datafusion::catalog::{TableFunctionImpl, TableProvider};
 use datafusion::datasource::MemTable;
 use datafusion_common::{DataFusionError, Result as DFResult, ScalarValue, exec_err};
 use datafusion_expr::Expr;
-use std::io::{BufReader, Cursor};
+use std::io::Cursor;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -85,12 +86,14 @@ impl ResultScanFunc {
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
         let arrow_json = convert_resultset_to_arrow_json_lines(&result_set)?;
-        let mut buf_reader = BufReader::new(Cursor::new(&arrow_json));
-        let (inferred_schema, _) = infer_json_schema(&mut buf_reader, None)
+
+        // Parse schema from serialized JSON
+        let schema_value = serde_json::from_str(&result_set.schema)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-        let schema_ref: SchemaRef = Arc::new(inferred_schema);
+        let schema_ref: SchemaRef = Arc::new(schema_value);
         let json_reader = ReaderBuilder::new(schema_ref.clone())
+            .with_struct_mode(StructMode::ListOnly)
             .build(Cursor::new(&arrow_json))
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
@@ -146,20 +149,17 @@ fn utf8_val(val: impl Into<String>) -> ScalarValue {
     ScalarValue::Utf8(Some(val.into()))
 }
 
-fn convert_resultset_to_arrow_json_lines(
+pub fn convert_resultset_to_arrow_json_lines(
     result_set: &ResultSet,
 ) -> Result<String, DataFusionError> {
-    let mut output = String::new();
-
+    let mut lines = String::new();
     for row in &result_set.rows {
-        let mut record = serde_json::Map::with_capacity(result_set.columns.len());
-        for (col, value) in result_set.columns.iter().zip(&row.0) {
-            record.insert(col.name.clone(), value.clone());
-        }
-        let json_line =
-            serde_json::to_string(&record).map_err(|e| DataFusionError::External(Box::new(e)))?;
-        output.push_str(&json_line);
-        output.push('\n');
+        let json_value = serde_json::Value::Array(row.0.clone());
+        lines.push_str(
+            &serde_json::to_string(&json_value)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?,
+        );
+        lines.push('\n');
     }
-    Ok(output)
+    Ok(lines)
 }

--- a/crates/embucket-functions/src/tests/utils.rs
+++ b/crates/embucket-functions/src/tests/utils.rs
@@ -44,9 +44,9 @@ pub fn history_store_mock() -> Arc<dyn HistoryStore> {
         {
             "columns": [{"name":"a","type":"text"},{"name":"b","type":"text"},{"name":"c","type":"text"}],
             "rows": [[1,"2",true],[2.0,"4",false]],
-            "data_format": "arrow"
-        }
-        "#;
+            "data_format": "arrow",
+            "schema": "{\"fields\":[{\"name\":\"a\",\"data_type\":\"Float64\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}},{\"name\":\"b\",\"data_type\":\"Utf8\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}},{\"name\":\"c\",\"data_type\":\"Boolean\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false,\"metadata\":{}}],\"metadata\":{}}"
+        }"#;
         record.result = Some(buf.to_string());
         if id == 500 {
             return Err(HistoryStoreError::ExecutionResult {


### PR DESCRIPTION
- **Added schema serialization to ResultSet to handle empty record batches**

  - Previously, when the ResultSet contained no rows (empty record batches), the schema was inferred at runtime using infer_json_schema, which sometimes resulted in an **empty schema**. This caused issues downstream because a valid schema is required even when no data rows are present (e.g., for joins).
  - To address this,  extended the ResultSet struct to include a serialized schema field. This allows the schema to be preserved and reused directly, ensuring consistent and complete schema information regardless of the presence of rows.

- Additionally, **enabled the serde feature for arrow-schema** to support serialization and deserialization of Schema. This is necessary because DataFusion itself does not enable this feature by default, so we had to explicitly activate it in our build to make schema (de)serialization possible.

Closes #1058 #1037
Related to #1057

