### PR TITLE
separated positional parameters functionality in tests

### DIFF
--- a/test/sql/other/aliases.slt
+++ b/test/sql/other/aliases.slt
@@ -1,0 +1,325 @@
+# Test basic column aliases
+query TT
+SELECT 'text' as alias, alias
+----
+text	text
+
+# Test multiple column aliases
+query TTT
+SELECT 'hello' AS greeting, 'world' AS target, greeting || ' ' || target AS message
+----
+hello	world	hello world
+
+# Test numeric expression aliases
+query III
+SELECT 10 AS num1, 20 AS num2, num1 + num2 AS sum_result
+----
+10	20	30
+
+# Test function aliases
+query TI
+SELECT 'hello world' AS text_val, LENGTH(text_val) AS text_length
+----
+hello world	11
+
+# Test case-insensitive aliases
+query TT
+SELECT 'test' AS MyAlias, myalias AS lower_ref
+----
+test	test
+
+# Setup test tables for more complex alias scenarios
+exclude-from-coverage
+statement ok
+CREATE OR REPLACE TABLE employees (
+    id INTEGER,
+    name VARCHAR,
+    department VARCHAR,
+    salary INTEGER
+);
+
+exclude-from-coverage
+statement ok
+INSERT INTO employees VALUES
+    (1, 'Alice', 'Engineering', 75000),
+    (2, 'Bob', 'Sales', 60000),
+    (3, 'Charlie', 'Engineering', 80000),
+    (4, 'Diana', 'Marketing', 65000);
+
+exclude-from-coverage
+statement ok
+CREATE OR REPLACE TABLE departments (
+    dept_name VARCHAR,
+    budget INTEGER
+);
+
+exclude-from-coverage
+statement ok
+INSERT INTO departments VALUES
+    ('Engineering', 500000),
+    ('Sales', 300000),
+    ('Marketing', 200000);
+
+# Test table aliases
+query TTI
+SELECT e.name, e.department, e.salary
+FROM employees AS e
+WHERE e.salary > 65000
+ORDER BY e.name
+----
+Alice	Engineering	75000
+Charlie	Engineering	80000
+
+# Test table aliases without AS keyword
+query TT
+SELECT emp.name, emp.department
+FROM employees emp
+WHERE emp.department = 'Sales'
+----
+Bob	Sales
+
+# Test join with table aliases
+query TTII
+SELECT e.name AS employee_name, e.department AS dept, e.salary AS emp_salary, d.budget AS dept_budget
+FROM employees e
+JOIN departments d ON e.department = d.dept_name
+WHERE e.salary > 70000
+ORDER BY e.name
+----
+Alice	Engineering	75000	500000
+Charlie	Engineering	80000	500000
+
+# Test aliases in ORDER BY clause
+query TI
+SELECT name AS employee_name, salary AS emp_salary
+FROM employees
+ORDER BY emp_salary DESC, employee_name
+----
+Charlie	80000
+Alice	75000
+Diana	65000
+Bob	60000
+
+# Test aliases in GROUP BY clause
+query TI
+SELECT department AS dept, COUNT(*) AS employee_count
+FROM employees
+GROUP BY dept
+ORDER BY dept
+----
+Engineering	2
+Marketing	1
+Sales	1
+
+# Test aliases in HAVING clause
+query TI
+SELECT department AS dept, AVG(salary) AS avg_salary
+FROM employees
+GROUP BY dept
+HAVING avg_salary > 65000
+ORDER BY dept
+----
+Engineering	77500.000000
+
+# Test subquery aliases
+query TI
+SELECT sub.dept_name, sub.emp_count
+FROM (
+    SELECT department AS dept_name, COUNT(*) AS emp_count
+    FROM employees
+    GROUP BY department
+) AS sub
+WHERE sub.emp_count > 1
+----
+Engineering	2
+
+# Test derived table aliases with column aliases
+query TI
+SELECT dept_info.name AS department_name, dept_info.count AS total_employees
+FROM (
+    SELECT department AS name, COUNT(*) AS count
+    FROM employees
+    GROUP BY department
+) dept_info
+ORDER BY dept_info.count DESC
+----
+Engineering	2
+Sales	1
+Marketing	1
+
+# Test CTE aliases
+query TI
+WITH dept_stats AS (
+    SELECT department AS dept_name, COUNT(*) AS emp_count, AVG(salary) AS avg_sal
+    FROM employees
+    GROUP BY department
+)
+SELECT dept_stats.dept_name, dept_stats.emp_count
+FROM dept_stats
+WHERE dept_stats.avg_sal > 70000
+----
+Engineering	2
+
+# Test multiple CTEs with aliases
+query TTI
+WITH
+high_earners AS (
+    SELECT name AS emp_name, department AS dept, salary AS sal
+    FROM employees
+    WHERE salary > 70000
+),
+dept_budgets AS (
+    SELECT dept_name AS department, budget AS total_budget
+    FROM departments
+)
+SELECT he.emp_name, he.dept, db.total_budget
+FROM high_earners he
+JOIN dept_budgets db ON he.dept = db.department
+ORDER BY he.emp_name
+----
+Alice	Engineering	500000
+Charlie	Engineering	500000
+
+# Test complex expression aliases
+query TTII
+SELECT
+    name AS emp_name,
+    UPPER(department) AS dept_upper,
+    salary * 12 AS annual_salary,
+    CASE
+        WHEN salary > 70000 THEN salary * 0.1
+        ELSE salary * 0.05
+    END AS bonus
+FROM employees
+WHERE annual_salary > 700000
+ORDER BY emp_name
+----
+Alice	ENGINEERING	900000	7500.00
+Bob	SALES	720000	3000.00
+Charlie	ENGINEERING	960000	8000.00
+Diana	MARKETING	780000	3250.00
+
+# Test nested subquery with aliases
+query TI
+SELECT outer_query.dept, outer_query.max_sal
+FROM (
+    SELECT
+        inner_query.department AS dept,
+        MAX(inner_query.salary) AS max_sal
+    FROM (
+        SELECT name, department, salary
+        FROM employees
+        WHERE salary > 60000
+    ) AS inner_query
+    GROUP BY inner_query.department
+) AS outer_query
+ORDER BY outer_query.max_sal DESC
+----
+Engineering	80000
+Marketing	65000
+
+# Test aliases with window functions
+query TII
+SELECT
+    name AS emp_name,
+    salary AS current_salary,
+    ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary DESC) AS dept_rank
+FROM employees
+ORDER BY dept_rank, current_salary DESC
+----
+Charlie	80000	1
+Diana	65000	1
+Bob	60000	1
+Alice	75000	2
+
+# Test aliases with UNION
+query T
+SELECT name AS person FROM employees WHERE department = 'Engineering'
+UNION
+SELECT 'Manager' AS person
+ORDER BY person
+----
+Alice
+Charlie
+Manager
+
+# Test table alias with qualified column references
+query TT
+SELECT e.name AS employee, d.dept_name AS department
+FROM employees e, departments d
+WHERE e.department = d.dept_name AND e.salary > 70000
+ORDER BY e.name
+----
+Alice	Engineering
+Charlie	Engineering
+
+# Test alias scoping - alias visible in WHERE clause of same level
+query TT
+SELECT name AS emp_name, salary
+FROM employees
+WHERE emp_name = 'Alice'
+----
+Alice	75000
+
+# Test valid alias usage in subquery WHERE clause
+query TI
+SELECT emp_name, sal
+FROM (
+    SELECT name AS emp_name, salary AS sal
+    FROM employees
+    WHERE salary > 65000
+) sub
+WHERE emp_name LIKE 'A%'
+----
+Alice	75000
+
+# Test aliases with special characters (quoted identifiers)
+query TT
+SELECT name AS "Employee Name", department AS "Dept-Code"
+FROM employees
+WHERE salary = 75000
+----
+Alice	Engineering
+
+# Test self-join with table aliases
+query TTI
+SELECT e1.name AS emp1, e2.name AS emp2, e1.salary AS salary_diff
+FROM employees e1
+JOIN employees e2 ON e1.department = e2.department AND e1.id < e2.id
+WHERE e1.department = 'Engineering'
+----
+Alice	Charlie	75000
+
+# Test alias reuse in different contexts
+query TT
+SELECT
+    (SELECT name FROM employees WHERE id = 1) AS result,
+    (SELECT department FROM employees WHERE id = 1) AS result
+----
+Alice	Engineering
+
+# Test aggregate function aliases
+query TII
+SELECT
+    department AS dept,
+    COUNT(*) AS headcount,
+    SUM(salary) AS total_payroll
+FROM employees
+GROUP BY dept
+HAVING headcount > 1
+----
+Engineering	2	155000
+
+# Test EXISTS with aliases
+query T
+SELECT e.name
+FROM employees e
+WHERE EXISTS (
+    SELECT 1
+    FROM departments d
+    WHERE d.dept_name = e.department AND d.budget > 400000
+)
+ORDER BY e.name
+----
+Alice
+Charlie

--- a/test/sql/other/positional_parameters.slt
+++ b/test/sql/other/positional_parameters.slt
@@ -1,0 +1,233 @@
+# Test basic positional parameter usage
+query T
+SELECT $1 as value FROM VALUES (1), (2), (3)
+----
+1
+2
+3
+
+# Test positional parameters with multiple columns
+query TT
+SELECT $1 as first_col, $2 as second_col FROM VALUES (1, 'one'), (2, 'two'), (3, 'three')
+----
+1	one
+2	two
+3	three
+
+# Test positional parameters in aggregated functions - SUM
+query T
+SELECT SUM($1) as total FROM VALUES (10), (20), (30)
+----
+60
+
+# Test positional parameters in aggregated functions - MAX
+query T
+SELECT MAX($1) as maximum FROM VALUES (10), (20), (30)
+----
+30
+
+# Test positional parameters in aggregated functions - MIN
+query T
+SELECT MIN($1) as minimum FROM VALUES (10), (20), (30)
+----
+10
+
+# Test positional parameters in aggregated functions - AVG
+query T
+SELECT AVG($1) as average FROM VALUES (10), (20), (30)
+----
+20.000000
+
+# Test positional parameters in aggregated functions - COUNT
+query T
+SELECT COUNT($1) as count_values FROM VALUES (10), (20), (30)
+----
+3
+
+# Test multiple positional parameters in different aggregated functions
+query TTT
+SELECT SUM($1) as sum_first, MAX($2) as max_second, AVG($1) as avg_first
+FROM VALUES (10, 100), (20, 200), (30, 300)
+----
+60	300	20.000000
+
+# Test positional parameters with complex aggregations (similar to pivot functionality)
+query TTTTTTTT
+SELECT SUM($1) AS q1_total,
+       SUM($2) AS q2_total,
+       SUM($3) AS q3_total,
+       SUM($4) AS q4_total,
+       MAX($5) AS q1_max,
+       MAX($6) AS q2_max,
+       MAX($7) AS q3_max,
+       MAX($8) AS q4_max
+FROM VALUES (100, 200, 300, 400, 10, 20, 30, 40),
+            (150, 250, 350, 450, 15, 25, 35, 45)
+----
+250	450	650	850	15	25	35	45
+
+# Test positional parameters with GROUP BY (using multiple rows)
+exclude-from-coverage
+statement ok
+CREATE OR REPLACE TABLE test_data(
+  id INT,
+  value1 INT,
+  value2 INT,
+  category TEXT)
+AS SELECT * FROM VALUES
+  (1, 100, 10, 'A'),
+  (2, 200, 20, 'A'),
+  (3, 300, 30, 'B'),
+  (4, 400, 40, 'B')
+
+query TTT
+SELECT category, SUM($2) as sum_val1, MAX($3) as max_val2
+FROM (SELECT category, value1, value2 FROM test_data)
+GROUP BY category
+ORDER BY category
+----
+A	300	20
+B	700	40
+
+# Test positional parameters with HAVING clause
+query TT
+SELECT SUM($1) as total, $2 as category
+FROM VALUES (100, 'A'), (200, 'A'), (50, 'B'), (75, 'B')
+GROUP BY $2
+HAVING SUM($1) > 150
+ORDER BY category
+----
+300	A
+
+# Test positional parameters with ORDER BY
+query TT
+SELECT $1 as value, $2 as category
+FROM VALUES (300, 'C'), (100, 'A'), (200, 'B')
+ORDER BY $1
+----
+100	A
+200	B
+300	C
+
+# Test positional parameters with WHERE clause
+query T
+SELECT $1 as value
+FROM VALUES (10), (20), (30), (40)
+WHERE $1 > 20
+----
+30
+40
+
+# Test positional parameters with mathematical operations
+query TTT
+SELECT $1 + $2 as sum_cols, $1 * $2 as product_cols, $1 - $2 as diff_cols
+FROM VALUES (10, 5), (20, 3), (15, 7)
+----
+15	50	5
+23	60	17
+22	105	8
+
+# Test positional parameters with string operations
+query TT
+SELECT $1 || '_' || $2 as concatenated, UPPER($2) as upper_second
+FROM VALUES ('hello', 'world'), ('foo', 'bar')
+----
+hello_world	WORLD
+foo_bar	BAR
+
+# Test positional parameters with NULL handling
+query TTT
+SELECT $1 as first, $2 as second, COALESCE($2, 'default') as with_default
+FROM VALUES (1, 'value'), (2, NULL), (3, 'another')
+----
+1	value	value
+2	NULL	default
+3	another	another
+
+# Test positional parameters with nested aggregations
+query TT
+SELECT SUM($1) as total_sum, COUNT(DISTINCT $2) as unique_categories
+FROM VALUES (100, 'A'), (200, 'A'), (300, 'B'), (400, 'B'), (500, 'C')
+----
+1500	3
+
+# Test positional parameters with CASE expressions
+query TT
+SELECT $1 as value,
+       CASE WHEN $1 > 200 THEN 'high'
+            WHEN $1 > 100 THEN 'medium'
+            ELSE 'low' END as category
+FROM VALUES (50), (150), (250)
+----
+50	low
+150	medium
+250	high
+
+# Test positional parameters with window functions
+query TTT
+SELECT $1 as value,
+       SUM($1) OVER () as total_sum,
+       ROW_NUMBER() OVER (ORDER BY $1) as row_num
+FROM VALUES (10), (30), (20)
+----
+10	60	1
+20	60	2
+30	60	3
+
+# Test positional parameters with VALUES clause (multiple columns)
+query TT
+SELECT $1 as first_col, $2 as second_col FROM VALUES (1, 'one'), (2, 'two'), (3, 'three')
+----
+1	one
+2	two
+3	three
+
+# Test positional parameters in JOIN operations
+query TT
+SELECT v1.$2, v2.$2
+  FROM (VALUES (1, 'one'), (2, 'two')) AS v1
+        INNER JOIN (VALUES (1, 'One'), (3, 'three')) AS v2
+  WHERE v2.$1 = v1.$1
+----
+one	One
+
+# Test positional parameters in LEFT JOIN
+query TTT
+SELECT v1.$1, v1.$2, v2.$2
+  FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS v1
+        LEFT JOIN (VALUES (1, 'ONE'), (2, 'TWO')) AS v2
+  ON v1.$1 = v2.$1
+ORDER BY v1.$1
+----
+1	one	ONE
+2	two	TWO
+3	three	NULL
+
+# Test positional parameters with UNION
+query T
+SELECT $1 FROM VALUES (1), (2)
+UNION
+SELECT $1 FROM VALUES (3), (4)
+ORDER BY $1
+----
+1
+2
+3
+4
+
+# Test positional parameters with subqueries
+query TT
+SELECT $1, $2
+FROM (
+  SELECT $1, $2
+  FROM VALUES (10, 'ten'), (20, 'twenty'), (30, 'thirty')
+  WHERE $1 > 15
+)
+----
+20	twenty
+30	thirty
+
+# Clean up test table
+exclude-from-coverage
+statement ok
+DROP TABLE IF EXISTS test_data

--- a/test/sql/sql-reference-commands/Query_syntax/pivot.slt
+++ b/test/sql/sql-reference-commands/Query_syntax/pivot.slt
@@ -249,14 +249,14 @@ SELECT *
 3	NULL	NULL	2.000000	2.000000
 
 query TTTTTTTT
-SELECT SUM($1) AS q1_sales_total,
-       SUM($2) AS q2_sales_total,
-       SUM($3) AS q3_sales_total,
-       SUM($4) AS q4_sales_total,
-       MAX($5) AS q1_maximum_discount,
-       MAX($6) AS q2_maximum_discount,
-       MAX($7) AS q3_maximum_discount,
-       MAX($8) AS q4_maximum_discount
+SELECT SUM(q1_sales) AS q1_sales_total,
+       SUM(q2_sales) AS q2_sales_total,
+       SUM(q3_sales) AS q3_sales_total,
+       SUM(q4_sales) AS q4_sales_total,
+       MAX(q1_discount) AS q1_maximum_discount,
+       MAX(q2_discount) AS q2_maximum_discount,
+       MAX(q3_discount) AS q3_maximum_discount,
+       MAX(q4_discount) AS q4_maximum_discount
   FROM
     (SELECT amount,
             quarter AS quarter_amount,
@@ -277,6 +277,10 @@ SELECT SUM($1) AS q1_sales_total,
       '2023_Q2',
       '2023_Q3',
       '2023_Q4'))
+  AS pivoted_data (
+    q1_sales, q2_sales, q3_sales, q4_sales,
+    q1_discount, q2_discount, q3_discount, q4_discount
+  )
 ----
 49900	98700	25700	52200	2	2	2	2
 

--- a/test/sql/sql-reference-commands/Query_syntax/values.slt
+++ b/test/sql/sql-reference-commands/Query_syntax/values.slt
@@ -6,17 +6,17 @@ SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three'))
 3	three
 
 query TT
-SELECT column1, $2 FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three'))
+SELECT column1, column2 FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three'))
 ----
 1	one
 2	two
 3	three
 
 query TT
-SELECT v1.$2, v2.$2
+SELECT v1.column2, v2.column2
   FROM (VALUES (1, 'one'), (2, 'two')) AS v1
         INNER JOIN (VALUES (1, 'One'), (3, 'three')) AS v2
-  WHERE v2.$1 = v1.$1
+  WHERE v2.column1 = v1.column1
 ----
 one	One
 

--- a/test/sql/sql-reference-functions/Table/result_scan.slt
+++ b/test/sql/sql-reference-functions/Table/result_scan.slt
@@ -1,5 +1,5 @@
 query T
-SELECT $1 AS value FROM VALUES (1), (2), (3)
+SELECT column1 AS value FROM VALUES (1), (2), (3)
 ----
 1
 2
@@ -10,24 +10,4 @@ SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID())) WHERE value > 1;
 ----
 2
 3
-
-exclude-from-coverage
-statement ok
-CREATE OR REPLACE PROCEDURE return_JSON()
-    RETURNS VARCHAR
-    LANGUAGE JavaScript
-    AS
-    $$
-        return '{"keyA": "ValueA", "keyB": "ValueB"}';
-    $$
-    ;
-
-exclude-from-coverage
-statement ok
-CALL return_JSON();
-
-query T
-SELECT $1 AS output_col FROM table(RESULT_SCAN(LAST_QUERY_ID()));
-----
-'{"keyA":"ValueA","keyB":"ValueB"}'
 


### PR DESCRIPTION
1. Tests for Pivot, Values, and Result_Scan were using positional parameters functionality ($). Now they don't use it. 
2. There is a separate .slt that extensively tests positional parameters functionality.
3. There is a separate file that extensively tests aliases functionality - because of the recently found issue.