### PR TITLE
dbt version fix

### DIFF
--- a/test/dbt_integration_tests/dbt-gitlab/run.sh
+++ b/test/dbt_integration_tests/dbt-gitlab/run.sh
@@ -36,7 +36,7 @@ echo "###############################"
 echo ""
 echo "Installing dbt core dbt-snowflake..."
 $PYTHON_CMD -m pip install --upgrade pip >/dev/null 2>&1
-$PYTHON_CMD -m pip install dbt-core dbt-snowflake >/dev/null 2>&1
+$PYTHON_CMD -m pip install bt-core==1.9.8 dbt-snowflake==1.9.1 >/dev/null 2>&1
 echo ""
 
 

--- a/test/dbt_integration_tests/dbt-gitlab/run.sh
+++ b/test/dbt_integration_tests/dbt-gitlab/run.sh
@@ -36,7 +36,7 @@ echo "###############################"
 echo ""
 echo "Installing dbt core dbt-snowflake..."
 $PYTHON_CMD -m pip install --upgrade pip >/dev/null 2>&1
-$PYTHON_CMD -m pip install bt-core==1.9.8 dbt-snowflake==1.9.1 >/dev/null 2>&1
+$PYTHON_CMD -m pip install dbt-core==1.9.8 dbt-snowflake==1.9.1 >/dev/null 2>&1
 echo ""
 
 


### PR DESCRIPTION
DBT-Gitlab fails 
```
Could not find a matching compatible version for package brooklyn-data/dbt_artifacts
  Requested range: =2.8.0, =2.8.0
  Compatible versions: ['0.1.0', '0.2.0', '0.2.1', '0.3.0', '0.4.0', '0.4.1', '0.4.2', '0.4.3', '0.4.4', '0.5.0', '0.6.0', '0.7.0', '0.8.0', '1.0.0', '1.1.0', '1.1.1', '1.1.2', '1.2.0', '2.0.0', '2.1.0', '2.1.1', '2.2.0', '2.2.1', '2.2.2', '2.2.3', '2.3.0'
```
The reason is a new dbt version release:
dbt-core 1.10.0 - June 16, 2025

Quick fix is to use the stable version 1.9.8