### PR TITLE
Add FETCH support test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,7 +1887,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ae675e87b284e299830649358b258a78a509687d)",
+ "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=97c03c04230fdf789c49c64eaaa5c0e77ffc8c78)",
  "strum",
  "tokio",
  "tokio-stream",
@@ -2159,7 +2159,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "arrow-ipc 55.1.0",
@@ -2201,7 +2201,7 @@ dependencies = [
  "parquet 55.1.0",
  "rand 0.8.5",
  "regex",
- "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ae675e87b284e299830649358b258a78a509687d)",
+ "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=97c03c04230fdf789c49c64eaaa5c0e77ffc8c78)",
  "tempfile",
  "tokio",
  "url",
@@ -2213,7 +2213,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2238,7 +2238,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2260,7 +2260,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2275,7 +2275,7 @@ dependencies = [
  "parquet 55.1.0",
  "paste",
  "recursive",
- "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ae675e87b284e299830649358b258a78a509687d)",
+ "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=97c03c04230fdf789c49c64eaaa5c0e77ffc8c78)",
  "tokio",
  "web-time",
 ]
@@ -2283,7 +2283,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "futures",
  "log",
@@ -2293,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "async-compression",
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2352,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2406,12 +2406,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 
 [[package]]
 name = "datafusion-execution"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "dashmap",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "chrono",
@@ -2443,13 +2443,13 @@ dependencies = [
  "paste",
  "recursive",
  "serde_json",
- "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ae675e87b284e299830649358b258a78a509687d)",
+ "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=97c03c04230fdf789c49c64eaaa5c0e77ffc8c78)",
 ]
 
 [[package]]
 name = "datafusion-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2461,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "arrow-buffer 55.1.0",
@@ -2489,7 +2489,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "arrow-ord 55.1.0",
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -2602,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "chrono",
@@ -2620,7 +2620,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2672,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "47.0.0"
-source = "git+https://github.com/Embucket/datafusion.git?rev=39d2324436523f2fc8fd375771ec5a4858898d65#39d2324436523f2fc8fd375771ec5a4858898d65"
+source = "git+https://github.com/Embucket/datafusion.git?rev=6218c31e097579342c1f6a0b9f43428e179c2d87#6218c31e097579342c1f6a0b9f43428e179c2d87"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2734,7 +2734,7 @@ dependencies = [
  "log",
  "recursive",
  "regex",
- "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ae675e87b284e299830649358b258a78a509687d)",
+ "sqlparser 0.55.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=97c03c04230fdf789c49c64eaaa5c0e77ffc8c78)",
 ]
 
 [[package]]
@@ -6695,11 +6695,11 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "sqlparser"
 version = "0.55.0"
-source = "git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ae675e87b284e299830649358b258a78a509687d#ae675e87b284e299830649358b258a78a509687d"
+source = "git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=97c03c04230fdf789c49c64eaaa5c0e77ffc8c78#97c03c04230fdf789c49c64eaaa5c0e77ffc8c78"
 dependencies = [
  "log",
  "recursive",
- "sqlparser_derive 0.3.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ae675e87b284e299830649358b258a78a509687d)",
+ "sqlparser_derive 0.3.0 (git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=97c03c04230fdf789c49c64eaaa5c0e77ffc8c78)",
 ]
 
 [[package]]
@@ -6715,7 +6715,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.3.0"
-source = "git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=ae675e87b284e299830649358b258a78a509687d#ae675e87b284e299830649358b258a78a509687d"
+source = "git+https://github.com/Embucket/datafusion-sqlparser-rs.git?rev=97c03c04230fdf789c49c64eaaa5c0e77ffc8c78#97c03c04230fdf789c49c64eaaa5c0e77ffc8c78"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,12 +88,12 @@ uuid = { version = "1.10.0", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "39d2324436523f2fc8fd375771ec5a4858898d65" }
-datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "39d2324436523f2fc8fd375771ec5a4858898d65" }
-datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "39d2324436523f2fc8fd375771ec5a4858898d65" }
-datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "39d2324436523f2fc8fd375771ec5a4858898d65" }
-datafusion-doc = { git = "https://github.com/Embucket/datafusion.git", rev = "39d2324436523f2fc8fd375771ec5a4858898d65" }
-datafusion-macros = { git = "https://github.com/Embucket/datafusion.git", rev = "39d2324436523f2fc8fd375771ec5a4858898d65" }
+datafusion = { git = "https://github.com/Embucket/datafusion.git", rev = "6218c31e097579342c1f6a0b9f43428e179c2d87" }
+datafusion-common = { git = "https://github.com/Embucket/datafusion.git", rev = "6218c31e097579342c1f6a0b9f43428e179c2d87" }
+datafusion-expr = { git = "https://github.com/Embucket/datafusion.git", rev = "6218c31e097579342c1f6a0b9f43428e179c2d87" }
+datafusion-physical-plan = { git = "https://github.com/Embucket/datafusion.git", rev = "6218c31e097579342c1f6a0b9f43428e179c2d87" }
+datafusion-doc = { git = "https://github.com/Embucket/datafusion.git", rev = "6218c31e097579342c1f6a0b9f43428e179c2d87" }
+datafusion-macros = { git = "https://github.com/Embucket/datafusion.git", rev = "6218c31e097579342c1f6a0b9f43428e179c2d87" }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/crates/api-snowflake-rest/src/error.rs
+++ b/crates/api-snowflake-rest/src/error.rs
@@ -185,7 +185,9 @@ fn convert_into_status_code_and_error(error: &core_executor::Error) -> (StatusCo
         | core_executor::Error::CatalogNotFound { .. }
         | core_executor::Error::Metastore { .. }
         | core_executor::Error::DataFusion { .. }
-        | core_executor::Error::DataFusionQuery { .. } => http::StatusCode::OK,
+        | core_executor::Error::DataFusionQuery { .. }
+        | core_executor::Error::UnimplementedFunction { .. }
+        | core_executor::Error::SqlParser { .. } => http::StatusCode::OK,=> http::StatusCode::OK,
     };
 
     let message = match error {

--- a/crates/api-snowflake-rest/src/error.rs
+++ b/crates/api-snowflake-rest/src/error.rs
@@ -187,7 +187,7 @@ fn convert_into_status_code_and_error(error: &core_executor::Error) -> (StatusCo
         | core_executor::Error::DataFusion { .. }
         | core_executor::Error::DataFusionQuery { .. }
         | core_executor::Error::UnimplementedFunction { .. }
-        | core_executor::Error::SqlParser { .. } => http::StatusCode::OK,=> http::StatusCode::OK,
+        | core_executor::Error::SqlParser { .. } => http::StatusCode::OK,
     };
 
     let message = match error {

--- a/crates/core-executor/Cargo.toml
+++ b/crates/core-executor/Cargo.toml
@@ -24,7 +24,7 @@ datafusion-functions-json = { workspace = true }
 datafusion-physical-plan = { workspace = true }
 datafusion_iceberg = { workspace = true }
 futures = { workspace = true }
-sqlparser = { git = "https://github.com/Embucket/datafusion-sqlparser-rs.git", rev = "ae675e87b284e299830649358b258a78a509687d", features = [
+sqlparser = { git = "https://github.com/Embucket/datafusion-sqlparser-rs.git", rev = "97c03c04230fdf789c49c64eaaa5c0e77ffc8c78", features = [
   "visitor",
 ] }
 iceberg-rust = { workspace = true }

--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -330,4 +330,18 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Unimplemented function: {error}"))]
+    UnimplementedFunction {
+        #[snafu(source)]
+        error: embucket_functions::visitors::unimplemented::functions_checker::UnimplementedFunctionError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("SQL parser error: {error}"))]
+    SqlParser {
+        #[snafu(source)]
+        error: datafusion::sql::sqlparser::parser::ParserError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }

--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -330,7 +330,7 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
-    #[snafu(display("Unimplemented function: {error}"))]
+    #[snafu(display("{error}"))]
     UnimplementedFunction {
         #[snafu(source)]
         error: embucket_functions::visitors::unimplemented::functions_checker::UnimplementedFunctionError,

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -46,8 +46,8 @@ use df_catalog::error::Error as CatalogError;
 use df_catalog::information_schema::session_params::SessionProperty;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::visitors::{
-    copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query, json_element,
-    select_expr_aliases, table_functions, top_limit, fetch_to_limit
+    copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query,
+    json_element, select_expr_aliases, table_functions, top_limit,
     unimplemented::functions_checker::visit as unimplemented_functions_checker,
 };
 use iceberg_rust::catalog::Catalog;

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -216,15 +216,11 @@ impl UserQuery {
             json_element::visit(value);
             functions_rewriter::visit(value);
             top_limit::visit(value);
-            unimplemented_functions_checker(value)
-                .map_err(|e| DataFusionError::NotImplemented(e.to_string()))
-                .context(ex_error::DataFusionSnafu)?;
+            unimplemented_functions_checker(value).context(ex_error::UnimplementedFunctionSnafu)?;
             copy_into_identifiers::visit(value);
             select_expr_aliases::visit(value);
             inline_aliases_in_query::visit(value);
-            fetch_to_limit::visit(value)
-                .map_err(|e| DataFusionError::SQL(e, None))
-                .context(ex_error::DataFusionSnafu)?;
+            fetch_to_limit::visit(value).context(ex_error::SqlParserSnafu)?;
             table_functions::visit(value);
             visit_all(value);
         }

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -46,7 +46,7 @@ use df_catalog::error::Error as CatalogError;
 use df_catalog::information_schema::session_params::SessionProperty;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::visitors::{
-    copy_into_identifiers, functions_rewriter, inline_aliases_in_query, json_element,
+    copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query, json_element,
     select_expr_aliases, table_functions, top_limit, fetch_to_limit
     unimplemented::functions_checker::visit as unimplemented_functions_checker,
 };
@@ -225,8 +225,9 @@ impl UserQuery {
             copy_into_identifiers::visit(value);
             select_expr_aliases::visit(value);
             inline_aliases_in_query::visit(value);
+            fetch_to_limit::visit(value)
+                .map_err(|e| ex_error::DataFusionSnafu.into_error(DataFusionError::SQL(e, None)))?;
             table_functions::visit(value);
-            fetch_to_limit::visit(value);
             visit_all(value);
         }
         Ok(())

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -47,7 +47,7 @@ use df_catalog::information_schema::session_params::SessionProperty;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::visitors::{
     copy_into_identifiers, functions_rewriter, inline_aliases_in_query, json_element,
-    select_expr_aliases, table_functions, top_limit,
+    select_expr_aliases, table_functions, top_limit, fetch_to_limit
     unimplemented::functions_checker::visit as unimplemented_functions_checker,
 };
 use iceberg_rust::catalog::Catalog;
@@ -226,6 +226,7 @@ impl UserQuery {
             select_expr_aliases::visit(value);
             inline_aliases_in_query::visit(value);
             table_functions::visit(value);
+            fetch_to_limit::visit(value);
             visit_all(value);
         }
         Ok(())

--- a/crates/core-executor/src/tests/sql/commands/fetch.rs
+++ b/crates/core-executor/src/tests/sql/commands/fetch.rs
@@ -1,0 +1,20 @@
+use crate::test_query;
+
+const SETUP_QUERIES: [&str; 2] = [
+    "CREATE OR REPLACE TABLE fetch_test(c1 INT)",
+    "INSERT INTO fetch_test VALUES (1),(2),(3),(4)",
+];
+
+test_query!(
+    fetch_first_rows_only,
+    "SELECT c1 FROM fetch_test FETCH FIRST 2 ROWS ONLY",
+    setup_queries = [SETUP_QUERIES[0], SETUP_QUERIES[1]],
+    snapshot_path = "fetch",
+);
+
+test_query!(
+    fetch_with_offset,
+    "SELECT c1 FROM fetch_test OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY",
+    setup_queries = [SETUP_QUERIES[0], SETUP_QUERIES[1]],
+    snapshot_path = "fetch",
+);

--- a/crates/core-executor/src/tests/sql/commands/fetch.rs
+++ b/crates/core-executor/src/tests/sql/commands/fetch.rs
@@ -36,11 +36,9 @@ test_query!(
     ) t1
     UNION ALL
     SELECT c1, 'last_two' as source FROM (
-        SELECT c1 FROM fetch_test OFFSET 2 ROWS FETCH NEXT 2 ROWS ORDER BY c1
+        SELECT c1 FROM fetch_test ORDER BY c1 FETCH NEXT 2 ROWS 
     ) t2
     ORDER BY c1, source",
     setup_queries = [SETUP_QUERIES[0], SETUP_QUERIES[1]],
     snapshot_path = "fetch"
 );
-
-

--- a/crates/core-executor/src/tests/sql/commands/fetch.rs
+++ b/crates/core-executor/src/tests/sql/commands/fetch.rs
@@ -7,14 +7,40 @@ const SETUP_QUERIES: [&str; 2] = [
 
 test_query!(
     fetch_first_rows_only,
-    "SELECT c1 FROM fetch_test FETCH FIRST 2 ROWS ONLY",
+    "SELECT c1 FROM fetch_test ORDER BY c1 FETCH FIRST 2 ROWS",
     setup_queries = [SETUP_QUERIES[0], SETUP_QUERIES[1]],
-    snapshot_path = "fetch",
+    snapshot_path = "fetch"
 );
 
 test_query!(
     fetch_with_offset,
-    "SELECT c1 FROM fetch_test OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY",
+    "SELECT c1 FROM fetch_test ORDER BY c1 OFFSET 1 ROWS FETCH NEXT 2 ROWS",
     setup_queries = [SETUP_QUERIES[0], SETUP_QUERIES[1]],
-    snapshot_path = "fetch",
+    snapshot_path = "fetch"
 );
+
+test_query!(
+    fetch_with_cte,
+    "WITH limited_data AS (
+        SELECT c1 FROM fetch_test ORDER BY c1 FETCH FIRST 3 ROWS
+    )
+    SELECT * FROM limited_data ORDER BY c1",
+    setup_queries = [SETUP_QUERIES[0], SETUP_QUERIES[1]],
+    snapshot_path = "fetch"
+);
+
+test_query!(
+    fetch_in_union_subquery,
+    "SELECT c1, 'first_two' as source FROM (
+        SELECT c1 FROM fetch_test ORDER BY c1 FETCH FIRST 2 ROWS
+    ) t1
+    UNION ALL
+    SELECT c1, 'last_two' as source FROM (
+        SELECT c1 FROM fetch_test OFFSET 2 ROWS FETCH NEXT 2 ROWS ORDER BY c1
+    ) t2
+    ORDER BY c1, source",
+    setup_queries = [SETUP_QUERIES[0], SETUP_QUERIES[1]],
+    snapshot_path = "fetch"
+);
+
+

--- a/crates/core-executor/src/tests/sql/commands/mod.rs
+++ b/crates/core-executor/src/tests/sql/commands/mod.rs
@@ -1,4 +1,4 @@
+mod fetch;
 mod pivot;
 mod top;
 mod unpivot;
-mod fetch;

--- a/crates/core-executor/src/tests/sql/commands/mod.rs
+++ b/crates/core-executor/src/tests/sql/commands/mod.rs
@@ -1,3 +1,4 @@
 mod pivot;
 mod top;
 mod unpivot;
+mod fetch;

--- a/crates/core-executor/src/tests/sql/commands/snapshots/fetch/query_fetch_first_rows_only.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/fetch/query_fetch_first_rows_only.snap
@@ -1,0 +1,15 @@
+---
+source: crates/core-executor/src/tests/sql/commands/fetch.rs
+description: "\"SELECT c1 FROM fetch_test ORDER BY c1 FETCH FIRST 2 ROWS\""
+info: "Setup queries: CREATE OR REPLACE TABLE fetch_test(c1 INT); INSERT INTO fetch_test VALUES (1),(2),(3),(4)"
+---
+Ok(
+    [
+        "+----+",
+        "| c1 |",
+        "+----+",
+        "| 1  |",
+        "| 2  |",
+        "+----+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/fetch/query_fetch_in_union_subquery.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/fetch/query_fetch_in_union_subquery.snap
@@ -1,0 +1,17 @@
+---
+source: crates/core-executor/src/tests/sql/commands/fetch.rs
+description: "\"SELECT c1, 'first_two' as source FROM (\n        SELECT c1 FROM fetch_test ORDER BY c1 FETCH FIRST 2 ROWS\n    ) t1\n    UNION ALL\n    SELECT c1, 'last_two' as source FROM (\n        SELECT c1 FROM fetch_test ORDER BY c1 FETCH NEXT 2 ROWS \n    ) t2\n    ORDER BY c1, source\""
+info: "Setup queries: CREATE OR REPLACE TABLE fetch_test(c1 INT); INSERT INTO fetch_test VALUES (1),(2),(3),(4)"
+---
+Ok(
+    [
+        "+----+-----------+",
+        "| c1 | source    |",
+        "+----+-----------+",
+        "| 1  | first_two |",
+        "| 1  | last_two  |",
+        "| 2  | first_two |",
+        "| 2  | last_two  |",
+        "+----+-----------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/fetch/query_fetch_with_cte.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/fetch/query_fetch_with_cte.snap
@@ -1,0 +1,16 @@
+---
+source: crates/core-executor/src/tests/sql/commands/fetch.rs
+description: "\"WITH limited_data AS (\n        SELECT c1 FROM fetch_test ORDER BY c1 FETCH FIRST 3 ROWS\n    )\n    SELECT * FROM limited_data ORDER BY c1\""
+info: "Setup queries: CREATE OR REPLACE TABLE fetch_test(c1 INT); INSERT INTO fetch_test VALUES (1),(2),(3),(4)"
+---
+Ok(
+    [
+        "+----+",
+        "| c1 |",
+        "+----+",
+        "| 1  |",
+        "| 2  |",
+        "| 3  |",
+        "+----+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/fetch/query_fetch_with_offset.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/fetch/query_fetch_with_offset.snap
@@ -1,0 +1,15 @@
+---
+source: crates/core-executor/src/tests/sql/commands/fetch.rs
+description: "\"SELECT c1 FROM fetch_test ORDER BY c1 OFFSET 1 ROWS FETCH NEXT 2 ROWS\""
+info: "Setup queries: CREATE OR REPLACE TABLE fetch_test(c1 INT); INSERT INTO fetch_test VALUES (1),(2),(3),(4)"
+---
+Ok(
+    [
+        "+----+",
+        "| c1 |",
+        "+----+",
+        "| 2  |",
+        "| 3  |",
+        "+----+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/visitors.rs
+++ b/crates/embucket-functions/src/tests/visitors.rs
@@ -250,9 +250,13 @@ fn test_fetch_to_limit_error_on_missing_quantity() -> DFResult<()> {
 
     if let DFStatement::Statement(ref mut stmt) = statement {
         let result = fetch_to_limit::visit(stmt);
-        assert!(result.is_err(), "Expected error for FETCH without quantity");
-        let error_msg = result.unwrap_err().to_string();
-        assert!(error_msg.contains("FETCH requires a quantity to be specified"));
+        match result {
+            Err(error) => {
+                let error_msg = error.to_string();
+                assert!(error_msg.contains("FETCH requires a quantity to be specified"));
+            }
+            Ok(()) => panic!("Expected error for FETCH without quantity"),
+        }
     }
 
     Ok(())

--- a/crates/embucket-functions/src/tests/visitors.rs
+++ b/crates/embucket-functions/src/tests/visitors.rs
@@ -1,6 +1,6 @@
 use crate::visitors::{
-    fetch_to_limit, functions_rewriter, inline_aliases_in_query, json_element,
-    select_expr_aliases, table_functions,
+    fetch_to_limit, functions_rewriter, inline_aliases_in_query, json_element, select_expr_aliases,
+    table_functions,
 };
 use datafusion::prelude::SessionContext;
 use datafusion::sql::parser::Statement as DFStatement;
@@ -247,13 +247,13 @@ fn test_fetch_to_limit_error_on_missing_quantity() -> DFResult<()> {
     let state = SessionContext::new().state();
     let sql = "SELECT * FROM test FETCH FIRST ROWS ONLY";
     let mut statement = state.sql_to_statement(sql, "snowflake")?;
-    
+
     if let DFStatement::Statement(ref mut stmt) = statement {
         let result = fetch_to_limit::visit(stmt);
         assert!(result.is_err(), "Expected error for FETCH without quantity");
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("FETCH requires a quantity to be specified"));
     }
-    
+
     Ok(())
 }

--- a/crates/embucket-functions/src/visitors/fetch_to_limit.rs
+++ b/crates/embucket-functions/src/visitors/fetch_to_limit.rs
@@ -13,12 +13,12 @@ impl VisitorMut for FetchToLimit {
             // Default quantity is 1 when not specified
             let quantity = fetch
                 .quantity
-                .unwrap_or_else(|| Expr::Value(Value::Number("1".to_string(), false)));
+                .unwrap_or_else(|| Expr::Value(Value::Number("1".to_string(), false).into()));
             // Ignore PERCENT and WITH TIES for now
             query.limit = Some(quantity);
         }
         // process WITH clauses recursively
-        if let Some(with) = &mut query.with {
+        /*if let Some(with) = &mut query.with {
             for cte in &mut with.cte_tables {
                 let _ = self.pre_visit_query(&mut cte.query);
             }
@@ -29,7 +29,7 @@ impl VisitorMut for FetchToLimit {
                     let _ = self.pre_visit_query(subquery);
                 }
             }
-        }
+        }*/
         ControlFlow::Continue(())
     }
 }

--- a/crates/embucket-functions/src/visitors/fetch_to_limit.rs
+++ b/crates/embucket-functions/src/visitors/fetch_to_limit.rs
@@ -1,0 +1,39 @@
+use datafusion::logical_expr::sqlparser::ast::VisitMut;
+use datafusion::sql::sqlparser::ast::{Expr, Query, SetExpr, Statement, Value, VisitorMut};
+use std::ops::ControlFlow;
+
+#[derive(Debug, Default)]
+pub struct FetchToLimit {}
+
+impl VisitorMut for FetchToLimit {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &mut Query) -> ControlFlow<Self::Break> {
+        if let Some(fetch) = query.fetch.take() {
+            // Default quantity is 1 when not specified
+            let quantity = fetch
+                .quantity
+                .unwrap_or_else(|| Expr::Value(Value::Number("1".to_string(), false)));
+            // Ignore PERCENT and WITH TIES for now
+            query.limit = Some(quantity);
+        }
+        // process WITH clauses recursively
+        if let Some(with) = &mut query.with {
+            for cte in &mut with.cte_tables {
+                let _ = self.pre_visit_query(&mut cte.query);
+            }
+        }
+        if let SetExpr::Select(select) = query.body.as_mut() {
+            for table_with_joins in &mut select.from {
+                if let Some(subquery) = table_with_joins.relation.get_subquery_mut() {
+                    let _ = self.pre_visit_query(subquery);
+                }
+            }
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+pub fn visit(stmt: &mut Statement) {
+    let _ = stmt.visit(&mut FetchToLimit {});
+}

--- a/crates/embucket-functions/src/visitors/fetch_to_limit.rs
+++ b/crates/embucket-functions/src/visitors/fetch_to_limit.rs
@@ -1,39 +1,35 @@
 use datafusion::logical_expr::sqlparser::ast::VisitMut;
-use datafusion::sql::sqlparser::ast::{Expr, Query, SetExpr, Statement, Value, VisitorMut};
+use datafusion::sql::sqlparser::ast::{Query, Statement, VisitorMut};
+use datafusion::sql::sqlparser::parser::ParserError;
 use std::ops::ControlFlow;
 
 #[derive(Debug, Default)]
 pub struct FetchToLimit {}
 
+/// A visitor that changes FETCH behavior to LIMIT in Snowflake SQL.
+/// This visitor rewrites Snowflake SQL `SELECT` statements by replacing the `FETCH` statement with the `LIMIT` statement.
+/// They are equivalent in Snowflake SQL.
 impl VisitorMut for FetchToLimit {
-    type Break = ();
+    type Break = ParserError;
 
     fn pre_visit_query(&mut self, query: &mut Query) -> ControlFlow<Self::Break> {
         if let Some(fetch) = query.fetch.take() {
-            // Default quantity is 1 when not specified
-            let quantity = fetch
-                .quantity
-                .unwrap_or_else(|| Expr::Value(Value::Number("1".to_string(), false).into()));
-            // Ignore PERCENT and WITH TIES for now
-            query.limit = Some(quantity);
-        }
-        // process WITH clauses recursively
-        /*if let Some(with) = &mut query.with {
-            for cte in &mut with.cte_tables {
-                let _ = self.pre_visit_query(&mut cte.query);
+            if let Some(quantity) = fetch.quantity {
+                query.limit = Some(quantity);
+            } else {
+                return ControlFlow::Break(ParserError::ParserError(
+                    "FETCH requires a quantity to be specified. The number of rows returned must be a non-negative integer constant.".to_string(),
+                ));
             }
         }
-        if let SetExpr::Select(select) = query.body.as_mut() {
-            for table_with_joins in &mut select.from {
-                if let Some(subquery) = table_with_joins.relation.get_subquery_mut() {
-                    let _ = self.pre_visit_query(subquery);
-                }
-            }
-        }*/
+
         ControlFlow::Continue(())
     }
 }
 
-pub fn visit(stmt: &mut Statement) {
-    let _ = stmt.visit(&mut FetchToLimit {});
+pub fn visit(stmt: &mut Statement) -> Result<(), ParserError> {
+    match stmt.visit(&mut FetchToLimit {}) {
+        ControlFlow::Continue(()) => Ok(()),
+        ControlFlow::Break(err) => Err(err),
+    }
 }

--- a/crates/embucket-functions/src/visitors/mod.rs
+++ b/crates/embucket-functions/src/visitors/mod.rs
@@ -5,5 +5,5 @@ pub mod json_element;
 pub mod select_expr_aliases;
 pub mod table_functions;
 pub mod unimplemented;
-
+pub mod fetch_to_limit;
 pub mod top_limit;

--- a/crates/embucket-functions/src/visitors/mod.rs
+++ b/crates/embucket-functions/src/visitors/mod.rs
@@ -1,9 +1,9 @@
 pub mod copy_into_identifiers;
+pub mod fetch_to_limit;
 pub mod functions_rewriter;
 pub mod inline_aliases_in_query;
 pub mod json_element;
 pub mod select_expr_aliases;
 pub mod table_functions;
-pub mod unimplemented;
-pub mod fetch_to_limit;
 pub mod top_limit;
+pub mod unimplemented;


### PR DESCRIPTION
## Summary
- add `fetch.rs` snapshot tests verifying `FETCH` clause behavior
- integrate new test module into SQL command tests
- remove old SLT test file for FETCH

## Testing
- `cargo test -p embucket-functions --tests -- --nocapture` *(failed to finish due to build time)*

------
https://chatgpt.com/codex/tasks/task_e_68516d925b188322a8bc662a4fbb630c