### PR TITLE
Drop schema with fixed quoted identifiers

### DIFF
--- a/crates/api-ui/src/tables/handlers.rs
+++ b/crates/api-ui/src/tables/handlers.rs
@@ -160,7 +160,7 @@ pub async fn get_table_columns(
     Path((database, schema, table)): Path<(String, String, String)>,
 ) -> Result<Json<TableColumnsResponse>> {
     let context = QueryContext::new(Some(database.clone()), Some(schema.clone()), None);
-    let sql_string = format!("SELECT * FROM {database}.{schema}.{table} LIMIT 0");
+    let sql_string = format!("SELECT * FROM `{database}`.`{schema}`.`{table}` LIMIT 0");
     let columns_info = state
         .execution_svc
         .query(&session_id, sql_string.as_str(), context)

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -217,8 +217,20 @@ macro_rules! test_query {
 // CREATE SCHEMA
 test_query!(
     create_schema,
-    "SHOW SCHEMAS IN embucket STARTS WITH 'new_schema'",
-    setup_queries = ["CREATE SCHEMA embucket.new_schema"]
+    "SHOW SCHEMAS IN embucket STARTS WITH 'new'",
+    setup_queries = [
+        "CREATE SCHEMA embucket.new_schema",
+        "CREATE SCHEMA embucket.\"new schema\""
+    ]
+);
+
+test_query!(
+    drop_schema_quoted_identifiers,
+    "SHOW SCHEMAS IN embucket STARTS WITH 'test'",
+    setup_queries = [
+        "CREATE SCHEMA embucket.\"test public\"",
+        "DROP SCHEMA embucket.\"test public\"",
+    ]
 );
 
 // CREATE TABLE with timestamp types
@@ -249,6 +261,16 @@ test_query!(
     ]
 );
 
+test_query!(
+    create_table_quoted_identifiers,
+    "SELECT * FROM embucket.\"test public\".\"test table\"",
+    setup_queries = [
+        "CREATE SCHEMA embucket.\"test public\"",
+        "CREATE TABLE embucket.\"test public\".\"test table\" (id INT)",
+        "INSERT INTO embucket.\"test public\".\"test table\" VALUES (1), (2)",
+    ]
+);
+
 // CREATE TABLE with casting timestamp nanosecond to iceberg timestamp microseconds
 test_query!(
     create_table_with_casting_timestamp,
@@ -256,13 +278,23 @@ test_query!(
         SELECT * FROM (VALUES ('2021-03-02 15:55:18.539000'::TIMESTAMP)) AS t(start_tstamp);"
 );
 
-// DROP TABLE
 test_query!(
     drop_table,
     "SHOW TABLES IN public STARTS WITH 'test'",
     setup_queries = [
         "CREATE TABLE embucket.public.test (id INT) as VALUES (1), (2)",
         "DROP TABLE embucket.public.test"
+    ]
+);
+
+test_query!(
+    drop_table_quoted_identifiers,
+    "SHOW TABLES IN public STARTS WITH 'test'",
+    setup_queries = [
+        "CREATE SCHEMA embucket.\"test public\"",
+        "CREATE TABLE embucket.\"test public\".\"test table\" (id INT)",
+        "INSERT INTO embucket.\"test public\".\"test table\" VALUES (1), (2)",
+        "DROP TABLE embucket.\"test public\".\"test table\"",
     ]
 );
 

--- a/crates/core-executor/src/tests/snapshots/query_create_schema.snap
+++ b/crates/core-executor/src/tests/snapshots/query_create_schema.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/core-executor/src/tests/query.rs
-description: "\"SHOW SCHEMAS IN embucket STARTS WITH 'new_schema'\""
-info: "PreQueries: CREATE SCHEMA embucket.new_schema"
-snapshot_kind: text
+description: "\"SHOW SCHEMAS IN embucket STARTS WITH 'new'\""
+info: "Setup queries: CREATE SCHEMA embucket.new_schema; CREATE SCHEMA embucket.\"new schema\""
 ---
 Ok(
     [
         "+------------+------------+------+---------------+-------------+",
         "| created_on | name       | kind | database_name | schema_name |",
         "+------------+------------+------+---------------+-------------+",
+        "|            | new schema |      | embucket      |             |",
         "|            | new_schema |      | embucket      |             |",
         "+------------+------------+------+---------------+-------------+",
     ],

--- a/crates/core-executor/src/tests/snapshots/query_create_table_quoted_identifiers.snap
+++ b/crates/core-executor/src/tests/snapshots/query_create_table_quoted_identifiers.snap
@@ -1,0 +1,15 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT * FROM embucket.\\\"test public\\\".\\\"test table\\\"\""
+info: "Setup queries: CREATE SCHEMA embucket.\"test public\"; CREATE TABLE embucket.\"test public\".\"test table\" (id INT); INSERT INTO embucket.\"test public\".\"test table\" VALUES (1), (2)"
+---
+Ok(
+    [
+        "+----+",
+        "| id |",
+        "+----+",
+        "| 1  |",
+        "| 2  |",
+        "+----+",
+    ],
+)

--- a/crates/core-executor/src/tests/snapshots/query_drop_schema_quoted_identifiers.snap
+++ b/crates/core-executor/src/tests/snapshots/query_drop_schema_quoted_identifiers.snap
@@ -1,0 +1,11 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SHOW SCHEMAS IN embucket STARTS WITH 'test'\""
+info: "Setup queries: CREATE SCHEMA embucket.\"test public\"; DROP SCHEMA embucket.\"test public\""
+---
+Ok(
+    [
+        "++",
+        "++",
+    ],
+)

--- a/crates/core-executor/src/tests/snapshots/query_drop_table_quoted_identifiers.snap
+++ b/crates/core-executor/src/tests/snapshots/query_drop_table_quoted_identifiers.snap
@@ -1,0 +1,11 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SHOW TABLES IN public STARTS WITH 'test'\""
+info: "Setup queries: CREATE SCHEMA embucket.\"test public\"; CREATE TABLE embucket.\"test public\".\"test table\" (id INT); INSERT INTO embucket.\"test public\".\"test table\" VALUES (1), (2); DROP TABLE embucket.\"test public\".\"test table\""
+---
+Ok(
+    [
+        "++",
+        "++",
+    ],
+)


### PR DESCRIPTION
This PR introduces several changes to improve handling of quoted identifiers in SQL statements, refactors code for better readability and maintainability, and adds comprehensive test cases to ensure correctness. The most significant updates include adjustments to SQL formatting, removal of unused code, enhancements to schema and table resolution, and the addition of tests for quoted identifiers.

### SQL Formatting and Quoted Identifiers:
*  Updated SQL formatting to use backticks for database, schema, and table names, ensuring compatibility with quoted identifiers.

### Code Refactoring:
* Removed unused `options` field and associated logic, simplifying the `ExtendedSqlToRel`. 
* Added `normalize_ident` method to centralize identifier normalization logic, improving code clarity.

### Schema and Table Resolution Enhancements:
* Introduced `resolve_schema_ref` method to handle schema references, supporting both bare and fully qualified schema names.
* Enhanced `drop_query` method to handle dropping schemas, tables, and views with quoted identifiers.

### Testing for Quoted Identifiers:
* Added test cases for creating and dropping schemas and tables with quoted identifiers.

```sql
CREATE SCHEMA "table schema"
CREATE TABLE "table schema"."table test"
```
Closes #1116 
Closes #1092