### PR TITLE
Improve SLT visualizations; add "not implemented" stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Embucket has deep integration with AWS S3 table buckets and relies on them for p
 
 ## SLT coverage
 ![Test Coverage Visualization](https://raw.githubusercontent.com/Embucket/embucket/assets/assets/test_coverage_visualization.png)
-*This visualization is automatically updated by CI/CD when tests are run.*
+
+![Not Implemented Tests Distribution](https://raw.githubusercontent.com/Embucket/embucket/assets/assets/not_implemented_visualization.png)
+
+*These visualizations are automatically updated by CI/CD when tests are run.*
 
 ### Install Embucket  
 

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,10 @@
 
 ## SLT coverage
 ![Test Coverage Visualization](https://raw.githubusercontent.com/Embucket/embucket/assets/assets/test_coverage_visualization.png)
-*This visualization is automatically updated by CI/CD when tests are run.*
+
+![Not Implemented Tests Distribution](https://raw.githubusercontent.com/Embucket/embucket/assets/assets/not_implemented_visualization.png)
+
+*These visualizations are automatically updated by CI/CD when tests are run.*
 
 # SQL Logic Tests
 We have a set of `.slt` files that represent our SQL Logic Tests. You can run them against Snowflake or Embucket.

--- a/test/generate_test_assets.py
+++ b/test/generate_test_assets.py
@@ -92,6 +92,7 @@ def generate_badge(coverage_pct, output_dir='assets'):
 def generate_visualization(stats_file='test_statistics.csv', output_dir='assets'):
     """
     Generate visualization from test statistics CSV file and save it as an image.
+    Only shows SLT files that have a success rate (excludes files with only "not implemented" tests).
 
     Args:
         stats_file (str): Path to the CSV file containing test statistics
@@ -112,36 +113,51 @@ def generate_visualization(stats_file='test_statistics.csv', output_dir='assets'
         if 'category_success_rate' not in df.columns:
             df['category_success_rate'] = (df['successful_tests'] / df['total_tests']) * 100
 
-        # Calculate overall coverage percentage
-        total_tests = df['total_tests'].sum()
-        successful_tests = df['successful_tests'].sum()
-        overall_coverage = (successful_tests / total_tests * 100) if total_tests > 0 else 0
+        # Calculate overall coverage percentage from ALL files (including files with only "not implemented" tests)
+        total_tests_all = df['total_tests'].sum()
+        successful_tests_all = df['successful_tests'].sum()
+        overall_coverage = (successful_tests_all / total_tests_all * 100) if total_tests_all > 0 else 0
 
-        # Use coverage_percentage if available, otherwise fall back to success_rate_percentage for backward compatibility
-        color_column = 'coverage_percentage' if 'coverage_percentage' in df.columns else 'success_rate_percentage'
-        if color_column not in df.columns:
-            # Fallback for old CSV format
-            color_column = 'success_percentage'
+        # Filter out files that have no success rate (only "not implemented" tests) for visualization only
+        # These are files where successful_tests + failed_tests = 0
+        df_filtered = df[(df['successful_tests'] + df['failed_tests']) > 0].copy()
 
-        # Create the treemap visualization
+        if len(df_filtered) == 0:
+            print("No SLT files with testable content found")
+            return None, 0
+
+        # Use success_rate_percentage for color coding (excludes "not implemented" tests)
+        color_column = 'success_rate_percentage'
+        if color_column not in df_filtered.columns:
+            # Fallback calculation if column doesn't exist
+            df_filtered['success_rate_percentage'] = (
+                df_filtered['successful_tests'] /
+                (df_filtered['successful_tests'] + df_filtered['failed_tests']) * 100
+            ).fillna(0)
+
+        # Create the treemap visualization with color coding for success rates
         fig = px.treemap(
-            df,
+            df_filtered,
             path=['category', 'page_name'],
             values='total_tests',
-            color=color_column,
+            color='success_rate_percentage',
             color_continuous_scale='RdYlGn',
-            hover_data=['successful_tests', 'failed_tests'],
-            range_color=[0, 100]
+            hover_data=['successful_tests', 'failed_tests', 'not_implemented_tests'],
+            range_color=[0, 100],
+            title='SLT Test Coverage by Success Rate'
         )
 
         # Add title and adjust layout
         fig.update_layout(
-            margin=dict(t=50, l=25, r=25, b=25)
+            margin=dict(t=80, l=25, r=25, b=25),
+            coloraxis_colorbar=dict(
+                title=dict(text="Success Rate %", side="right")
+            )
         )
 
         # Save the figure as a static image
         fig.write_image(output_file, width=1200, height=800)
-        print(f"Visualization saved to {output_file}")
+        print(f"Success rate visualization saved to {output_file}")
 
         return output_file, overall_coverage
 
@@ -153,9 +169,92 @@ def generate_visualization(stats_file='test_statistics.csv', output_dir='assets'
         return None, 0
 
 
+def generate_not_implemented_visualization(stats_file='test_statistics.csv', output_dir='assets'):
+    """
+    Generate a bar chart showing "not implemented" tests vs other tests (successful + failed).
+
+    Args:
+        stats_file (str): Path to the CSV file containing test statistics
+        output_dir (str): Directory to save the visualization image
+
+    Returns:
+        str: Path to the saved visualization image or None if failed
+    """
+    # Create output directory if it doesn't exist
+    os.makedirs(output_dir, exist_ok=True)
+    output_file = os.path.join(output_dir, 'not_implemented_visualization.png')
+
+    try:
+        # Read the CSV file
+        df = pd.read_csv(stats_file)
+
+        # Calculate totals
+        total_not_implemented = df['not_implemented_tests'].sum() if 'not_implemented_tests' in df.columns else 0
+        total_other_tests = df['successful_tests'].sum() + df['failed_tests'].sum()
+        total_all_tests = total_not_implemented + total_other_tests
+
+        if total_all_tests == 0:
+            print("No test data found")
+            return None
+
+        # Create data for the bar chart
+        data = {
+            'Test Type': ['Not Implemented', 'Other Tests (Success + Failed)'],
+            'Count': [total_not_implemented, total_other_tests]
+        }
+
+        # Create DataFrame for plotting
+        plot_df = pd.DataFrame(data)
+
+        # Create horizontal bar chart
+        fig = px.bar(
+            plot_df,
+            x='Count',
+            y='Test Type',
+            orientation='h',
+            color='Test Type',
+            color_discrete_map={
+                'Not Implemented': '#2196F3',  # Blue
+                'Other Tests (Success + Failed)': '#1976D2'  # Darker Blue
+            },
+            title='Test Distribution: Not Implemented vs Other Tests',
+            text='Count'
+        )
+
+        # Update layout - remove x-axis and simplify
+        fig.update_layout(
+            margin=dict(t=80, l=25, r=25, b=25),
+            showlegend=False,
+            xaxis=dict(
+                showticklabels=False,
+                showgrid=False,
+                zeroline=False,
+                title=""
+            ),
+            yaxis_title="",
+            height=400
+        )
+
+        # Update text position to show counts on bars
+        fig.update_traces(textposition='inside', textfont_size=14, textfont_color='white')
+
+        # Save the figure as a static image
+        fig.write_image(output_file, width=1200, height=400)
+        print(f"Not implemented visualization saved to {output_file}")
+
+        return output_file
+
+    except FileNotFoundError:
+        print(f"Error: Test statistics file not found at {stats_file}")
+        return None
+    except Exception as e:
+        print(f"Error generating not implemented visualization: {str(e)}")
+        return None
+
+
 def main():
     """
-    Generate test assets (badge and visualization) from test statistics.
+    Generate test assets (badge and visualizations) from test statistics.
     """
     parser = argparse.ArgumentParser(description='Generate test coverage assets')
     parser.add_argument('--stats-file', default='test_statistics.csv', help='Path to test statistics CSV file')
@@ -165,11 +264,19 @@ def main():
     # Create output directory if it doesn't exist
     os.makedirs(args.output_dir, exist_ok=True)
 
-    # Generate visualization first to get the overall coverage percentage
+    # Generate main visualization first to get the overall coverage percentage
     viz_path, overall_coverage = generate_visualization(
         stats_file=args.stats_file,
         output_dir=args.output_dir
     )
+
+    # Generate not implemented visualization
+    not_impl_viz_path = generate_not_implemented_visualization(
+        stats_file=args.stats_file,
+        output_dir=args.output_dir
+    )
+
+    success_count = 0
 
     if overall_coverage > 0:
         # Generate badge with the coverage percentage
@@ -178,15 +285,31 @@ def main():
             output_dir=args.output_dir
         )
 
-        if badge_path and viz_path:
-            print(f"All assets generated successfully in {args.output_dir}")
-            print(f"Overall coverage: {overall_coverage:.1f}%")
-            return 0
+        if badge_path:
+            success_count += 1
+            print(f"Badge generated successfully")
         else:
-            print("Failed to generate some assets")
-            return 1
+            print("Failed to generate badge")
+
+    if viz_path:
+        success_count += 1
+        print(f"Success rate visualization generated successfully")
     else:
-        print("Failed to calculate overall coverage")
+        print("Failed to generate success rate visualization")
+
+    if not_impl_viz_path:
+        success_count += 1
+        print(f"Not implemented visualization generated successfully")
+    else:
+        print("Failed to generate not implemented visualization")
+
+    if success_count >= 2:  # At least 2 out of 3 assets generated
+        print(f"Assets generated successfully in {args.output_dir}")
+        if overall_coverage > 0:
+            print(f"Overall coverage: {overall_coverage:.1f}%")
+        return 0
+    else:
+        print("Failed to generate sufficient assets")
         return 1
 
 

--- a/test/slt_runner/visualise_statistics.py
+++ b/test/slt_runner/visualise_statistics.py
@@ -17,8 +17,8 @@ except FileNotFoundError:
 
 df['category_success_rate'] = (df['successful_tests'] / df['total_tests']) * 100
 
-# Use coverage_percentage if available, otherwise fall back to success_rate_percentage for backward compatibility
-color_column = 'coverage_percentage' if 'coverage_percentage' in df.columns else 'success_rate_percentage'
+# Use success_rate_percentage (excludes "Not Implemented" tests) instead of coverage_percentage
+color_column = 'success_rate_percentage' if 'success_rate_percentage' in df.columns else 'coverage_percentage'
 if color_column not in df.columns:
     # Fallback for old CSV format
     color_column = 'success_percentage'


### PR DESCRIPTION
Separate tests the fail with "Not yet implemented" on the visual in Readme.
Now the heatmap excludes them - only shows success/failed tests that DO NOT return "Not yet implemented".
There is a new visual to show how many tests return "Not implemented".
<img width="801" alt="image" src="https://github.com/user-attachments/assets/09df7668-1a19-4593-a2ae-3c2c74be6cd6" />
