### PR TITLE
Issue #1123 Open telemetry tracing, logs fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,6 +2980,7 @@ dependencies = [
  "clap",
  "cookie",
  "core-metastore",
+ "dotenv",
  "error-stack",
  "error-stack-trace",
  "fake",
@@ -4966,6 +4967,8 @@ dependencies = [
  "rand 0.9.1",
  "serde_json",
  "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7392,6 +7392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7401,12 +7411,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/embucket-seed/Cargo.toml
+++ b/crates/embucket-seed/Cargo.toml
@@ -19,6 +19,7 @@ error-stack = { path = "../error-stack" }
 
 async-trait = { workspace = true }
 cookie = "0.18.1"
+dotenv = "0.15.0"
 http = { workspace = true }
 serde_yaml = { workspace = true }
 serde = { workspace = true }

--- a/crates/embucket-seed/src/bin/main.rs
+++ b/crates/embucket-seed/src/bin/main.rs
@@ -1,12 +1,15 @@
 use clap::Parser;
 use std::{net::SocketAddr, str::FromStr};
 
+use dotenv::dotenv;
 use embucket_seed::seed_client::seed_database;
 use embucket_seed::static_seed_assets::SeedVariant;
 
 #[tokio::main]
 #[allow(clippy::expect_used)]
 async fn main() {
+    dotenv().ok();
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()

--- a/crates/embucketd/Cargo.toml
+++ b/crates/embucketd/Cargo.toml
@@ -21,7 +21,7 @@ console-subscriber = { version = "0.4.1" }
 dotenv = "0.15.0"
 object_store = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter", "registry", "fmt"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "registry", "fmt", "json"] }
 tracing-opentelemetry = { version = "0.31.0" }
 opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = { version = "0.30.0", features = [

--- a/crates/embucketd/Cargo.toml
+++ b/crates/embucketd/Cargo.toml
@@ -24,7 +24,10 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "registry", "fmt"] }
 tracing-opentelemetry = { version = "0.31.0" }
 opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic"] }
-opentelemetry_sdk = { version = "0.30.0" }
+opentelemetry_sdk = { version = "0.30.0", features = [
+    "experimental_trace_batch_span_processor_with_async_runtime",
+    "rt-tokio-current-thread"
+    ] } # sending spans in a separate thread
 opentelemetry = { version = "0.30.0" }
 snmalloc-rs = { workspace = true }
 time = { workspace = true }

--- a/crates/embucketd/TRACING_AND_PROFILING.md
+++ b/crates/embucketd/TRACING_AND_PROFILING.md
@@ -5,7 +5,7 @@ Embucket uses `tracing::instrument` for instrumenting a code for tracing. It's c
 Optionally BatchSpanProcessor used for sending spans in a separate thread can be tuned with environment variables, like:
 * `OTEL_BSP_MAX_CONCURRENT_EXPORTS`: Maximum number of concurrent exports threads. When used with cmd line arg:
 --span-processor=batch-span-processor-experimental-async-runtime
-* `OTEL_BSP_SCHEDULE_DELAY`: Frequency at which the batch is exported.
+* `OTEL_BSP_SCHEDULE_DELAY`: Frequency at which the batch is exported, in miliseconds. Setting to higher values helps decreasing amount of "BatchSpanProcessor.ExportError" messages in log when no OTLP collector is used.
 * `OTEL_BSP_EXPORT_TIMEOUT`: Maximum allowed time to export data.
 * `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`: Maximum number of spans to include in a single export.
 * `OTEL_BSP_MAX_QUEUE_SIZE`: Maximum number of spans that can be buffered.

--- a/crates/embucketd/TRACING_AND_PROFILING.md
+++ b/crates/embucketd/TRACING_AND_PROFILING.md
@@ -3,7 +3,8 @@
 ## Tracing
 Embucket uses `tracing::instrument` for instrumenting a code for tracing. It's can be used in both dev and production environments. For development use `info`, `debug` or `trace` level; for production `info` level is recommended.
 Optionally BatchSpanProcessor used for sending spans in a separate thread can be tuned with environment variables, like:
-* `OTEL_BSP_MAX_CONCURRENT_EXPORTS`: Maximum number of concurrent exports threads.
+* `OTEL_BSP_MAX_CONCURRENT_EXPORTS`: Maximum number of concurrent exports threads. When used with cmd line arg:
+--span-processor=batch-span-processor-experimental-async-runtime
 * `OTEL_BSP_SCHEDULE_DELAY`: Frequency at which the batch is exported.
 * `OTEL_BSP_EXPORT_TIMEOUT`: Maximum allowed time to export data.
 * `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`: Maximum number of spans to include in a single export.

--- a/crates/embucketd/TRACING_AND_PROFILING.md
+++ b/crates/embucketd/TRACING_AND_PROFILING.md
@@ -2,9 +2,15 @@
 
 ## Tracing
 Embucket uses `tracing::instrument` for instrumenting a code for tracing. It's can be used in both dev and production environments. For development use `info`, `debug` or `trace` level; for production `info` level is recommended.
-Optionally BatchSpanProcessor used for sending spans in a separate thread can be tuned with environment variables, like:
+
+### Tracing span processor experimental async runtime
+We use `BatchSpanProcessor` that uses dedicated background thread for collecting and exporting spans, it also suitable for production. But for some dev environments it can hang on startup as reported in [issue #1123](https://github.com/embucket/embucket/issues/1123). In this case it's possible switching to `BatchSpanProcessor` using experimental async runtime. 
+Try this cmd-line arg: `--tracing-span-processor=batch-span-processor-experimental-async-runtime`.
+
+### Tracing span processor tuning
+BatchSpanProcessor can be tuned with following environment variables:
 * `OTEL_BSP_MAX_CONCURRENT_EXPORTS`: Maximum number of concurrent exports threads. When used with cmd line arg:
---span-processor=batch-span-processor-experimental-async-runtime
+`--tracing-span-processor=batch-span-processor-experimental-async-runtime`
 * `OTEL_BSP_SCHEDULE_DELAY`: Frequency at which the batch is exported, in miliseconds. Setting to higher values helps decreasing amount of "BatchSpanProcessor.ExportError" messages in log when no OTLP collector is used.
 * `OTEL_BSP_EXPORT_TIMEOUT`: Maximum allowed time to export data.
 * `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`: Maximum number of spans to include in a single export.

--- a/crates/embucketd/TRACING_AND_PROFILING.md
+++ b/crates/embucketd/TRACING_AND_PROFILING.md
@@ -2,6 +2,12 @@
 
 ## Tracing
 Embucket uses `tracing::instrument` for instrumenting a code for tracing. It's can be used in both dev and production environments. For development use `info`, `debug` or `trace` level; for production `info` level is recommended.
+Optionally BatchSpanProcessor used for sending spans in a separate thread can be tuned with environment variables, like:
+* `OTEL_BSP_MAX_CONCURRENT_EXPORTS`: Maximum number of concurrent exports threads.
+* `OTEL_BSP_SCHEDULE_DELAY`: Frequency at which the batch is exported.
+* `OTEL_BSP_EXPORT_TIMEOUT`: Maximum allowed time to export data.
+* `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`: Maximum number of spans to include in a single export.
+* `OTEL_BSP_MAX_QUEUE_SIZE`: Maximum number of spans that can be buffered.
 
 ### Logging
 Logging is the basic way to observe debug and tracing events.

--- a/crates/embucketd/src/cli.rs
+++ b/crates/embucketd/src/cli.rs
@@ -247,7 +247,6 @@ pub enum TracingLevel {
     Trace,
 }
 
-
 #[derive(Debug, Clone, ValueEnum)]
 pub enum TracingSpanProcessor {
     BatchSpanProcessor,

--- a/crates/embucketd/src/cli.rs
+++ b/crates/embucketd/src/cli.rs
@@ -173,6 +173,15 @@ pub struct CliOpts {
         help = "Tracing level, it can be overrided by *RUST_LOG* env var"
     )]
     pub tracing_level: TracingLevel,
+
+    #[arg(
+        long,
+        value_enum,
+        env = "span_processor",
+        default_value = "batch-span-processor",
+        help = "Tracing span processor"
+    )]
+    pub tracing_span_processor: TracingSpanProcessor,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -236,6 +245,13 @@ pub enum TracingLevel {
     Info,
     Debug,
     Trace,
+}
+
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum TracingSpanProcessor {
+    BatchSpanProcessor,
+    BatchSpanProcessorExperimentalAsyncRuntime,
 }
 
 #[allow(clippy::from_over_into)]

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -34,7 +34,9 @@ use dotenv::dotenv;
 use object_store::path::Path;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::runtime::TokioCurrentThread;
 use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
 use slatedb::{Db as SlateDb, config::DbOptions};
 use std::fs;
 use std::net::SocketAddr;
@@ -233,7 +235,8 @@ fn setup_tracing(opts: &cli::CliOpts) -> SdkTracerProvider {
     let resource = Resource::builder().with_service_name("Em").build();
 
     let provider = SdkTracerProvider::builder()
-        .with_batch_exporter(exporter)
+        // Use TokioCurrentThread for sending spans in a separate thread
+        .with_span_processor(BatchSpanProcessor::builder(exporter, TokioCurrentThread).build())
         .with_resource(resource)
         .build();
 
@@ -278,7 +281,7 @@ fn setup_tracing(opts: &cli::CliOpts) -> SdkTracerProvider {
                                 "tower_sessions",
                                 "tower_sessions_core",
                                 "tower_http",
-                                "opentelemetry_sdk",
+                                // "opentelemetry_sdk",
                             ],
                             LevelFilter::OFF,
                         ))

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -220,12 +220,9 @@ async fn main() {
         .await
         .expect("Failed to start server");
 
-    // Run shutdown in blocking mode to avoid deadlock on shutdown, as per opentelemetry_sdk docs
-    tokio::task::spawn_blocking(move || {
-        provider
-            .shutdown()
-            .expect("TracerProvider should shutdown successfully");
-    });
+    provider
+        .shutdown()
+        .expect("TracerProvider should shutdown successfully");
 }
 
 #[allow(clippy::expect_used)]


### PR DESCRIPTION
Closes issue: #1053
Closes issue: #1123


* Add --tracing-batch-processor argument to address reported hanging of embucket service when no opetelemetry otlp collector is running:
  - `--tracing-span-processor=batch-span-processor-experimental-async-runtime` - to be checked if this cmd-line argument resolves a deadlock
  - `--tracing-span-processor=batch-span-processor` - default argument enables using of generic `BatchSpanProcessor`, like it is worked before.
* Added info about OTEL_BSP_SCHEDULE_DELAY to avoid spam with unwanted errors in log, addressing issue #1053
