### PR TITLE
Fix: Correct syntax error in python_runner.py for older Python versions

### DIFF
--- a/test/slt_runner/python_runner.py
+++ b/test/slt_runner/python_runner.py
@@ -106,7 +106,7 @@ def reset_database(config, con: SnowflakeConnection):
         db_name = config['database']
         con.execute(f"DROP DATABASE IF EXISTS {db_name};")
         con.execute(f"CREATE DATABASE {db_name};")
-        con.execute(f"CREATE SCHEMA IF NOT EXISTS {config["schema"]};")
+        con.execute(f"CREATE SCHEMA IF NOT EXISTS {config['schema']};")
 
 # This is pretty much just a VM
 class SQLLogicTestExecutor(SQLLogicRunner):


### PR DESCRIPTION
The f-string `con.execute(f"CREATE SCHEMA IF NOT EXISTS {config["schema"]};")` used double quotes for both the f-string and the dictionary key. This commit changes the inner quotes to single quotes to ensure compatibility with older Python versions, specifically 3.11.13, as reported in issue #1142.

The corrected line is:
`con.execute(f"CREATE SCHEMA IF NOT EXISTS {config['schema']};")`