### PR TITLE
api: UI inconsistent schemas returned by handler

### DIFF
--- a/crates/api-ui/src/tests/schemas.rs
+++ b/crates/api-ui/src/tests/schemas.rs
@@ -118,7 +118,7 @@ async fn test_ui_schemas() {
     .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     let schemas_response: SchemasResponse = res.json().await.unwrap();
-    assert_eq!(3, schemas_response.items.len());
+    assert_eq!(4, schemas_response.items.len());
 
     //Get list schemas with parameters
     let res = req(
@@ -155,7 +155,7 @@ async fn test_ui_schemas() {
     .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     let schemas_response: SchemasResponse = res.json().await.unwrap();
-    assert_eq!(2, schemas_response.items.len());
+    assert_eq!(3, schemas_response.items.len());
     assert_eq!(
         "testing2".to_string(),
         schemas_response.items.first().unwrap().name


### PR DESCRIPTION
Closes #1084

- Added slatedb schemas (`meta`, `history`) to the handler
- Added `information_schema` to the handler
- Used `UNION ALL` in a subquery to stitch everything together, to be able to use search, ordering, etc, instead of just modifying the json result
- Fixed tests to accommodate +1 information schema to each database (catalog)

**Would be great** to hear about using the `chrono::UTC::now()` since `slatedb` schemas are recrearted each time (views) I figured it's okay. They don't really have a consistent creation time (maybe the start of service, and only change the updated_at).