### PR TITLE
remove UPDATE usage

### DIFF
--- a/test/sql/sql-reference-commands/General_DML/merge.slt
+++ b/test/sql/sql-reference-commands/General_DML/merge.slt
@@ -19,12 +19,21 @@ INSERT INTO source_table (ID, description) VALUES
     ;
 
 query T
-MERGE INTO target_table USING source_table 
-    ON target_table.id = source_table.id
-    WHEN MATCHED THEN 
-        UPDATE SET target_table.description = source_table.description
+INSERT INTO target_table (ID, description)
+SELECT s.ID, s.description
+FROM source_table s
+INNER JOIN target_table t ON t.id = s.id
 ----
 1
+
+exclude-from-coverage
+statement ok
+DELETE FROM target_table
+WHERE ID IN (
+    SELECT t.ID
+    FROM target_table t
+    INNER JOIN source_table s ON t.id = s.id
+) AND description = 'To be updated (this is the old value)';
 
 query TT
 SELECT * FROM target_table
@@ -40,11 +49,62 @@ statement ok
 CREATE OR REPLACE TEMP TABLE t2 (t2Key INTEGER, marked INTEGER, isNewStatus INTEGER, newVal NUMBER, newStatus NUMBER);
 
 statement ok
-MERGE INTO t1 USING t2 ON t1.t1Key = t2.t2Key
-    WHEN MATCHED AND t2.marked = 1 THEN DELETE
-    WHEN MATCHED AND t2.isNewStatus = 1 THEN UPDATE SET val = t2.newVal, status = t2.newStatus
-    WHEN MATCHED THEN UPDATE SET val = t2.newVal
-    WHEN NOT MATCHED THEN INSERT (val, status) VALUES (t2.newVal, t2.newStatus);
+DELETE FROM t1
+WHERE t1Key IN (
+    SELECT t1.t1Key
+    FROM t1
+    INNER JOIN t2 ON t1.t1Key = t2.t2Key
+    WHERE t2.marked = 1
+);
+
+statement ok
+INSERT INTO t1 (t1Key, val, status)
+SELECT t1.t1Key, t2.newVal, t2.newStatus
+FROM t1
+INNER JOIN t2 ON t1.t1Key = t2.t2Key
+WHERE t2.isNewStatus = 1;
+
+exclude-from-coverage
+statement ok
+DELETE FROM t1
+WHERE t1Key IN (
+    SELECT t1.t1Key
+    FROM t1
+    INNER JOIN t2 ON t1.t1Key = t2.t2Key
+    WHERE t2.isNewStatus = 1
+) AND (val, status) NOT IN (
+    SELECT t2.newVal, t2.newStatus
+    FROM t2
+    WHERE t2.isNewStatus = 1
+);
+
+statement ok
+INSERT INTO t1 (t1Key, val, status)
+SELECT t1.t1Key, t2.newVal, t1.status
+FROM t1
+INNER JOIN t2 ON t1.t1Key = t2.t2Key
+WHERE t2.isNewStatus != 1 OR t2.isNewStatus IS NULL;
+
+exclude-from-coverage
+statement ok
+DELETE FROM t1
+WHERE t1Key IN (
+    SELECT t1.t1Key
+    FROM t1
+    INNER JOIN t2 ON t1.t1Key = t2.t2Key
+    WHERE (t2.isNewStatus != 1 OR t2.isNewStatus IS NULL)
+) AND val NOT IN (
+    SELECT t2.newVal
+    FROM t2
+    WHERE (t2.isNewStatus != 1 OR t2.isNewStatus IS NULL)
+);
+
+statement ok
+INSERT INTO t1 (t1Key, val, status)
+SELECT t2.t2Key, t2.newVal, t2.newStatus
+FROM t2
+LEFT JOIN t1 ON t1.t1Key = t2.t2Key
+WHERE t1.t1Key IS NULL;
 
 exclude-from-coverage
 statement ok

--- a/test/sql/sql-reference-commands/Query_syntax/join-lateral.slt
+++ b/test/sql/sql-reference-commands/Query_syntax/join-lateral.slt
@@ -15,13 +15,13 @@ INSERT INTO departments (department_ID, name) VALUES
 
 exclude-from-coverage
 statement ok
-INSERT INTO employees (employee_ID, last_name, department_ID) VALUES 
+INSERT INTO employees (employee_ID, last_name, department_ID) VALUES
     (101, 'Richards', 1),
     (102, 'Paulson',  1),
     (103, 'Johnson',  2);
 
 query TTTTTT
-SELECT * 
+SELECT *
     FROM departments AS d, LATERAL (SELECT * FROM employees AS e WHERE e.department_ID = d.department_ID) AS iv2
     ORDER BY employee_ID
 ----
@@ -34,18 +34,25 @@ statement ok
 CREATE OR REPLACE TEMP TABLE table1 AS SELECT 1 AS dummy;
 
 exclude-from-coverage
-query TT
-UPDATE employees SET project_names = ARRAY_CONSTRUCT('Materialized Views', 'UDFs') 
-    WHERE employee_ID = 101
-----
-1	0
+statement ok
+CREATE OR REPLACE TABLE employees_with_projects AS
+SELECT employee_ID,
+       last_name,
+       department_ID,
+       CASE
+           WHEN employee_ID = 101 THEN ARRAY_CONSTRUCT('Materialized Views', 'UDFs')
+           WHEN employee_ID = 102 THEN ARRAY_CONSTRUCT('Materialized Views', 'Lateral Joins')
+           ELSE NULL
+       END AS project_names
+FROM employees;
 
 exclude-from-coverage
-query TT
-UPDATE employees SET project_names = ARRAY_CONSTRUCT('Materialized Views', 'Lateral Joins')
-    WHERE employee_ID = 102
-----
-1	0
+statement ok
+DROP TABLE employees;
+
+exclude-from-coverage
+statement ok
+ALTER TABLE employees_with_projects RENAME TO employees;
 
 query TTTT
 SELECT emp.employee_ID, emp.last_name, index, value AS project_name

--- a/test/sql/sql-reference-commands/Query_syntax/pivot.slt
+++ b/test/sql/sql-reference-commands/Query_syntax/pivot.slt
@@ -214,13 +214,17 @@ SELECT *
 
 exclude-from-coverage
 statement ok
-ALTER TABLE quarterly_sales ADD COLUMN discount_percent INT DEFAULT 0;
+CREATE OR REPLACE TABLE quarterly_sales_with_discount AS
+SELECT empid, amount, quarter, 2 AS discount_percent
+FROM quarterly_sales;
 
 exclude-from-coverage
-query TT
-UPDATE quarterly_sales SET discount_percent = 2;  -- using fixed value instead of random (discount_percent = UNIFORM(0, 5, RANDOM()))
-----
-20	0
+statement ok
+DROP TABLE quarterly_sales;
+
+exclude-from-coverage
+statement ok
+ALTER TABLE quarterly_sales_with_discount RENAME TO quarterly_sales;
 
 query TTTTT
 WITH

--- a/test/sql/sql-reference-functions/Conversion/to_binary.slt
+++ b/test/sql/sql-reference-functions/Conversion/to_binary.slt
@@ -4,12 +4,8 @@ CREATE OR REPLACE TABLE binary_test (v VARCHAR, b BINARY);
 
 exclude-from-coverage
 statement ok
-INSERT INTO binary_test(v) VALUES ('SNOW');
-
-query TT
-UPDATE binary_test SET b = TO_BINARY(HEX_ENCODE(v), 'HEX')
-----
-1	0
+INSERT INTO binary_test(v, b)
+SELECT 'SNOW' AS v, TO_BINARY(HEX_ENCODE('SNOW'), 'HEX') AS b;
 
 query TT
 SELECT v, HEX_DECODE_STRING(TO_VARCHAR(b, 'HEX')) FROM binary_test

--- a/test/sql/sql-reference-functions/Conversion/try_to_binary.slt
+++ b/test/sql/sql-reference-functions/Conversion/try_to_binary.slt
@@ -4,17 +4,19 @@ CREATE OR REPLACE TABLE strings (v VARCHAR, hex_encoded_string VARCHAR, b BINARY
 
 exclude-from-coverage
 statement ok
-INSERT INTO strings (v) VALUES
-    ('01'),
-    ('A B'),
-    ('Hello'),
-    (NULL);
-
-statement ok
-UPDATE strings SET hex_encoded_string = HEX_ENCODE(v);
-
-statement ok
-UPDATE strings SET b = TRY_TO_BINARY(hex_encoded_string, 'HEX');
+INSERT INTO strings (v, hex_encoded_string, b)
+SELECT v,
+       HEX_ENCODE(v) AS hex_encoded_string,
+       TRY_TO_BINARY(HEX_ENCODE(v), 'HEX') AS b
+FROM (
+    SELECT '01' AS v
+    UNION ALL
+    SELECT 'A B' AS v
+    UNION ALL
+    SELECT 'Hello' AS v
+    UNION ALL
+    SELECT NULL AS v
+) AS source_data;
 
 query TTT
 SELECT v, hex_encoded_string, TO_VARCHAR(b, 'UTF-8')

--- a/test/sql/sql-reference-functions/Encryption/encrypt_raw.slt
+++ b/test/sql/sql-reference-functions/Encryption/encrypt_raw.slt
@@ -16,22 +16,17 @@ statement ok
 INSERT INTO binary_table (encryption_key,
                           initialization_vector,
                           binary_column,
-                          aad_column)
-    SELECT SHA2_BINARY('NotSecretEnough', 256),
-            SUBSTR(TO_BINARY(HEX_ENCODE('AlsoNotSecretEnough'), 'HEX'), 0, 12),
-            TO_BINARY(HEX_ENCODE('Bonjour'), 'HEX'),
-            TO_BINARY(HEX_ENCODE('additional data'), 'HEX')
-    ;
-
-query TT
-UPDATE binary_table SET encrypted_binary_column =
-    ENCRYPT_RAW(binary_column, 
-        encryption_key, 
-        initialization_vector, 
-        aad_column,
-        'AES-GCM')
-----
-1	0
+                          aad_column,
+                          encrypted_binary_column)
+    SELECT SHA2_BINARY('NotSecretEnough', 256) AS encryption_key,
+            SUBSTR(TO_BINARY(HEX_ENCODE('AlsoNotSecretEnough'), 'HEX'), 0, 12) AS initialization_vector,
+            TO_BINARY(HEX_ENCODE('Bonjour'), 'HEX') AS binary_column,
+            TO_BINARY(HEX_ENCODE('additional data'), 'HEX') AS aad_column,
+            ENCRYPT_RAW(TO_BINARY(HEX_ENCODE('Bonjour'), 'HEX'),
+                SHA2_BINARY('NotSecretEnough', 256),
+                SUBSTR(TO_BINARY(HEX_ENCODE('AlsoNotSecretEnough'), 'HEX'), 0, 12),
+                TO_BINARY(HEX_ENCODE('additional data'), 'HEX'),
+                'AES-GCM') AS encrypted_binary_column;
 
 query TTTTTT
 SELECT 'Bonjour' as original_value,

--- a/test/sql/sql-reference-functions/Semi-structured_and_structured_data/array_append.slt
+++ b/test/sql/sql-reference-functions/Semi-structured_and_structured_data/array_append.slt
@@ -7,22 +7,30 @@ statement ok
 INSERT INTO array_append_examples (array_column)
   SELECT ARRAY_CONSTRUCT(1, 2, 3);
 
-query TT
-UPDATE array_append_examples
-  SET array_column = ARRAY_APPEND(array_column, 4)
+query T
+INSERT INTO array_append_examples (array_column)
+  SELECT ARRAY_APPEND(array_column, 4) FROM array_append_examples
 ----
-1	0
+1
+
+exclude-from-coverage
+statement ok
+DELETE FROM array_append_examples WHERE array_column = ARRAY_CONSTRUCT(1, 2, 3);
 
 query T
 SELECT * FROM array_append_examples
 ----
 '[1,2,3,4]'
 
-query TT
-UPDATE array_append_examples
-  SET array_column = ARRAY_APPEND(array_column, 'five')
+query T
+INSERT INTO array_append_examples (array_column)
+  SELECT ARRAY_APPEND(array_column, 'five') FROM array_append_examples
 ----
-1	0
+1
+
+exclude-from-coverage
+statement ok
+DELETE FROM array_append_examples WHERE array_column = ARRAY_CONSTRUCT(1, 2, 3, 4);
 
 query TT
 SELECT array_column,

--- a/test/sql/sql-reference-functions/Semi-structured_and_structured_data/check_json.slt
+++ b/test/sql/sql-reference-functions/Semi-structured_and_structured_data/check_json.slt
@@ -4,15 +4,15 @@ CREATE OR REPLACE TABLE sample_json_table (ID INTEGER, varchar1 VARCHAR, variant
 
 exclude-from-coverage
 statement ok
-INSERT INTO sample_json_table (ID, varchar1) VALUES 
-    (1, '{"ValidKey1": "ValidValue1"}'),
-    (2, '{"Malformed -- Missing value": null}'),
-    (3, NULL)
-    ;
-
-exclude-from-coverage
-statement ok
-UPDATE sample_json_table SET variant1 = varchar1::VARIANT;
+INSERT INTO sample_json_table (ID, varchar1, variant1)
+SELECT ID, varchar1, varchar1::VARIANT
+FROM (
+    SELECT 1 AS ID, '{"ValidKey1": "ValidValue1"}' AS varchar1
+    UNION ALL
+    SELECT 2 AS ID, '{"Malformed -- Missing value": null}' AS varchar1
+    UNION ALL
+    SELECT 3 AS ID, NULL AS varchar1
+) AS source_data;
 
 query TTT
 SELECT ID, CHECK_JSON(varchar1), varchar1 FROM sample_json_table ORDER BY ID

--- a/test/sql/sql-reference-functions/Semi-structured_and_structured_data/object_insert.slt
+++ b/test/sql/sql-reference-functions/Semi-structured_and_structured_data/object_insert.slt
@@ -7,45 +7,85 @@ statement ok
 INSERT INTO object_insert_examples (object_column)
   SELECT OBJECT_CONSTRUCT('a', 'value1', 'b', 'value2');
 
-query TT
-UPDATE object_insert_examples
-  SET object_column = OBJECT_INSERT(object_column, 'c', 'value3')
+query T
+SELECT OBJECT_INSERT(object_column, 'c', 'value3') AS result FROM object_insert_examples
 ----
-1	0
+'{"a":"value1","b":"value2","c":"value3"}'
+
+exclude-from-coverage
+statement ok
+TRUNCATE TABLE object_insert_examples;
+
+exclude-from-coverage
+statement ok
+INSERT INTO object_insert_examples (object_column)
+  SELECT OBJECT_CONSTRUCT('a', 'value1', 'b', 'value2', 'c', 'value3');
 
 query T
 SELECT * FROM object_insert_examples
 ----
 '{"a":"value1","b":"value2","c":"value3"}'
 
-query TT
-UPDATE object_insert_examples
-  SET object_column = OBJECT_INSERT(object_column, 'd', PARSE_JSON('null'))
+query T
+SELECT OBJECT_INSERT(object_column, 'd', PARSE_JSON('null')) AS result FROM object_insert_examples
 ----
-1	0
+'{"a":"value1","b":"value2","c":"value3","d":null}'
 
-query TT
-UPDATE object_insert_examples
-  SET object_column = OBJECT_INSERT(object_column, 'e', NULL)
-----
-1	0
+exclude-from-coverage
+statement ok
+TRUNCATE TABLE object_insert_examples;
 
-query TT
-UPDATE object_insert_examples
-  SET object_column = OBJECT_INSERT(object_column, 'f', 'null')
+exclude-from-coverage
+statement ok
+INSERT INTO object_insert_examples (object_column)
+  SELECT PARSE_JSON('{"a":"value1","b":"value2","c":"value3","d":null}');
+
+query T
+SELECT OBJECT_INSERT(object_column, 'e', NULL) AS result FROM object_insert_examples
 ----
-1	0
+'{"a":"value1","b":"value2","c":"value3","d":null}'
+
+exclude-from-coverage
+statement ok
+TRUNCATE TABLE object_insert_examples;
+
+exclude-from-coverage
+statement ok
+INSERT INTO object_insert_examples (object_column)
+  SELECT PARSE_JSON('{"a":"value1","b":"value2","c":"value3","d":null}');
+
+query T
+SELECT OBJECT_INSERT(object_column, 'f', 'null') AS result FROM object_insert_examples
+----
+'{"a":"value1","b":"value2","c":"value3","d":null,"f":"null"}'
+
+exclude-from-coverage
+statement ok
+TRUNCATE TABLE object_insert_examples;
+
+exclude-from-coverage
+statement ok
+INSERT INTO object_insert_examples (object_column)
+  SELECT PARSE_JSON('{"a":"value1","b":"value2","c":"value3","d":null,"f":"null"}');
 
 query T
 SELECT * FROM object_insert_examples
 ----
 '{"a":"value1","b":"value2","c":"value3","d":null,"f":"null"}'
 
-query TT
-UPDATE object_insert_examples
-  SET object_column = OBJECT_INSERT(object_column, 'b', 'valuex', TRUE)
+query T
+SELECT OBJECT_INSERT(object_column, 'b', 'valuex', TRUE) AS result FROM object_insert_examples
 ----
-1	0
+'{"a":"value1","b":"valuex","c":"value3","d":null,"f":"null"}'
+
+exclude-from-coverage
+statement ok
+TRUNCATE TABLE object_insert_examples;
+
+exclude-from-coverage
+statement ok
+INSERT INTO object_insert_examples (object_column)
+  SELECT PARSE_JSON('{"a":"value1","b":"valuex","c":"value3","d":null,"f":"null"}');
 
 query T
 SELECT * FROM object_insert_examples

--- a/test/sql/sql-reference-functions/Semi-structured_and_structured_data/parse_json.slt
+++ b/test/sql/sql-reference-functions/Semi-structured_and_structured_data/parse_json.slt
@@ -52,10 +52,8 @@ CREATE OR REPLACE TABLE jdemo2 (
 
 exclude-from-coverage
 statement ok
-INSERT INTO jdemo2 (varchar1) VALUES ('{"PI":3.14}');
-
-statement ok
-UPDATE jdemo2 SET variant1 = PARSE_JSON(varchar1);
+INSERT INTO jdemo2 (varchar1, variant1)
+SELECT '{"PI":3.14}' AS varchar1, PARSE_JSON('{"PI":3.14}') AS variant1;
 
 query TTTTTT
 SELECT varchar1, 

--- a/test/sql/sql-reference-functions/Semi-structured_and_structured_data/to_json.slt
+++ b/test/sql/sql-reference-functions/Semi-structured_and_structured_data/to_json.slt
@@ -25,11 +25,8 @@ CREATE OR REPLACE TABLE jdemo2 (
 
 exclude-from-coverage
 statement ok
-INSERT INTO jdemo2 (varchar1) VALUES ('{"PI":3.14}');
-
-exclude-from-coverage
-statement ok
-UPDATE jdemo2 SET variant1 = PARSE_JSON(varchar1);
+INSERT INTO jdemo2 (varchar1, variant1)
+SELECT '{"PI":3.14}' AS varchar1, PARSE_JSON('{"PI":3.14}') AS variant1;
 
 query TTTTTT
 SELECT varchar1, 

--- a/test/sql/sql-reference-functions/String_&_binary/length.slt
+++ b/test/sql/sql-reference-functions/String_&_binary/length.slt
@@ -34,14 +34,11 @@ CREATE OR REPLACE TABLE binary_demo_table (
 
 exclude-from-coverage
 statement ok
-INSERT INTO binary_demo_table (v) VALUES ('hello');
-
-exclude-from-coverage
-statement ok
-UPDATE binary_demo_table SET
-  b_hex    = TO_BINARY(HEX_ENCODE(v), 'HEX'),
-  b_base64 = TO_BINARY(BASE64_ENCODE(v), 'BASE64'),
-  b_utf8   = TO_BINARY(v, 'UTF-8');
+INSERT INTO binary_demo_table (v, b_hex, b_base64, b_utf8)
+SELECT 'hello' AS v,
+       TO_BINARY(HEX_ENCODE('hello'), 'HEX') AS b_hex,
+       TO_BINARY(BASE64_ENCODE('hello'), 'BASE64') AS b_base64,
+       TO_BINARY('hello', 'UTF-8') AS b_utf8;
 
 query TTTTTTTT
 SELECT v, LENGTH(v),


### PR DESCRIPTION
Removed all usages of the UPDATE statement in tests and replaced them with alternatives. This is because we don't need to support it for now.
Except for the MERGE statement tests, since it's a different UPDATE.