### PR TITLE
Fix default number scale

### DIFF
--- a/crates/core-executor/src/datafusion/type_planner.rs
+++ b/crates/core-executor/src/datafusion/type_planner.rs
@@ -1,3 +1,4 @@
+use arrow_schema::DECIMAL128_MAX_PRECISION;
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
 use datafusion::common::Result;
 use datafusion::logical_expr::planner::TypePlanner;
@@ -34,7 +35,7 @@ impl TypePlanner for CustomTypePlanner {
                 }
                 "NUMBER" => {
                     let (precision, scale) = match b.len() {
-                        0 => (None, None),
+                        0 => (Some(u64::from(DECIMAL128_MAX_PRECISION)), Some(0)),
                         1 => {
                             let precision = b[0].parse().map_err(|_| {
                                 DataFusionError::Plan(format!("Invalid precision: {}", b[0]))

--- a/crates/core-executor/src/datafusion/type_planner.rs
+++ b/crates/core-executor/src/datafusion/type_planner.rs
@@ -35,7 +35,7 @@ impl TypePlanner for CustomTypePlanner {
                 }
                 "NUMBER" => {
                     let (precision, scale) = match b.len() {
-                        0 => (Some(u64::from(DECIMAL128_MAX_PRECISION)), Some(0)),
+                        0 => (Some(u64::from(DECIMAL128_MAX_PRECISION)), None),
                         1 => {
                             let precision = b[0].parse().map_err(|_| {
                                 DataFusionError::Plan(format!("Invalid precision: {}", b[0]))


### PR DESCRIPTION
https://docs.snowflake.com/en/sql-reference/data-types-numeric#number

By default, precision is 38, and scale is 0 (that is, NUMBER(38, 0)). Precision limits the range of values that can be inserted into (or cast to) columns of a given type. For example, the value 999 fits into NUMBER(38,0) but not into NUMBER(2,0).
