### PR TITLE
update iceberg-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,13 +2740,14 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869#7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
 dependencies = [
  "async-trait",
  "chrono",
  "dashmap",
  "datafusion",
  "datafusion-expr",
+ "derive_builder",
  "futures",
  "iceberg-rust",
  "itertools 0.14.0",
@@ -3832,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869#7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -3857,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869#7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -3865,6 +3866,7 @@ dependencies = [
  "bytes",
  "derive-getters",
  "derive_builder",
+ "flate2",
  "futures",
  "getrandom 0.3.3",
  "iceberg-rust-spec",
@@ -3888,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869#7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.1.0",
@@ -3913,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869#7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "7f7e21f0bcf50f6fe6c13cada6b76057ffdfa869" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -157,7 +157,7 @@ impl UserSession {
             let catalog = S3TablesCatalog::new(
                 &config,
                 volume.arn.as_str(),
-                ObjectStoreBuilder::S3(volume.s3_builder()),
+                ObjectStoreBuilder::S3(Box::new(volume.s3_builder())),
             )
             .context(ex_error::S3TablesSnafu)?;
 

--- a/crates/df-catalog/src/catalog_list.rs
+++ b/crates/df-catalog/src/catalog_list.rs
@@ -176,7 +176,7 @@ impl EmbucketCatalogList {
             let catalog = S3TablesCatalog::new(
                 &config,
                 volume.arn.as_str(),
-                ObjectStoreBuilder::S3(volume.s3_builder()),
+                ObjectStoreBuilder::S3(Box::new(volume.s3_builder())),
             )
             .context(df_catalog_error::S3TablesSnafu)?;
 


### PR DESCRIPTION
This PR updates iceberg-rust to its latest version.

**Important:**

It uses the [embucket-sync-df47.0.0-latest](https://github.com/Embucket/iceberg-rust/tree/embucket-sync-df47.0.0-latest) branch of the Embucket/iceberg-rust repo instead of the embucket-sync-df47.0.0 branch. The embucket-sync-df47.0.0-latest branch is a rewrite of the The embucket-sync-df47.0.0 branch that squashed many previous commits together.