### PR TITLE
api: UI Fixed default sort order for list handlers

### DIFF
--- a/crates/api-ui/src/lib.rs
+++ b/crates/api-ui/src/lib.rs
@@ -113,12 +113,7 @@ fn apply_parameters(
     );
     //Default order by is the first search column or created at
     let sql_string = parameters.order_by.map_or_else(
-        || {
-            format!(
-                "{sql_string} ORDER BY {}",
-                search_columns.first().unwrap_or(&"created_at")
-            )
-        },
+        || format!("{sql_string} ORDER BY created_at"),
         |order_by| format!("{sql_string} ORDER BY {order_by}"),
     );
     let sql_string = parameters.order_direction.map_or_else(

--- a/crates/api-ui/src/tests/databases.rs
+++ b/crates/api-ui/src/tests/databases.rs
@@ -205,7 +205,7 @@ async fn test_ui_databases() {
     let databases_response: DatabasesResponse = res.json().await.unwrap();
     assert_eq!(2, databases_response.items.len());
     assert_eq!(
-        "test4".to_string(),
+        "test".to_string(),
         databases_response.items.first().unwrap().name
     );
     //Get list databases with parameters
@@ -221,7 +221,7 @@ async fn test_ui_databases() {
     let databases_response: DatabasesResponse = res.json().await.unwrap();
     assert_eq!(2, databases_response.items.len());
     assert_eq!(
-        "test2".to_string(),
+        "test3".to_string(),
         databases_response.items.first().unwrap().name
     );
 
@@ -252,7 +252,7 @@ async fn test_ui_databases() {
     let databases_response: DatabasesResponse = res.json().await.unwrap();
     assert_eq!(4, databases_response.items.len());
     assert_eq!(
-        "test4".to_string(),
+        "test".to_string(),
         databases_response.items.first().unwrap().name
     );
 
@@ -271,9 +271,16 @@ async fn test_ui_databases() {
     .unwrap();
     assert_eq!(http::StatusCode::OK, res.status());
     let databases_response: DatabasesResponse = res.json().await.unwrap();
+    assert_eq!(4, databases_response.items.len());
+    //Since we are using ASC, the first element is the one with the name "test2",
+    // because we deleted "test" and added it back, and we are sorting by 'created_at'
+    assert_eq!(
+        "test2".to_string(),
+        databases_response.items.first().unwrap().name
+    );
     assert_eq!(
         "test".to_string(),
-        databases_response.items.first().unwrap().name
+        databases_response.items.last().unwrap().name
     );
 
     //Get list databases with search
@@ -289,7 +296,7 @@ async fn test_ui_databases() {
     let databases_response: DatabasesResponse = res.json().await.unwrap();
     assert_eq!(2, databases_response.items.len());
     assert_eq!(
-        "test4".to_string(),
+        "test".to_string(),
         databases_response.items.first().unwrap().name
     );
 
@@ -306,7 +313,7 @@ async fn test_ui_databases() {
     let databases_response: DatabasesResponse = res.json().await.unwrap();
     assert_eq!(2, databases_response.items.len());
     assert_eq!(
-        "test2".to_string(),
+        "test3".to_string(),
         databases_response.items.first().unwrap().name
     );
 


### PR DESCRIPTION
Closes #1204 & #1152 

- Changed the `fn apply_parameters` from using the first `search_column` as the default `order by` to `created_at`
- All handlers that use the `SearchParameters` are now affected (volumes, databases, schemas, tables)
- Fixed tests for databases, since they are the ones that delete and then add back the same value, so by `order by created_at` the value that was first and was deleted and added back should be at the back (which it is)