### PR TITLE
Move qualify to visitor with common_sub_expression_eliminate rule fix 

### DIFF
--- a/crates/embucket-functions/src/tests/visitors.rs
+++ b/crates/embucket-functions/src/tests/visitors.rs
@@ -1,6 +1,6 @@
 use crate::visitors::{
-    fetch_to_limit, functions_rewriter, inline_aliases_in_query, json_element, select_expr_aliases,
-    table_functions,
+    fetch_to_limit, functions_rewriter, inline_aliases_in_query, json_element, qualify_in_query,
+    select_expr_aliases, table_functions,
 };
 use datafusion::prelude::SessionContext;
 use datafusion::sql::parser::Statement as DFStatement;
@@ -259,5 +259,48 @@ fn test_fetch_to_limit_error_on_missing_quantity() -> DFResult<()> {
         }
     }
 
+    Ok(())
+}
+
+#[test]
+fn test_qualify_in_query() -> DFResult<()> {
+    let state = SessionContext::new().state();
+    let cases = vec![
+        (
+            "SELECT product_id FROM sales QUALIFY ROW_NUMBER() OVER (PARTITION BY city ORDER BY retail_price) = 1",
+            "SELECT * FROM (SELECT product_id, ROW_NUMBER() OVER (PARTITION BY city ORDER BY retail_price) AS qualify_alias FROM sales) WHERE qualify_alias = 1",
+        ),
+        (
+            "create table test_table as (WITH max_task_instance AS (
+                SELECT MAX(task_instance) AS max_column_value
+                FROM base WHERE RIGHT( task_instance, 8) = (SELECT MAX(RIGHT( task_instance, 8)) FROM base )
+            ), filtered AS (
+                SELECT * FROM base
+                WHERE _task_instance = (SELECT max_column_value  FROM max_task_instance)
+                QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY _uploaded_at DESC) = 1
+            ) SELECT * FROM filtered);",
+            "CREATE TABLE test_table AS (WITH max_task_instance AS (SELECT MAX(task_instance) \
+            AS max_column_value FROM base WHERE RIGHT(task_instance, 8) = (SELECT MAX(RIGHT(task_instance, 8)) FROM base)), \
+            filtered AS (SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY _uploaded_at DESC) AS qualify_alias \
+            FROM (SELECT * FROM base WHERE _task_instance = (SELECT max_column_value FROM max_task_instance))) WHERE qualify_alias = 1) \
+            SELECT * FROM filtered)"
+        ),
+        (
+            "SELECT * FROM test
+            WHERE task = (SELECT max_column_value FROM max_task_instance)
+            QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY uploaded_at DESC) = 1",
+            "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY id ORDER BY uploaded_at DESC) \
+            AS qualify_alias FROM (SELECT * FROM test WHERE task = (SELECT max_column_value FROM max_task_instance))) \
+            WHERE qualify_alias = 1",
+        ),
+    ];
+
+    for (input, expected) in cases {
+        let mut statement = state.sql_to_statement(input, "snowflake")?;
+        if let DFStatement::Statement(ref mut stmt) = statement {
+            qualify_in_query::visit(stmt);
+        }
+        assert_eq!(statement.to_string(), expected);
+    }
     Ok(())
 }

--- a/crates/embucket-functions/src/visitors/mod.rs
+++ b/crates/embucket-functions/src/visitors/mod.rs
@@ -3,6 +3,7 @@ pub mod fetch_to_limit;
 pub mod functions_rewriter;
 pub mod inline_aliases_in_query;
 pub mod json_element;
+pub mod qualify_in_query;
 pub mod select_expr_aliases;
 pub mod table_functions;
 pub mod top_limit;

--- a/crates/embucket-functions/src/visitors/qualify_in_query.rs
+++ b/crates/embucket-functions/src/visitors/qualify_in_query.rs
@@ -1,0 +1,127 @@
+use datafusion::logical_expr::sqlparser;
+use datafusion::logical_expr::sqlparser::ast::helpers::attached_token::AttachedToken;
+use datafusion::logical_expr::sqlparser::ast::{
+    GroupByExpr, Ident, Select, SelectItem, TableFactor, TableWithJoins,
+};
+use datafusion::sql::sqlparser::ast::{Expr, Query, SetExpr};
+use datafusion_expr::sqlparser::ast::VisitMut;
+use datafusion_expr::sqlparser::ast::{Statement, VisitorMut};
+use std::ops::ControlFlow;
+
+/// Visitor that converts BINARY and VARBINARY types to BYTEA in CREATE TABLE statements
+///
+/// This allows `DataFusion` to support standard SQL BINARY types by converting them to
+/// the supported BYTEA type, which maps to `DataType::Binary` internally.
+#[derive(Debug, Default)]
+pub struct QualifyInQuery;
+
+impl QualifyInQuery {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl VisitorMut for QualifyInQuery {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &mut Query) -> ControlFlow<Self::Break> {
+        if let Some(with) = query.with.as_mut() {
+            for cte in &mut with.cte_tables {
+                match self.pre_visit_query(&mut cte.query) {
+                    ControlFlow::Break(b) => return ControlFlow::Break(b),
+                    ControlFlow::Continue(()) => {}
+                }
+            }
+        }
+
+        match query.body.as_mut() {
+            SetExpr::Select(select) => {
+                if let Some(Expr::BinaryOp { left, op, right }) = select.qualify.as_ref() {
+                    let mut inner_select = if select.selection.is_some() {
+                        Box::from(wrap_select_in_subquery(select, None))
+                    } else {
+                        select.clone()
+                    };
+                    inner_select.qualify = None;
+                    inner_select.projection.push(SelectItem::ExprWithAlias {
+                        expr: *(left.clone()),
+                        alias: Ident::new("qualify_alias".to_string()),
+                    });
+                    let outer_selection = Some(Expr::BinaryOp {
+                        left: Box::new(Expr::Identifier(Ident::new("qualify_alias"))),
+                        op: op.clone(),
+                        right: Box::new(*right.clone()),
+                    });
+                    let outer_select =
+                        Box::new(wrap_select_in_subquery(&inner_select, outer_selection));
+                    *query.body = SetExpr::Select(outer_select);
+                }
+            }
+            SetExpr::Query(inner_query) => match self.pre_visit_query(inner_query) {
+                ControlFlow::Break(b) => return ControlFlow::Break(b),
+                ControlFlow::Continue(()) => {}
+            },
+            _ => {}
+        }
+
+        ControlFlow::Continue(())
+    }
+}
+
+pub fn visit(stmt: &mut Statement) {
+    let _ = stmt.visit(&mut QualifyInQuery::new());
+}
+
+#[must_use]
+pub fn wrap_select_in_subquery(select: &Select, selection: Option<Expr>) -> Select {
+    let mut inner_select = select.clone();
+    inner_select.qualify = None;
+
+    let subquery = Query {
+        with: None,
+        body: Box::new(SetExpr::Select(Box::new(inner_select))),
+        order_by: None,
+        limit: None,
+        limit_by: vec![],
+        offset: None,
+        fetch: None,
+        locks: vec![],
+        for_clause: None,
+        settings: None,
+        format_clause: None,
+    };
+
+    Select {
+        select_token: AttachedToken::empty(),
+        distinct: None,
+        top: None,
+        top_before_distinct: false,
+        projection: vec![SelectItem::UnnamedExpr(sqlparser::ast::Expr::Identifier(
+            Ident::new("*"),
+        ))],
+        into: None,
+        from: vec![TableWithJoins {
+            relation: TableFactor::Derived {
+                lateral: false,
+                subquery: Box::new(subquery),
+                alias: None,
+            },
+            joins: vec![],
+        }],
+        lateral_views: vec![],
+        prewhere: None,
+        selection,
+        group_by: GroupByExpr::Expressions(vec![], vec![]),
+        cluster_by: vec![],
+        distribute_by: vec![],
+        sort_by: vec![],
+        having: None,
+        named_window: vec![],
+        qualify: None,
+        window_before_qualify: false,
+        value_table_mode: None,
+        connect_by: None,
+        flavor: sqlparser::ast::SelectFlavor::Standard,
+    }
+}


### PR DESCRIPTION
This pull request introduces a new qualify_in_query, to handle `QUALIFY` clauses in SQL queries. It refactors the existing query processing logic to replace an inline implementation with this modular approach, improving maintainability and testability. Additionally, it includes a new test case to validate the behavior of the `qualify_in_query` visitor.

Closes #1154 