### PR TITLE
fix: remove hardcoded /catalog suffix from iceberg catalog URL

### DIFF
--- a/crates/api-iceberg-rest/src/handlers.rs
+++ b/crates/api-iceberg-rest/src/handlers.rs
@@ -294,7 +294,7 @@ pub async fn get_config(
     let config = CatalogConfig {
         defaults: HashMap::new(),
         overrides: HashMap::from([
-            ("uri".into(), format!("{catalog_url}/catalog")),
+            ("uri".into(), catalog_url),
             ("prefix".into(), params.warehouse.unwrap_or_default()),
         ]),
         // TODO: I think it can be useful and should be utilized somehow


### PR DESCRIPTION
## Summary
- Remove hardcoded `/catalog` suffix from iceberg catalog URL in handlers.rs line 297
- This change removes the hardcoded path when returning the catalog configuration in `/v1/config` endpoint

## Test plan
- [ ] Verify that the `/v1/config` endpoint returns the correct catalog URL without the hardcoded suffix
- [ ] Test that iceberg catalog functionality still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)