### PR TITLE
update iceberg-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -788,9 +788,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455e9fb7743c6f6267eb2830ccc08686fbb3d13c9a689369562fd4d4ef9ea462"
+checksum = "c18d005c70d2b9c0c1ea8876c039db0ec7fb71164d25c73ccea21bf41fd02171"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3tables"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6bcb9ccd33ac33e75c39de6f136642e1ca42b3cefabdd4eb87ddc2c52af199"
+checksum = "e9317ac3787d523790cfaa7bb352403b39b868f9a5f7094661f2d9efab1c0abc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.73.0"
+version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ac1674cba7872061a29baaf02209fefe499ff034dfd91bd4cc59e4d7741489"
+checksum = "e0a69de9c1b9272da2872af60c7402683e7f45c06267735b4332deacb203239b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -921,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.74.0"
+version = "1.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6a22f077f5fd3e3c0270d4e1a110346cddf6769e9433eb9e6daceb4ca3b149"
+checksum = "f0b161d836fac72bdd5ac1a4cd1cdc38ab888c7af26cfd95f661be4409505e63"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -943,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.75.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3258fa707f2f585ee3049d9550954b959002abd59176975150a01d5cf38ae3f"
+checksum = "cb1cd79a3412751a341a28e2cd0d6fa4345241976da427b075a0c0cd5409f886"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1055,15 +1055,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f491388e741b7ca73b24130ff464c1478acc34d5b331b7dd0a2ee4643595a15"
+checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types 1.3.2",
  "h2 0.3.26",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -1617,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "jobserver",
  "libc",
@@ -2761,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3720,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3959,7 +3959,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -4180,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.2.0",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bdcc055bd58f5a429670c7407a3abf59af615df4#bdcc055bd58f5a429670c7407a3abf59af615df4"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4443,6 +4443,17 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "ipnet"
@@ -6312,9 +6323,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.16.3"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9323c0afb30e54f793f4705b10c890395bccc87c6e6ea62c4e7e82d09a380dc6"
+checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6336,13 +6347,14 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6350,7 +6362,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -6515,13 +6527,12 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+checksum = "e7295b7ce3bf4806b419dc3420745998b447178b7005e2011947b38fc5aa6791"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
- "trim-in-place",
 ]
 
 [[package]]
@@ -6737,6 +6748,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6913,16 +6936,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.10.0",
- "schemars",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6932,9 +6956,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7531,17 +7555,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "tracing",
@@ -7665,7 +7691,7 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -7951,12 +7977,6 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
-
-[[package]]
-name = "trim-in-place"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bdcc055bd58f5a429670c7407a3abf59af615df4" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }


### PR DESCRIPTION
Updates iceberg-rust dependency for better partition columns bounds. This can be used in MERGE INTO statements to prune the target table.