### PR TITLE
Fix projection expression in flatten

### DIFF
--- a/crates/embucket-functions/src/tests/table/flatten.rs
+++ b/crates/embucket-functions/src/tests/table/flatten.rs
@@ -27,6 +27,11 @@ test_query!(
     snapshot_path = "flatten"
 );
 test_query!(
+    flatten_projection_alias,
+    r#"SELECT d.value as row from flatten('{"a":1, "b":[77,88], "c": {"d":"X"}}','',false,true,'both') d;"#,
+    snapshot_path = "flatten"
+);
+test_query!(
     flatten_empty,
     "SELECT * FROM FLATTEN(INPUT => PARSE_JSON('[]')) f;",
     snapshot_path = "flatten"

--- a/crates/embucket-functions/src/tests/table/snapshots/flatten/query_flatten_join.snap
+++ b/crates/embucket-functions/src/tests/table/snapshots/flatten/query_flatten_join.snap
@@ -2,11 +2,12 @@
 source: crates/embucket-functions/src/tests/table/flatten.rs
 description: "\"SELECT column1, f.* FROM json_tbl, LATERAL FLATTEN(INPUT => column1, PATH => 'name') f\""
 info: "Setup queries: CREATE TABLE json_tbl AS  SELECT * FROM values\n          ('{\"name\":  {\"first\": \"John\", \"last\": \"Smith\"}}'),\n          ('{\"name\":  {\"first\": \"Jane\", \"last\": \"Doe\"}}') v;"
+snapshot_kind: text
 ---
 Ok(
     [
         "+-----------------------------------------------+-----+-------+------------+-------+---------+--------------------+",
-        "| column1                                       | SEQ | KEY   | PATH       | INDEX | VALUE   | THIS               |",
+        "| column1                                       | seq | key   | path       | index | value   | this               |",
         "+-----------------------------------------------+-----+-------+------------+-------+---------+--------------------+",
         "| {\"name\":  {\"first\": \"John\", \"last\": \"Smith\"}} | 1   | first | name.first |       | \"John\"  | {                  |",
         "|                                               |     |       |            |       |         |   \"first\": \"John\", |",

--- a/crates/embucket-functions/src/tests/table/snapshots/flatten/query_flatten_projection_alias.snap
+++ b/crates/embucket-functions/src/tests/table/snapshots/flatten/query_flatten_projection_alias.snap
@@ -1,0 +1,24 @@
+---
+source: crates/embucket-functions/src/tests/table/flatten.rs
+description: "r#\"SELECT d.value as row from flatten('{\"a\":1, \"b\":[77,88], \"c\": {\"d\":\"X\"}}','',false,true,'both') d;\"#"
+snapshot_kind: text
+---
+Ok(
+    [
+        "+------------+",
+        "| row        |",
+        "+------------+",
+        "| 1          |",
+        "| [          |",
+        "|   77,      |",
+        "|   88       |",
+        "| ]          |",
+        "| 77         |",
+        "| 88         |",
+        "| {          |",
+        "|   \"d\": \"X\" |",
+        "| }          |",
+        "| \"X\"        |",
+        "+------------+",
+    ],
+)


### PR DESCRIPTION
### Refactoring and modularity improvements:

* **Refactored Flatten schema creation logic**: Moved the schema creation logic from `FlattenTableFunc` to a new `FlattenTableProvider::new` method for better encapsulation. This centralizes schema handling and simplifies the `TableFunctionImpl` implementation.
* **Moved `empty_record_batch` method**: Relocated the `empty_record_batch` method from `FlattenTableFunc` to `FlattenExec` to align its functionality with execution-specific concerns. Updated its signature to include `row_id` for more flexibility.

### Schema handling improvements:

* **Normalized schema projection**: Enhanced schema handling in `FlattenExec` to use normalized schemas for projections, reducing mismatches between logical and physical schemas. 
* **Updated schema type in `FlattenExec`**: Changed the schema type from `Arc<DFSchema>` to `Arc<Schema>` to better align with DataFusion's schema representation. 

### Test and snapshot updates:

* **Added new test case**: Introduced a test for aliasing projections in flatten queries to verify compatibility with the updated schema handling.
Related to #1264 