### PR TITLE
update iceberg-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,8 +2825,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion_iceberg"
-version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
+version = "0.8.0"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4259,8 +4259,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-rest-catalog"
-version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
+version = "0.8.0"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4284,8 +4284,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-rust"
-version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
+version = "0.8.0"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -4316,8 +4316,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-rust-spec"
-version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
+version = "0.8.0"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.2.0",
@@ -4341,8 +4341,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-s3tables-catalog"
-version = "0.7.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8#adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8"
+version = "0.8.0"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "adf4416c6b46cef51eb7dc0cb40a703ba8d1f3f8" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }


### PR DESCRIPTION
This PR updates the iceberg-rust dependency. This mostly involves a fix regarding the JSON serialization.

Should fix #1297 