### PR TITLE
Add visitor to add CTEs in flatten

### DIFF
--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -47,7 +47,8 @@ use df_catalog::information_schema::session_params::SessionProperty;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::visitors::{
     copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query,
-    json_element, qualify_in_query, select_expr_aliases, table_functions, top_limit,
+    json_element, qualify_in_query, select_expr_aliases, table_functions,
+    table_functions_cte_relation, top_limit,
     unimplemented::functions_checker::visit as unimplemented_functions_checker,
 };
 use iceberg_rust::catalog::Catalog;
@@ -222,6 +223,7 @@ impl UserQuery {
             fetch_to_limit::visit(value).context(ex_error::SqlParserSnafu)?;
             table_functions::visit(value);
             qualify_in_query::visit(value);
+            table_functions_cte_relation::visit(value);
             visit_all(value);
         }
         Ok(())

--- a/crates/core-executor/src/tests/sql/functions/mod.rs
+++ b/crates/core-executor/src/tests/sql/functions/mod.rs
@@ -1,2 +1,3 @@
 mod aggregate;
+mod table;
 mod unimplemented;

--- a/crates/core-executor/src/tests/sql/functions/table/flatten.rs
+++ b/crates/core-executor/src/tests/sql/functions/table/flatten.rs
@@ -1,0 +1,9 @@
+use crate::test_query;
+
+test_query!(
+    flatten_cte,
+    r#"WITH base AS (SELECT '{"a": 1}' AS jsontext),
+        intermediate AS (SELECT value FROM base, LATERAL FLATTEN(INPUT => parse_json(jsontext)) d)
+    SELECT * FROM intermediate;"#,
+    snapshot_path = "flatten"
+);

--- a/crates/core-executor/src/tests/sql/functions/table/mod.rs
+++ b/crates/core-executor/src/tests/sql/functions/table/mod.rs
@@ -1,0 +1,1 @@
+mod flatten;

--- a/crates/core-executor/src/tests/sql/functions/table/snapshots/flatten/query_flatten_cte.snap
+++ b/crates/core-executor/src/tests/sql/functions/table/snapshots/flatten/query_flatten_cte.snap
@@ -1,0 +1,13 @@
+---
+source: crates/core-executor/src/tests/sql/functions/table/table.rs
+description: "r#\"WITH base AS (SELECT '{\"a\": 1}' AS jsontext),\n        intermediate AS (SELECT value FROM base, LATERAL FLATTEN(INPUT => parse_json(jsontext)) d)\n    SELECT * FROM intermediate;\"#"
+---
+Ok(
+    [
+        "+-------+",
+        "| value |",
+        "+-------+",
+        "| 1     |",
+        "+-------+",
+    ],
+)

--- a/crates/embucket-functions/src/table/flatten/provider.rs
+++ b/crates/embucket-functions/src/table/flatten/provider.rs
@@ -18,7 +18,8 @@ use datafusion_common::{
     Column, DFSchema, Result as DFResult, Result, ScalarValue, TableReference,
 };
 use datafusion_expr::execution_props::ExecutionProps;
-use datafusion_expr::{LogicalPlanBuilder, TableType};
+use datafusion_expr::expr::ScalarFunction;
+use datafusion_expr::{BinaryExpr, LogicalPlanBuilder, Subquery, TableType};
 use datafusion_physical_plan::common::collect;
 use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion_physical_plan::memory::MemoryStream;
@@ -30,6 +31,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
+use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -362,8 +364,9 @@ async fn evaluate_expr_or_plan(
     match extract_table_ref(expr) {
         // Evaluates the expression directly without column references
         None => {
+            let parsed_expr = inline_scalar_subqueries_in_expr(expr.clone(), session_state).await?;
             let exec_props = ExecutionProps::new();
-            let phys_expr = create_physical_expr(expr, &DFSchema::empty(), &exec_props)?;
+            let phys_expr = create_physical_expr(&parsed_expr, &DFSchema::empty(), &exec_props)?;
             let batch = RecordBatch::new_empty(Arc::new(Schema::empty()));
             let result = phys_expr.evaluate(&batch)?;
 
@@ -397,6 +400,67 @@ async fn evaluate_expr_or_plan(
             collect(input_stream).await
         }
     }
+}
+
+pub fn inline_scalar_subqueries_in_expr<'a>(
+    expr: Expr,
+    session_state: &'a SessionState,
+) -> Pin<Box<dyn Future<Output = Result<Expr>> + Send + 'a>> {
+    Box::pin(async move {
+        match expr {
+            Expr::ScalarFunction(ScalarFunction { func, args }) => {
+                let mut inlined_args = Vec::with_capacity(args.len());
+                for arg in args {
+                    let inlined_arg = inline_scalar_subqueries_in_expr(arg, session_state).await?;
+                    inlined_args.push(inlined_arg);
+                }
+                Ok(Expr::ScalarFunction(ScalarFunction {
+                    func,
+                    args: inlined_args,
+                }))
+            }
+            Expr::ScalarSubquery(subquery) => {
+                let batches = evaluate_subquery(subquery, session_state).await?;
+                let value = if let Some(batch) = batches.first() {
+                    if batch.num_rows() > 0 && batch.num_columns() > 0 {
+                        let array = batch.column(0);
+                        let scalar = ScalarValue::try_from_array(array.as_ref(), 0)?;
+                        Expr::Literal(scalar)
+                    } else {
+                        Expr::Literal(ScalarValue::Null)
+                    }
+                } else {
+                    Expr::Literal(ScalarValue::Null)
+                };
+
+                Ok(value)
+            }
+            Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
+                let (left, right) = tokio::try_join!(
+                    inline_scalar_subqueries_in_expr(*left, session_state),
+                    inline_scalar_subqueries_in_expr(*right, session_state),
+                )?;
+                Ok(Expr::BinaryExpr(BinaryExpr {
+                    left: Box::new(left),
+                    op,
+                    right: Box::new(right),
+                }))
+            }
+            other => Ok(other),
+        }
+    })
+}
+
+pub async fn evaluate_subquery(
+    subquery: Subquery,
+    session_state: &SessionState,
+) -> Result<Vec<RecordBatch>> {
+    let physical_plan = session_state
+        .create_physical_plan(&subquery.subquery)
+        .await?;
+
+    let stream = physical_plan.execute(0, session_state.task_ctx())?;
+    collect(stream).await
 }
 
 pub fn normalize_schema(schema: &DFSchema) -> SchemaRef {

--- a/crates/embucket-functions/src/visitors/mod.rs
+++ b/crates/embucket-functions/src/visitors/mod.rs
@@ -1,3 +1,10 @@
+use datafusion::logical_expr::sqlparser;
+use datafusion::logical_expr::sqlparser::ast::helpers::attached_token::AttachedToken;
+use datafusion::logical_expr::sqlparser::ast::{
+    Expr, GroupByExpr, Query, SelectItem, SetExpr, TableFactor, TableWithJoins,
+};
+use datafusion::sql::sqlparser::ast::Select;
+
 pub mod copy_into_identifiers;
 pub mod fetch_to_limit;
 pub mod functions_rewriter;
@@ -6,5 +13,57 @@ pub mod json_element;
 pub mod qualify_in_query;
 pub mod select_expr_aliases;
 pub mod table_functions;
+pub mod table_functions_cte_relation;
 pub mod top_limit;
 pub mod unimplemented;
+
+#[must_use]
+pub fn query_with_body(inner_select: Select) -> Query {
+    Query {
+        with: None,
+        body: Box::new(SetExpr::Select(Box::new(inner_select))),
+        order_by: None,
+        limit: None,
+        limit_by: vec![],
+        offset: None,
+        fetch: None,
+        locks: vec![],
+        for_clause: None,
+        settings: None,
+        format_clause: None,
+    }
+}
+
+#[must_use]
+pub fn select_with_body(
+    projection: Vec<SelectItem>,
+    relation: TableFactor,
+    selection: Option<Expr>,
+) -> Select {
+    Select {
+        select_token: AttachedToken::empty(),
+        distinct: None,
+        top: None,
+        top_before_distinct: false,
+        projection,
+        into: None,
+        from: vec![TableWithJoins {
+            relation,
+            joins: vec![],
+        }],
+        lateral_views: vec![],
+        prewhere: None,
+        selection,
+        group_by: GroupByExpr::Expressions(vec![], vec![]),
+        cluster_by: vec![],
+        distribute_by: vec![],
+        sort_by: vec![],
+        having: None,
+        named_window: vec![],
+        qualify: None,
+        window_before_qualify: false,
+        value_table_mode: None,
+        connect_by: None,
+        flavor: sqlparser::ast::SelectFlavor::Standard,
+    }
+}

--- a/crates/embucket-functions/src/visitors/table_functions_cte_relation.rs
+++ b/crates/embucket-functions/src/visitors/table_functions_cte_relation.rs
@@ -1,0 +1,174 @@
+use crate::visitors::{query_with_body, select_with_body};
+use datafusion::logical_expr::sqlparser::ast::{
+    Expr, FunctionArg, FunctionArgExpr, FunctionArguments, Ident, SelectItem, SetExpr, TableFactor,
+};
+use datafusion::sql::sqlparser::ast::{Query, TableAlias};
+use datafusion_expr::sqlparser::ast::VisitMut;
+use datafusion_expr::sqlparser::ast::{Statement, VisitorMut};
+use std::collections::HashMap;
+use std::ops::ControlFlow;
+
+#[derive(Debug, Default)]
+pub struct TableFuncInlineCte {
+    ctes: HashMap<String, Query>,
+    current_from_tables: Vec<TableFactor>,
+}
+
+impl VisitorMut for TableFuncInlineCte {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &mut Query) -> ControlFlow<()> {
+        if let Some(with) = &mut query.with {
+            for cte in &with.cte_tables {
+                self.ctes
+                    .insert(cte.alias.name.value.clone(), (*cte.query).clone());
+            }
+        }
+        if let SetExpr::Select(select) = &*query.body {
+            self.current_from_tables = select.from.iter().map(|f| f.relation.clone()).collect();
+        } else {
+            self.current_from_tables.clear();
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn post_visit_table_factor(&mut self, table_factor: &mut TableFactor) -> ControlFlow<()> {
+        match table_factor {
+            TableFactor::Function { name, args, .. }
+                if name.to_string().eq_ignore_ascii_case("flatten") =>
+            {
+                *args = self.replace_flatten_args(args);
+            }
+            _ => {}
+        }
+
+        ControlFlow::Continue(())
+    }
+}
+
+impl TableFuncInlineCte {
+    pub fn replace_flatten_args(&mut self, args: &mut [FunctionArg]) -> Vec<FunctionArg> {
+        args.iter()
+            .map(|arg| match arg {
+                FunctionArg::Named {
+                    name,
+                    arg: FunctionArgExpr::Expr(expr),
+                    operator,
+                } if name.to_string().eq_ignore_ascii_case("input") => {
+                    let new_expr = self.replace_expr(expr.clone());
+                    FunctionArg::Named {
+                        name: name.clone(),
+                        arg: FunctionArgExpr::Expr(new_expr),
+                        operator: operator.clone(),
+                    }
+                }
+                other => other.clone(), // Unnamed or non-Expr args
+            })
+            .collect()
+    }
+    fn replace_expr(&self, expr: Expr) -> Expr {
+        match expr {
+            Expr::Function(mut func) => {
+                func.args = match func.args {
+                    FunctionArguments::List(mut arg_list) => {
+                        arg_list.args = arg_list
+                            .args
+                            .into_iter()
+                            .map(|arg| match arg {
+                                FunctionArg::Named {
+                                    name,
+                                    arg: FunctionArgExpr::Expr(inner),
+                                    operator,
+                                } => FunctionArg::Named {
+                                    name,
+                                    arg: FunctionArgExpr::Expr(self.replace_expr(inner)),
+                                    operator,
+                                },
+                                FunctionArg::Unnamed(FunctionArgExpr::Expr(inner)) => {
+                                    FunctionArg::Unnamed(FunctionArgExpr::Expr(
+                                        self.replace_expr(inner),
+                                    ))
+                                }
+                                other => other,
+                            })
+                            .collect();
+                        FunctionArguments::List(arg_list)
+                    }
+                    other => other,
+                };
+                Expr::Function(func)
+            }
+            Expr::Identifier(ident) => {
+                let column = &ident.value;
+
+                if let Some((alias, query)) = self.extract_projected_columns(column) {
+                    let relation = TableFactor::Derived {
+                        lateral: false,
+                        subquery: Box::new(query.clone()),
+                        alias: Some(TableAlias {
+                            name: Ident::new(alias.clone()),
+                            columns: vec![],
+                        }),
+                    };
+                    let projection = vec![SelectItem::UnnamedExpr(Expr::Identifier(Ident::new(
+                        column.clone(),
+                    )))];
+                    let subquery = select_with_body(projection, relation, None);
+                    return Expr::Subquery(Box::new(query_with_body(subquery)));
+                }
+                Expr::Identifier(ident)
+            }
+            other => other,
+        }
+    }
+
+    fn extract_projected_columns(&self, column: &String) -> Option<(&String, &Query)> {
+        // Search for CTEs that are defined on the same level as the current FROM tables
+        let cte_names_on_same_level: Vec<String> = self
+            .current_from_tables
+            .iter()
+            .filter_map(|tf| match tf {
+                TableFactor::Table { name, .. } | TableFactor::Function { name, .. } => {
+                    let table_name = name.to_string();
+                    if self.ctes.contains_key(&table_name) {
+                        Some(table_name)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Check if the column is a part of any CTE's projection on the same level
+        for cte in cte_names_on_same_level.clone() {
+            if let Some((alias, query)) = self.ctes.get_key_value(&cte) {
+                if let SetExpr::Select(select) = &*query.body {
+                    let mut columns = vec![];
+                    for item in &select.projection {
+                        match item {
+                            SelectItem::ExprWithAlias { alias, .. } => {
+                                columns.push(alias.value.clone());
+                            }
+                            SelectItem::UnnamedExpr(Expr::Identifier(ident)) => {
+                                columns.push(ident.value.clone());
+                            }
+                            _ => {}
+                        }
+                    }
+                    if columns.iter().any(|c| c == column) {
+                        return Some((alias, query));
+                    }
+                }
+            }
+        }
+        if !cte_names_on_same_level.is_empty() {
+            return self.ctes.get_key_value(&cte_names_on_same_level[0]);
+        }
+        None
+    }
+}
+
+pub fn visit(stmt: &mut Statement) {
+    let _ = stmt.visit(&mut TableFuncInlineCte::default());
+}


### PR DESCRIPTION
This pull request introduces support for inlining scalar subqueries and table functions within Common Table Expressions (CTEs). It adds new capabilities for handling complex SQL queries, particularly those involving lateral joins and nested subqueries, while also improving modularity and reusability in the codebase. 

### Enhancements to query processing:

* **Support for scalar subqueries in expressions**: Added the `inline_scalar_subqueries_in_expr` function to recursively inline scalar subqueries, enabling more efficient query evaluation.
* **Evaluation of subqueries**: Introduced the `evaluate_subquery` function to execute subqueries and convert their results into scalar expressions.

### Improvements to table function handling:

* **Inlining table functions within CTEs**: Added the `TableFuncInlineCte` visitor to replace `FLATTEN` table function arguments with expressions derived from CTEs, enhancing support for nested queries.
* **New visitor module**: Created the `table_functions_cte_relation` module to encapsulate logic for processing table functions in CTEs.

### Testing additions:

* **Unit tests for table functions and CTEs**: Added tests for `FLATTEN` within CTEs in `test_table_function_cte` and `flatten_cte` to validate the new functionality.
* **Snapshot testing for `FLATTEN` queries**: Included snapshot tests to ensure consistent output for queries involving lateral joins and table functions.

### Code modularity and reuse:

* **Reusable helper functions for query and select construction**: Introduced `query_with_body` and `select_with_body` functions to simplify query and select object creation.
* **Refactoring of `qualify_in_query`**: Updated the `qualify_in_query` module to use the new helper functions, reducing redundancy.

Closes #1279 