### PR TITLE
Support drop database

### DIFF
--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -59,6 +59,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Invalid database identifier: {ident}"))]
+    InvalidDatabaseIdentifier {
+        ident: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Invalid file path: {path}"))]
     InvalidFilePath {
         path: String,
@@ -265,6 +272,14 @@ pub enum Error {
 
     #[snafu(display("Failed to register catalog: {source}"))]
     RegisterCatalog {
+        #[snafu(source(from(CatalogError, Box::new)))]
+        source: Box<CatalogError>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to drop catalog: {source}"))]
+    DropCatalog {
         #[snafu(source(from(CatalogError, Box::new)))]
         source: Box<CatalogError>,
         #[snafu(implicit)]

--- a/crates/core-executor/src/snowflake_error.rs
+++ b/crates/core-executor/src/snowflake_error.rs
@@ -171,8 +171,10 @@ impl From<Error> for SnowflakeError {
                     MetastoreError::UrlParse { .. } => Self::Custom { message },
                 }
             }
+            Error::InvalidDatabaseIdentifier { .. } => Self::Custom { message },
             Error::InvalidTableIdentifier { .. } => Self::Custom { message },
             Error::InvalidSchemaIdentifier { .. } => Self::Custom { message },
+            Error::DropCatalog { .. } => Self::Custom { message },
             Error::InvalidFilePath { .. } => Self::Custom { message },
             Error::InvalidBucketIdentifier { .. } => Self::Custom { message },
             Error::Arrow { .. } => Self::Custom { message },

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -214,6 +214,8 @@ macro_rules! test_query {
     };
 }
 
+test_query!(drop_database, "DROP DATABASE embucket");
+
 // CREATE SCHEMA
 test_query!(
     create_schema,

--- a/crates/core-executor/src/tests/snapshots/query_drop_database.snap
+++ b/crates/core-executor/src/tests/snapshots/query_drop_database.snap
@@ -1,0 +1,12 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"DROP DATABASE embucket\""
+---
+Ok(
+    [
+        "+--------+",
+        "| status |",
+        "+--------+",
+        "+--------+",
+    ],
+)

--- a/crates/df-catalog/src/catalog.rs
+++ b/crates/df-catalog/src/catalog.rs
@@ -6,10 +6,18 @@ use std::{any::Any, sync::Arc};
 #[derive(Clone)]
 pub struct CachingCatalog {
     pub catalog: Arc<dyn CatalogProvider>,
+    pub catalog_type: CatalogType,
     pub schemas_cache: DashMap<String, Arc<CachingSchema>>,
     pub should_refresh: bool,
     pub name: String,
     pub enable_information_schema: bool,
+}
+
+#[derive(Clone, Debug)]
+pub enum CatalogType {
+    Internal,
+    Memory,
+    S3tables,
 }
 
 impl CachingCatalog {
@@ -20,6 +28,7 @@ impl CachingCatalog {
             should_refresh: false,
             enable_information_schema: true,
             name,
+            catalog_type: CatalogType::Internal,
         }
     }
     #[must_use]
@@ -30,6 +39,12 @@ impl CachingCatalog {
     #[must_use]
     pub const fn with_information_schema(mut self, enable_information_schema: bool) -> Self {
         self.enable_information_schema = enable_information_schema;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_catalog_type(mut self, catalog_type: CatalogType) -> Self {
+        self.catalog_type = catalog_type;
         self
     }
 }

--- a/crates/df-catalog/src/error.rs
+++ b/crates/df-catalog/src/error.rs
@@ -79,4 +79,10 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Feature not implemented: '{details:?}'"))]
+    NotImplemented {
+        details: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }


### PR DESCRIPTION
* This pull request introduces support for dropping catalogs, including databases, in the core executor and catalog management components. It also removes functionality related to external catalog registration (duplicated call) and simplifies catalog handling by introducing a new `CatalogType` enum.
* Added test cases for `DROP DATABASE` functionality in `crates/core-executor/src/tests/query.rs` and corresponding snapshot validation.
* Extended `SnowflakeError` to include mappings for the new error variants `InvalidDatabaseIdentifier` and `DropCatalog`.
* Added a new `NotImplemented` error variant to `crates/df-catalog/src/error.rs` for unsupported catalog operations, such as dropping S3 tables catalogs.
* For Embucket catalog we return an error if database in use by schemas

Added tests with
```sql
DROP DATABASE test
```
Closes #159 