### PR TITLE
Fix s3 tables create/drop schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=3448a9bbc92d1c0026668b3cb0a736f61df05282#3448a9bbc92d1c0026668b3cb0a736f61df05282"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=3448a9bbc92d1c0026668b3cb0a736f61df05282#3448a9bbc92d1c0026668b3cb0a736f61df05282"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4286,7 +4286,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=3448a9bbc92d1c0026668b3cb0a736f61df05282#3448a9bbc92d1c0026668b3cb0a736f61df05282"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=3448a9bbc92d1c0026668b3cb0a736f61df05282#3448a9bbc92d1c0026668b3cb0a736f61df05282"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.2.0",
@@ -4343,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=609016aa7eab4ffcfff7c9264a64afb13c92c3e1#609016aa7eab4ffcfff7c9264a64afb13c92c3e1"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=3448a9bbc92d1c0026668b3cb0a736f61df05282#3448a9bbc92d1c0026668b3cb0a736f61df05282"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "3448a9bbc92d1c0026668b3cb0a736f61df05282" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "609016aa7eab4ffcfff7c9264a64afb13c92c3e1" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "3448a9bbc92d1c0026668b3cb0a736f61df05282" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "3448a9bbc92d1c0026668b3cb0a736f61df05282" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "3448a9bbc92d1c0026668b3cb0a736f61df05282" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "3448a9bbc92d1c0026668b3cb0a736f61df05282" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }

--- a/crates/df-catalog/src/catalog_list.rs
+++ b/crates/df-catalog/src/catalog_list.rs
@@ -183,10 +183,9 @@ impl EmbucketCatalogList {
             let catalog = DataFusionIcebergCatalog::new(Arc::new(catalog), None)
                 .await
                 .context(df_catalog_error::DataFusionSnafu)?;
-            catalogs.push(CachingCatalog::new(
-                Arc::new(catalog),
-                volume.database.clone(),
-            ));
+            catalogs.push(
+                CachingCatalog::new(Arc::new(catalog), volume.database.clone()).with_refresh(true),
+            );
         }
         Ok(catalogs)
     }


### PR DESCRIPTION
For IcebergCatalog we need to update catalog internal mirror storage. 
We call register_schema for this catalog type only.
Closes #1248 