### PR TITLE
Many auth DedicatedExecutors fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,13 +257,13 @@ dependencies = [
 name = "api-sessions"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "axum 0.8.4",
  "core-executor",
+ "error-stack",
+ "error-stack-trace",
  "http 1.3.1",
  "regex",
  "serde",
- "serde_json",
  "snafu",
  "time",
  "tokio",

--- a/crates/api-sessions/Cargo.toml
+++ b/crates/api-sessions/Cargo.toml
@@ -6,15 +6,15 @@ license-file.workspace = true
 
 [dependencies]
 core-executor = { path = "../core-executor" }
+error-stack-trace = { path = "../error-stack-trace" }
+error-stack = { path = "../error-stack" }
 
-async-trait = { workspace = true }
 axum = { workspace = true }
 tower-sessions = { workspace = true }
 tokio = { workspace = true }
 time = { workspace = true }
 http = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 snafu = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/api-sessions/src/error.rs
+++ b/crates/api-sessions/src/error.rs
@@ -1,0 +1,56 @@
+use axum::{Json, http, response::IntoResponse};
+use error_stack_trace;
+use http::header::InvalidHeaderValue;
+use http::{StatusCode, header::MaxSizeReached};
+use serde::{Deserialize, Serialize};
+use snafu::Location;
+use snafu::prelude::*;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[error_stack_trace::debug]
+pub enum Error {
+    #[snafu(display("Can't add header to response: {error}"))]
+    ResponseHeader {
+        #[snafu(source)]
+        error: InvalidHeaderValue,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Set-Cookie error: {error}"))]
+    SetCookie {
+        #[snafu(source)]
+        error: MaxSizeReached,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Execution error: {error}"))]
+    Execution {
+        #[snafu(source)]
+        error: core_executor::Error,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    pub message: String,
+    pub status_code: u16,
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> axum::response::Response<axum::body::Body> {
+        let message = self.to_string();
+        let code = StatusCode::INTERNAL_SERVER_ERROR;
+
+        let error = ErrorResponse {
+            message,
+            status_code: code.as_u16(),
+        };
+
+        (code, Json(error)).into_response()
+    }
+}

--- a/crates/api-sessions/src/layer.rs
+++ b/crates/api-sessions/src/layer.rs
@@ -1,0 +1,86 @@
+use crate::error as session_error;
+use crate::error::Result;
+use crate::session::{
+    DFSessionId, SESSION_ID_COOKIE_NAME, SessionStore, extract_token_from_cookie,
+};
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use http::header::SET_COOKIE;
+use http::{HeaderMap, HeaderName};
+use snafu::ResultExt;
+use tower_sessions::cookie::{Cookie, SameSite};
+
+#[allow(clippy::unwrap_used)]
+pub async fn propagate_session_cookie(
+    State(state): State<SessionStore>,
+    mut req: Request,
+    next: Next,
+) -> Result<impl IntoResponse> {
+    if let Some(token) = extract_token_from_cookie(req.headers()) {
+        tracing::debug!("Found DF session_id in cookie header: {}", token);
+
+        let sessions = state.execution_svc.get_sessions().await;
+
+        let sessions = sessions.read().await;
+
+        //session_id is expired and deleted
+        if !sessions.contains_key(&token) {
+            drop(sessions);
+            tracing::debug!("This DF session_id is expired or deleted.");
+
+            let session_id = uuid::Uuid::new_v4().to_string();
+            //Propagate new session_id to the extractor
+            req.extensions_mut().insert(DFSessionId(session_id.clone()));
+            let mut res = next.run(req).await;
+            set_headers_in_flight(
+                res.headers_mut(),
+                SET_COOKIE,
+                SESSION_ID_COOKIE_NAME,
+                session_id.as_str(),
+            )?;
+            return Ok(res);
+        }
+        tracing::debug!("This DF session_id is not expired or deleted.");
+        //Propagate in-use (valid) session_id to the extractor
+        req.extensions_mut().insert(DFSessionId(token));
+    } else {
+        let session_id = uuid::Uuid::new_v4().to_string();
+        tracing::debug!("Created new DF session_id: {}", session_id);
+        //Propagate new session_id to the extractor
+        req.extensions_mut().insert(DFSessionId(session_id.clone()));
+        let mut res = next.run(req).await;
+        set_headers_in_flight(
+            res.headers_mut(),
+            SET_COOKIE,
+            SESSION_ID_COOKIE_NAME,
+            session_id.as_str(),
+        )?;
+        return Ok(res);
+    }
+
+    Ok(next.run(req).await)
+}
+
+fn set_headers_in_flight(
+    headers: &mut HeaderMap,
+    header_name: HeaderName,
+    name: &str,
+    token: &str,
+) -> Result<()> {
+    headers
+        .try_insert(
+            header_name,
+            Cookie::build((name, token))
+                .http_only(true)
+                .secure(true)
+                .same_site(SameSite::Strict)
+                .path("/")
+                .to_string()
+                .parse()
+                .context(session_error::ResponseHeaderSnafu)?,
+        )
+        .context(session_error::SetCookieSnafu)?;
+
+    Ok(())
+}

--- a/crates/api-sessions/src/lib.rs
+++ b/crates/api-sessions/src/lib.rs
@@ -1,2 +1,5 @@
+pub mod error;
+pub mod layer;
 pub mod session;
-pub use crate::session::{DFSessionId, RequestSessionStore};
+
+pub use crate::session::DFSessionId;

--- a/crates/api-sessions/src/session.rs
+++ b/crates/api-sessions/src/session.rs
@@ -108,6 +108,9 @@ impl DFSessionId {
     }
 }
 
+//Snowflake token extraction lives in the api-session crate (used here also),
+// so to not create a cyclic dependency exporting it from the api-snowflake-rest crate,
+// where it's used in the `require_auth` layer as part of the session flow and was originally from
 #[must_use]
 pub fn extract_token_from_auth(headers: &HeaderMap) -> Option<String> {
     //First we check the header

--- a/crates/api-sessions/src/session.rs
+++ b/crates/api-sessions/src/session.rs
@@ -1,128 +1,54 @@
-use axum::{Json, extract::FromRequestParts, response::IntoResponse};
+use crate::error as session_error;
+use axum::extract::FromRequestParts;
+use core_executor::ExecutionAppState;
 use core_executor::service::ExecutionService;
 use core_executor::session::SESSION_INACTIVITY_EXPIRATION_SECONDS;
 use http::header::COOKIE;
 use http::request::Parts;
 use http::{HeaderMap, HeaderName};
 use regex::Regex;
-use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
-use snafu::prelude::*;
 use std::{collections::HashMap, sync::Arc};
 use time::{Duration, OffsetDateTime};
-use tower_sessions::{
-    ExpiredDeletion, Expiry, Session, SessionStore,
-    session::{Id, Record},
-    session_store,
-};
-use uuid;
 
 pub const SESSION_ID_COOKIE_NAME: &str = "session_id";
 
 pub const SESSION_EXPIRATION_SECONDS: u64 = 60;
 
 #[derive(Clone)]
-pub struct RequestSessionStore {
-    execution_svc: Arc<dyn ExecutionService>,
+pub struct SessionStore {
+    pub execution_svc: Arc<dyn ExecutionService>,
 }
 
-#[allow(clippy::missing_const_for_fn)]
-impl RequestSessionStore {
+impl SessionStore {
     pub fn new(execution_svc: Arc<dyn ExecutionService>) -> Self {
         Self { execution_svc }
     }
-
-    pub async fn continuously_delete_expired(
-        self,
-        period: tokio::time::Duration,
-    ) -> session_store::Result<()> {
+    pub async fn continuously_delete_expired(&self, period: tokio::time::Duration) {
         let mut interval = tokio::time::interval(period);
         interval.tick().await; // The first tick completes immediately; skip.
         loop {
             interval.tick().await;
-            self.delete_expired().await?;
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl SessionStore for RequestSessionStore {
-    #[tracing::instrument(name = "SessionStore::create", level = "trace", skip(self), err, ret)]
-    async fn create(&self, record: &mut Record) -> session_store::Result<()> {
-        if let Some(df_session_id) = record.data.get("DF_SESSION_ID").and_then(|v| v.as_str()) {
             let sessions = self.execution_svc.get_sessions().await;
 
             let mut sessions = sessions.write().await;
 
-            if let Some(session) = sessions.get_mut(df_session_id) {
-                let mut expiry = session.expiry.lock().await;
-                *expiry = record.expiry_date;
-                tracing::debug!("Updating expiry: {}", *expiry);
-            } else {
-                drop(sessions);
-                self.execution_svc
-                    .create_session(df_session_id.to_string())
-                    .await
-                    .map_err(|e| session_store::Error::Backend(e.to_string()))?;
+            let now = OffsetDateTime::now_utc();
+            tracing::error!("Starting to delete expired for: {}", now);
+            //Sadly can't use `sessions.retain(|_, session| { ... }`, since the `OffsetDatetime` is in a `Mutex`
+            let mut session_ids = Vec::new();
+            for (session_id, session) in sessions.iter() {
+                let expiry = session.expiry.lock().await;
+                if *expiry <= now {
+                    session_ids.push(session_id.clone());
+                }
+            }
+
+            for session_id in session_ids {
+                tracing::error!("Deleting expired: {}", session_id);
+                sessions.remove(&session_id);
             }
         }
-        Ok(())
-    }
-
-    #[tracing::instrument(name = "SessionStore::save", level = "trace", skip(self), err, ret)]
-    async fn save(&self, _record: &Record) -> session_store::Result<()> {
-        Ok(())
-    }
-
-    #[tracing::instrument(name = "SessionStore::load", level = "trace", skip(self), err, ret)]
-    async fn load(&self, _id: &Id) -> session_store::Result<Option<Record>> {
-        Ok(None)
-    }
-
-    #[tracing::instrument(name = "SessionStore::delete", level = "trace", skip(self), err, ret)]
-    async fn delete(&self, _id: &Id) -> session_store::Result<()> {
-        Ok(())
-    }
-}
-
-#[async_trait::async_trait]
-impl ExpiredDeletion for RequestSessionStore {
-    #[tracing::instrument(
-        name = "ExpiredDeletion::delete_expired",
-        level = "trace",
-        skip(self),
-        err,
-        ret
-    )]
-    async fn delete_expired(&self) -> session_store::Result<()> {
-        let sessions = self.execution_svc.get_sessions().await;
-
-        let mut sessions = sessions.write().await;
-
-        let now = OffsetDateTime::now_utc();
-        tracing::debug!("Starting to delete expired for: {}", now);
-        //Sadly can't use `sessions.retain(|_, session| { ... }`, since the `OffsetDatetime` is in a `Mutex`
-        let mut session_ids = Vec::new();
-        for (session_id, session) in sessions.iter() {
-            let expiry = session.expiry.lock().await;
-            if *expiry <= now {
-                session_ids.push(session_id.clone());
-            }
-        }
-
-        for session_id in session_ids {
-            tracing::debug!("Deleting expired: {}", session_id);
-            sessions.remove(&session_id);
-        }
-
-        Ok(())
-    }
-}
-
-impl std::fmt::Debug for RequestSessionStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RequestSessionStore")
-            .finish_non_exhaustive()
     }
 }
 
@@ -131,82 +57,78 @@ pub struct DFSessionId(pub String);
 
 impl<S> FromRequestParts<S> for DFSessionId
 where
-    S: Send + Sync,
+    S: Send + Sync + ExecutionAppState,
 {
-    type Rejection = SessionError;
+    type Rejection = session_error::Error;
 
+    #[allow(clippy::unwrap_used)]
     async fn from_request_parts(req: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let session = Session::from_request_parts(req, state).await.map_err(|e| {
-            tracing::error!("Failed to get session: {}", e.1);
-            SessionError::SessionLoad {
-                msg: e.1.to_string(),
-            }
-        })?;
-        //If UI Auth middleware generated a new session id
-        let session_id = if let Some(Self(session_id)) = req.extensions.get::<Self>() {
-            tracing::debug!(
-                "Found DF session_id in extensions for creation: {}",
-                session_id
-            );
-            Self::create_session(&session, session_id.clone()).await
-        //If the session is alive
-        } else if let Some(token) = extract_token(&req.headers) {
-            tracing::debug!("Found DF session_id in headers: {}", token);
-            session
-                .insert("DF_SESSION_ID", token.clone())
-                .await
-                .context(SessionPersistSnafu)?;
-            session.set_expiry(Some(Expiry::OnInactivity(Duration::seconds(
-                SESSION_INACTIVITY_EXPIRATION_SECONDS,
-            ))));
-            session.save().await.context(SessionPersistSnafu)?;
-            Ok(Self(token))
-        //If the session is dead
+        let execution_svc = state.get_execution_svc();
+
+        if let Some(token) = extract_token_from_auth(&req.headers) {
+            tracing::debug!("Found DF session_id in auth header: {}", token);
+
+            let id = Self::get_or_create_session(execution_svc, token.clone()).await?;
+
+            Ok(id)
         } else {
-            let id = uuid::Uuid::new_v4().to_string();
-            Self::create_session(&session, id.clone()).await
-        };
-        //We don't rely on their cookie :)
-        session.flush().await.context(SessionPersistSnafu)?;
-        session_id
+            //This is guaranteed by the `propagate_session_cookie`, so we can unwrap
+            let Self(token) = req.extensions.get::<Self>().unwrap();
+            tracing::debug!("Found DF session_id in extensions: {}", token);
+
+            let id = Self::get_or_create_session(execution_svc, token.clone()).await?;
+
+            Ok(id)
+        }
     }
 }
 
 impl DFSessionId {
-    async fn create_session(session: &Session, id: String) -> Result<Self, SessionError> {
-        tracing::debug!("Creating new DF session_id: {}", id);
-        session
-            .insert("DF_SESSION_ID", id.clone())
-            .await
-            .context(SessionPersistSnafu)?;
-        session.save().await.context(SessionPersistSnafu)?;
+    async fn get_or_create_session(
+        execution_svc: Arc<dyn ExecutionService>,
+        id: String,
+    ) -> Result<Self, session_error::Error> {
+        let sessions = execution_svc.get_sessions().await;
+
+        let mut sessions = sessions.write().await;
+
+        if let Some(session) = sessions.get_mut(&id) {
+            let mut expiry = session.expiry.lock().await;
+            *expiry = OffsetDateTime::now_utc()
+                + Duration::seconds(SESSION_INACTIVITY_EXPIRATION_SECONDS);
+            tracing::debug!("Updating expiry: {}", *expiry);
+        } else {
+            drop(sessions);
+            let _ = execution_svc
+                .create_session(id.clone())
+                .await
+                .context(session_error::ExecutionSnafu)?;
+        }
         Ok(Self(id))
     }
 }
 
 #[must_use]
-pub fn extract_token(headers: &HeaderMap) -> Option<String> {
-    //First we check the header, second the cookie
-    headers
-        .get("authorization")
-        .and_then(|value| {
-            value.to_str().ok().and_then(|auth| {
-                #[allow(clippy::unwrap_used)]
-                let re = Regex::new(r#"Snowflake Token="([a-f0-9\-]+)""#).unwrap();
-                re.captures(auth)
-                    .and_then(|caps| caps.get(1).map(|m| m.as_str().to_string()))
-            })
+pub fn extract_token_from_auth(headers: &HeaderMap) -> Option<String> {
+    //First we check the header
+    headers.get("authorization").and_then(|value| {
+        value.to_str().ok().and_then(|auth| {
+            #[allow(clippy::unwrap_used)]
+            let re = Regex::new(r#"Snowflake Token="([a-f0-9\-]+)""#).unwrap();
+            re.captures(auth)
+                .and_then(|caps| caps.get(1).map(|m| m.as_str().to_string()))
         })
-        .map_or_else(
-            || {
-                let cookies = cookies_from_header(headers, COOKIE);
-                cookies
-                    .get(SESSION_ID_COOKIE_NAME)
-                    .map(|str_ref| (*str_ref).to_string())
-            },
-            Some,
-        )
+    })
 }
+
+#[must_use]
+pub fn extract_token_from_cookie(headers: &HeaderMap) -> Option<String> {
+    let cookies = cookies_from_header(headers, COOKIE);
+    cookies
+        .get(SESSION_ID_COOKIE_NAME)
+        .map(|str_ref| (*str_ref).to_string())
+}
+
 #[allow(clippy::explicit_iter_loop)]
 pub fn cookies_from_header(headers: &HeaderMap, header_name: HeaderName) -> HashMap<&str, &str> {
     let mut cookies_map = HashMap::new();
@@ -226,45 +148,15 @@ pub fn cookies_from_header(headers: &HeaderMap, header_name: HeaderName) -> Hash
     cookies_map
 }
 
-#[derive(Debug, Snafu)]
-#[snafu(visibility(pub(crate)))]
-pub enum SessionError {
-    #[snafu(display("Session load error: {msg}"))]
-    SessionLoad { msg: String },
-    #[snafu(display("Unable to persist session {source:?}"))]
-    SessionPersist {
-        source: tower_sessions::session::Error,
-    },
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ErrorResponse {
-    pub message: String,
-    pub status_code: u16,
-}
-
-impl IntoResponse for SessionError {
-    fn into_response(self) -> axum::response::Response {
-        let er = ErrorResponse {
-            message: self.to_string(),
-            status_code: 500,
-        };
-        (http::StatusCode::INTERNAL_SERVER_ERROR, Json(er)).into_response()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::session::SessionStore;
     use core_executor::models::QueryContext;
     use core_executor::service::ExecutionService;
     use core_executor::service::make_text_execution_svc;
-    use serde_json::json;
-    use std::collections::HashMap;
+    use std::time::Duration;
     use time::OffsetDateTime;
     use tokio::time::sleep;
-    use tower_sessions::SessionStore;
-    use tower_sessions::session::{Id, Record};
 
     #[tokio::test]
     #[allow(clippy::expect_used, clippy::too_many_lines)]
@@ -272,32 +164,27 @@ mod tests {
         let execution_svc = make_text_execution_svc().await;
 
         let df_session_id = "fasfsafsfasafsass".to_string();
-        execution_svc
+        let user_session = execution_svc
             .create_session(df_session_id.clone())
             .await
             .expect("Failed to create a session");
 
-        let session_store = RequestSessionStore::new(execution_svc.clone());
+        let mut expiry = user_session.expiry.lock().await;
+        *expiry = OffsetDateTime::now_utc();
+        drop(expiry);
 
-        let data = HashMap::new();
-        let mut record = Record {
-            id: Id::default(),
-            data,
-            expiry_date: OffsetDateTime::now_utc(),
-        };
-        record
-            .data
-            .insert("DF_SESSION_ID".to_string(), json!(df_session_id.clone()));
-        tokio::task::spawn(
-            session_store
-                .clone()
-                .continuously_delete_expired(tokio::time::Duration::from_secs(5)),
-        );
-        let () = session_store
-            .create(&mut record)
-            .await
-            .expect("Failed to get a session");
-        let () = sleep(core::time::Duration::from_secs(11)).await;
+        let session_store = SessionStore::new(execution_svc.clone());
+
+        tokio::task::spawn({
+            let session_store = session_store.clone();
+            async move {
+                session_store
+                    .continuously_delete_expired(Duration::from_secs(5))
+                    .await;
+            }
+        });
+
+        let () = sleep(Duration::from_secs(7)).await;
         execution_svc
             .query(&df_session_id, "SELECT 1", QueryContext::default())
             .await

--- a/crates/api-sessions/src/session.rs
+++ b/crates/api-sessions/src/session.rs
@@ -109,8 +109,8 @@ impl DFSessionId {
 }
 
 //Snowflake token extraction lives in the api-session crate (used here also),
-// so to not create a cyclic dependency exporting it from the api-snowflake-rest crate,
-// where it's used in the `require_auth` layer as part of the session flow and was originally from
+// so to not create a cyclic dependency exporting it from the api-snowflake-rest crate.
+// Where it's used in the `require_auth` layer as part of the session flow and where it was originally from.
 #[must_use]
 pub fn extract_token_from_auth(headers: &HeaderMap) -> Option<String> {
     //First we check the header

--- a/crates/api-snowflake-rest/src/handlers.rs
+++ b/crates/api-snowflake-rest/src/handlers.rs
@@ -34,7 +34,6 @@ const ARROW_IPC_ALIGNMENT: usize = 8;
 
 #[tracing::instrument(level = "debug", skip(state, body), err, ret(level = tracing::Level::TRACE))]
 pub async fn login(
-    DFSessionId(session_id): DFSessionId,
     State(state): State<AppState>,
     Query(query): Query<LoginRequestQuery>,
     body: Bytes,
@@ -55,6 +54,13 @@ pub async fn login(
     {
         return api_snowflake_rest_error::InvalidAuthDataSnafu.fail()?;
     }
+
+    let session_id = uuid::Uuid::new_v4().to_string();
+
+    let _ = state
+        .execution_svc
+        .create_session(session_id.clone())
+        .await?;
 
     Ok(Json(LoginResponse {
         data: Option::from(LoginData { token: session_id }),

--- a/crates/api-snowflake-rest/src/state.rs
+++ b/crates/api-snowflake-rest/src/state.rs
@@ -1,4 +1,5 @@
 use crate::schemas::Config;
+use core_executor::ExecutionAppState;
 use core_executor::service::ExecutionService;
 use std::sync::Arc;
 
@@ -6,4 +7,10 @@ use std::sync::Arc;
 pub struct AppState {
     pub execution_svc: Arc<dyn ExecutionService>,
     pub config: Config,
+}
+
+impl ExecutionAppState for AppState {
+    fn get_execution_svc(&self) -> Arc<dyn ExecutionService> {
+        self.execution_svc.clone()
+    }
 }

--- a/crates/api-ui/src/auth/error.rs
+++ b/crates/api-ui/src/auth/error.rs
@@ -95,6 +95,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Execution error: {error}"))]
+    Execution {
+        #[snafu(source)]
+        error: core_executor::Error,
+    },
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, ToSchema)]

--- a/crates/api-ui/src/auth/error.rs
+++ b/crates/api-ui/src/auth/error.rs
@@ -95,12 +95,6 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
-
-    #[snafu(display("Execution error: {error}"))]
-    Execution {
-        #[snafu(source)]
-        error: core_executor::Error,
-    },
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, ToSchema)]

--- a/crates/api-ui/src/auth/handlers.rs
+++ b/crates/api-ui/src/auth/handlers.rs
@@ -6,7 +6,6 @@ use crate::auth::models::{AuthResponse, Claims, LoginPayload};
 use crate::error::Result;
 use crate::state::AppState;
 
-use api_sessions::DFSessionId;
 use api_sessions::session::SESSION_ID_COOKIE_NAME;
 use axum::Json;
 use axum::extract::State;
@@ -174,7 +173,6 @@ pub struct ApiDoc;
 )]
 #[tracing::instrument(name = "api_ui::login", level = "info", skip_all, err)]
 pub async fn login(
-    DFSessionId(session_id): DFSessionId,
     State(state): State<AppState>,
     Json(LoginPayload { username, password }): Json<LoginPayload>,
 ) -> Result<impl IntoResponse> {
@@ -198,7 +196,6 @@ pub async fn login(
 
     let mut headers = HeaderMap::new();
     set_cookies(&mut headers, REFRESH_COOKIE_NAME, &refresh_token)?;
-    set_cookies(&mut headers, SESSION_ID_COOKIE_NAME, &session_id)?;
 
     Ok((
         headers,
@@ -227,7 +224,6 @@ pub async fn login(
 )]
 #[tracing::instrument(name = "api_ui::refresh_access_token", level = "info", skip_all, err)]
 pub async fn refresh_access_token(
-    DFSessionId(session_id): DFSessionId,
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
@@ -248,7 +244,6 @@ pub async fn refresh_access_token(
 
             let mut headers = HeaderMap::new();
             set_cookies(&mut headers, REFRESH_COOKIE_NAME, refresh_token)?;
-            set_cookies(&mut headers, SESSION_ID_COOKIE_NAME, &session_id)?;
 
             Ok((
                 headers,

--- a/crates/api-ui/src/auth/layer.rs
+++ b/crates/api-ui/src/auth/layer.rs
@@ -1,18 +1,13 @@
 use super::error::{self as auth_error, BadAuthTokenSnafu, Result};
 use super::handlers::get_claims_validate_jwt_token;
 use crate::state::AppState;
-use api_sessions::DFSessionId;
-use api_sessions::session::{SESSION_ID_COOKIE_NAME, extract_token};
 use axum::{
     extract::{Request, State},
     middleware::Next,
     response::IntoResponse,
 };
-use http::header::SET_COOKIE;
-use http::{HeaderMap, HeaderName};
+use http::HeaderMap;
 use snafu::ResultExt;
-use tower_sessions::cookie::{Cookie, SameSite};
-use uuid;
 
 fn get_authorization_token(headers: &HeaderMap) -> Result<&str> {
     let auth = headers.get(http::header::AUTHORIZATION);
@@ -32,32 +27,9 @@ fn get_authorization_token(headers: &HeaderMap) -> Result<&str> {
     }
 }
 
-fn set_headers_in_flight(
-    headers: &mut HeaderMap,
-    header_name: HeaderName,
-    name: &str,
-    token: &str,
-) -> Result<()> {
-    headers
-        .try_insert(
-            header_name,
-            Cookie::build((name, token))
-                .http_only(true)
-                .secure(true)
-                .same_site(SameSite::Strict)
-                .path("/")
-                .to_string()
-                .parse()
-                .context(auth_error::ResponseHeaderSnafu)?,
-        )
-        .context(auth_error::SetCookieSnafu)?;
-
-    Ok(())
-}
-
 pub async fn require_auth(
     State(state): State<AppState>,
-    mut req: Request,
+    req: Request,
     next: Next,
 ) -> Result<impl IntoResponse> {
     // no demo user -> no auth required
@@ -75,28 +47,5 @@ pub async fn require_auth(
     let _ = get_claims_validate_jwt_token(access_token, &audience, jwt_secret)
         .context(BadAuthTokenSnafu)?;
 
-    if let Some(token) = extract_token(req.headers()) {
-        let sessions = state.execution_svc.get_sessions().await; // `get_sessions` returns an RwLock
-
-        // Step 2: Acquire the read lock on the session data
-        let sessions = sessions.read().await;
-
-        // Step 3: Check if the token is in the session data
-        if !sessions.contains_key(&token) {
-            drop(sessions);
-            //If no session_id, get a new one to the extractor,
-            // in a way that we can provide it to the response header for the browser also
-            let session_id = uuid::Uuid::new_v4().to_string();
-            req.extensions_mut().insert(DFSessionId(session_id.clone()));
-            let mut res = next.run(req).await;
-            set_headers_in_flight(
-                res.headers_mut(),
-                SET_COOKIE,
-                SESSION_ID_COOKIE_NAME,
-                session_id.as_str(),
-            )?;
-            return Ok(res);
-        }
-    }
     Ok(next.run(req).await)
 }

--- a/crates/api-ui/src/state.rs
+++ b/crates/api-ui/src/state.rs
@@ -1,12 +1,12 @@
+use crate::config::AuthConfig;
+use crate::config::WebConfig;
+use core_executor::ExecutionAppState;
+use core_executor::service::ExecutionService;
+use core_history::history_store::HistoryStore;
 use core_metastore::Metastore;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-
-use crate::config::AuthConfig;
-use crate::config::WebConfig;
-use core_executor::service::ExecutionService;
-use core_history::history_store::HistoryStore;
 
 // Define a State struct that contains shared services or repositories
 #[derive(Clone)]
@@ -37,5 +37,11 @@ impl AppState {
             config,
             auth_config,
         }
+    }
+}
+
+impl ExecutionAppState for AppState {
+    fn get_execution_svc(&self) -> Arc<dyn ExecutionService> {
+        self.execution_svc.clone()
     }
 }

--- a/crates/api-ui/src/tests/auth.rs
+++ b/crates/api-ui/src/tests/auth.rs
@@ -237,15 +237,17 @@ async fn test_query_request_ok() {
         .get("refresh_token")
         .expect("No Set-Cookie found with refresh_token");
 
+    // Successfuly run query
+    let (query_resp_headers, query_response) =
+        query::<QueryCreateResponse>(&client, &addr, &login_response.access_token, "SELECT 1")
+            .await
+            .expect("Failed to run query");
+
+    let set_cookies = get_set_cookie_from_response_headers(&query_resp_headers);
     let _ = set_cookies
         .get("session_id")
         .expect("No Set-Cookie found with session_id");
 
-    // Successfuly run query
-    let (_, query_response) =
-        query::<QueryCreateResponse>(&client, &addr, &login_response.access_token, "SELECT 1")
-            .await
-            .expect("Failed to run query");
     assert_eq!(query_response.0.query, "SELECT 1");
 }
 

--- a/crates/core-executor/src/lib.rs
+++ b/crates/core-executor/src/lib.rs
@@ -1,4 +1,5 @@
 pub use df_catalog as catalog;
+use std::sync::Arc;
 pub mod datafusion;
 pub mod dedicated_executor;
 pub mod error;
@@ -12,5 +13,10 @@ pub mod utils;
 #[cfg(test)]
 pub mod tests;
 
+use crate::service::ExecutionService;
 pub use error::{Error, Result};
 pub use snowflake_error::SnowflakeError;
+
+pub trait ExecutionAppState {
+    fn get_execution_svc(&self) -> Arc<dyn ExecutionService>;
+}


### PR DESCRIPTION
Closes #1290 

- Removed Extractor from `login` in `snowflake-rest` and `api-ui` auths to not call the session generation before log in.
- Also removed Extractor from `refresh_token` in `api-ui`.
- Removed `tower_session` layer since it was used just as a gimmick to get to execution service through a trait. 
- Instead, added an `ExecutionAppState` trait for getting `execution_svc` from any AppState that has it.
- As suggested by @YaroslavLitvinov removed session management from `api-ui` auth flow entirely. This resulted in a somewhat big rewrite (refactor). 
- However, this now means that session flow is completely self-contained, including, but not limited to: session generation, session cookie management, session extraction, etc.