### PR TITLE
Shared catalog list

### DIFF
--- a/crates/api-sessions/src/session.rs
+++ b/crates/api-sessions/src/session.rs
@@ -156,7 +156,7 @@ mod tests {
     use crate::session::SessionStore;
     use core_executor::models::QueryContext;
     use core_executor::service::ExecutionService;
-    use core_executor::service::make_text_execution_svc;
+    use core_executor::service::make_test_execution_svc;
     use std::time::Duration;
     use time::OffsetDateTime;
     use tokio::time::sleep;
@@ -164,7 +164,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::expect_used, clippy::too_many_lines)]
     async fn test_expiration() {
-        let execution_svc = make_text_execution_svc().await;
+        let execution_svc = make_test_execution_svc().await;
 
         let df_session_id = "fasfsafsfasafsass".to_string();
         let user_session = execution_svc

--- a/crates/api-ui/src/test_server.rs
+++ b/crates/api-ui/src/test_server.rs
@@ -40,6 +40,7 @@ pub async fn run_test_server_with_demo_auth(
         },
         auth_config,
     )
+    .await
     .unwrap()
     .into_make_service_with_connect_info::<SocketAddr>();
 
@@ -55,18 +56,22 @@ pub async fn run_test_server() -> SocketAddr {
     run_test_server_with_demo_auth(String::new(), String::new(), String::new()).await
 }
 
-#[allow(clippy::needless_pass_by_value)]
-pub fn make_app(
+#[allow(clippy::needless_pass_by_value, clippy::expect_used)]
+pub async fn make_app(
     metastore: Arc<SlateDBMetastore>,
     history_store: Arc<SlateDBHistoryStore>,
     config: &WebConfig,
     auth_config: AuthConfig,
 ) -> Result<Router, Box<dyn std::error::Error>> {
-    let execution_svc = Arc::new(CoreExecutionService::new(
-        metastore.clone(),
-        history_store.clone(),
-        Arc::new(Config::default()),
-    ));
+    let execution_svc = Arc::new(
+        CoreExecutionService::new(
+            metastore.clone(),
+            history_store.clone(),
+            Arc::new(Config::default()),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
 
     // Create the application state
     let app_state = state::AppState::new(

--- a/crates/core-executor/src/tests/e2e_common.rs
+++ b/crates/core-executor/src/tests/e2e_common.rs
@@ -244,7 +244,9 @@ pub async fn create_executor(
         metastore.clone(),
         history_store.clone(),
         Arc::new(Config::default()),
-    );
+    )
+    .await
+    .expect("Failed to create execution service");
 
     // Create all kind of volumes to just use them in queries
 

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -2,6 +2,7 @@ use crate::session::UserSession;
 use std::collections::HashMap;
 
 use crate::models::QueryContext;
+use crate::service::CoreExecutionService;
 use crate::utils::Config;
 #[cfg(test)]
 use core_history::MockHistoryStore;
@@ -131,11 +132,17 @@ pub async fn create_df_session() -> Arc<UserSession> {
         )
         .await
         .expect("Failed to create schema");
-
+    let catalog_list = CoreExecutionService::catalog_list(metastore.clone(), history_store.clone())
+        .await
+        .expect("Failed to create catalog list");
     let user_session = Arc::new(
-        UserSession::new(metastore, history_store, Arc::new(Config::default()))
-            .await
-            .expect("Failed to create user session"),
+        UserSession::new(
+            metastore,
+            history_store,
+            Arc::new(Config::default()),
+            catalog_list,
+        )
+        .expect("Failed to create user session"),
     );
 
     for query in TABLE_SETUP.split(';') {

--- a/crates/core-executor/src/tests/service.rs
+++ b/crates/core-executor/src/tests/service.rs
@@ -288,14 +288,6 @@ async fn test_query_recording() {
     let db = Db::memory().await;
     let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
     let history_store = Arc::new(SlateDBHistoryStore::new(db));
-    let execution_svc = CoreExecutionService::new(
-        metastore.clone(),
-        history_store.clone(),
-        Arc::new(Config::default()),
-    )
-    .await
-    .expect("Failed to create execution service");
-
     metastore
         .create_volume(
             &"test_volume".to_string(),
@@ -320,6 +312,14 @@ async fn test_query_recording() {
         )
         .await
         .expect("Failed to create database");
+
+    let execution_svc = CoreExecutionService::new(
+        metastore.clone(),
+        history_store.clone(),
+        Arc::new(Config::default()),
+    )
+    .await
+    .expect("Failed to create execution service");
 
     let session_id = "test_session_id";
     execution_svc

--- a/crates/core-executor/src/tests/service.rs
+++ b/crates/core-executor/src/tests/service.rs
@@ -24,7 +24,9 @@ async fn test_execute_always_returns_schema() {
         metastore.clone(),
         history_store.clone(),
         Arc::new(Config::default()),
-    );
+    )
+    .await
+    .expect("Failed to create execution service");
 
     execution_svc
         .create_session("test_session_id".to_string())
@@ -102,7 +104,9 @@ async fn test_service_upload_file() {
         metastore.clone(),
         history_store.clone(),
         Arc::new(Config::default()),
-    );
+    )
+    .await
+    .expect("Failed to create execution service");
 
     let session_id = "test_session_id";
     execution_svc
@@ -229,7 +233,9 @@ async fn test_service_create_table_file_volume() {
         metastore.clone(),
         history_store.clone(),
         Arc::new(Config::default()),
-    );
+    )
+    .await
+    .expect("Failed to create execution service");
 
     let session_id = "test_session_id";
     execution_svc
@@ -286,7 +292,9 @@ async fn test_query_recording() {
         metastore.clone(),
         history_store.clone(),
         Arc::new(Config::default()),
-    );
+    )
+    .await
+    .expect("Failed to create execution service");
 
     metastore
         .create_volume(

--- a/crates/df-catalog/src/catalog_list.rs
+++ b/crates/df-catalog/src/catalog_list.rs
@@ -87,14 +87,11 @@ impl EmbucketCatalogList {
             .fail();
         };
         match catalog.catalog_type {
-            CatalogType::Embucket => {
-                self.metastore
-                    .delete_database(&name.to_string(), cascade)
-                    .await
-                    .context(MetastoreSnafu)?;
-                Ok(())
-            }
-            CatalogType::Memory => Ok(()),
+            CatalogType::Embucket | CatalogType::Memory => self
+                .metastore
+                .delete_database(&name.to_string(), cascade)
+                .await
+                .context(MetastoreSnafu),
             CatalogType::S3tables => NotImplementedSnafu {
                 feature: UnsupportedFeature::DropS3TablesDatabase,
                 details: "Dropping S3 tables catalogs is not supported",

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -141,11 +141,15 @@ async fn main() {
 
     let history_store = Arc::new(SlateDBHistoryStore::new(db.clone()));
 
-    let execution_svc = Arc::new(CoreExecutionService::new(
-        metastore.clone(),
-        history_store.clone(),
-        Arc::new(execution_cfg),
-    ));
+    let execution_svc = Arc::new(
+        CoreExecutionService::new(
+            metastore.clone(),
+            history_store.clone(),
+            Arc::new(execution_cfg),
+        )
+        .await
+        .expect("Failed to create execution service"),
+    );
 
     let session_store = SessionStore::new(execution_svc.clone());
 


### PR DESCRIPTION
Closes #699
💥 Impact
- Reduces session initialization time.
- Speeds up first query execution, especially in systems with large external catalogs.
- Prevents redundant metadata fetching, improving scalability.
- All catalog data changes within one session are immediately visible in other sessions.