### PR TITLE
Use sql to create database

### DIFF
--- a/crates/api-ui/src/dashboard/handlers.rs
+++ b/crates/api-ui/src/dashboard/handlers.rs
@@ -50,7 +50,6 @@ pub async fn get_dashboard(State(state): State<AppState>) -> Result<Json<Dashboa
         .await
         .context(UtilSlateDBSnafu)
         .context(MetastoreSnafu)?;
-
     let total_databases = rw_databases.len();
     let mut total_schemas = 0;
     let mut total_tables = 0;

--- a/crates/api-ui/src/databases/handlers.rs
+++ b/crates/api-ui/src/databases/handlers.rs
@@ -76,6 +76,7 @@ pub struct QueryParameters {
 )]
 #[tracing::instrument(name = "api_ui::create_database", level = "info", skip(state, database), err, ret(level = tracing::Level::TRACE))]
 pub async fn create_database(
+    DFSessionId(session_id): DFSessionId,
     State(state): State<AppState>,
     Json(database): Json<DatabaseCreatePayload>,
 ) -> Result<Json<DatabaseCreateResponse>> {
@@ -88,6 +89,19 @@ pub async fn create_database(
         .validate()
         .context(ValidationSnafu)
         .context(CreateSnafu)?;
+    state
+        .execution_svc
+        .query(
+            &session_id,
+            &format!(
+                "CREATE DATABASE {} EXTERNAL_VOLUME = '{}'",
+                database.ident, database.volume
+            ),
+            QueryContext::default(),
+        )
+        .await
+        .context(crate::schemas::error::CreateSnafu)?;
+
     let database = state
         .metastore
         .create_database(&database.ident.clone(), database)

--- a/crates/api-ui/src/tests/dashboard.rs
+++ b/crates/api-ui/src/tests/dashboard.rs
@@ -71,7 +71,7 @@ async fn test_ui_dashboard() {
     assert_eq!(4, dashboard.total_databases);
     assert_eq!(0, dashboard.total_schemas);
     assert_eq!(0, dashboard.total_tables);
-    assert_eq!(0, dashboard.total_queries);
+    assert_eq!(4, dashboard.total_queries);
 
     let schema_name = "testing1".to_string();
     let payload = SchemaCreatePayload {
@@ -100,8 +100,8 @@ async fn test_ui_dashboard() {
     assert_eq!(4, dashboard.total_databases);
     assert_eq!(1, dashboard.total_schemas);
     assert_eq!(0, dashboard.total_tables);
-    //Since schemas are created with sql
-    assert_eq!(1, dashboard.total_queries);
+    //Since databases and schemas are created with sql
+    assert_eq!(5, dashboard.total_queries);
 
     let res = req(
         &client,
@@ -160,6 +160,6 @@ async fn test_ui_dashboard() {
     assert_eq!(4, dashboard.total_databases);
     assert_eq!(1, dashboard.total_schemas);
     assert_eq!(1, dashboard.total_tables);
-    //Since schemas are created with sql
-    assert_eq!(2, dashboard.total_queries);
+    //Since databases and schemas are created with sql
+    assert_eq!(6, dashboard.total_queries);
 }


### PR DESCRIPTION
For now we create databases for file, s3, memory volume types.
Memory is also created as metastore database.


Next step is to remove call to metastore to get created database back. We need to get all data from sql query (maybe from information schema)
Related to #1372 (not closes)