### PR TITLE
disable dbt gitlab workflow

### DIFF
--- a/.github/workflows/dbt-gitlab-run.yml
+++ b/.github/workflows/dbt-gitlab-run.yml
@@ -3,10 +3,10 @@ name: DBT Gitlab run
 permissions:
   contents: write
   
-on:
-  schedule:
-    # Runs every day at 2 AM UTC
-    - cron: '0 2 * * *'
+on: []
+  # schedule:
+  #   # Runs every day at 2 AM UTC
+  #   - cron: '0 2 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Disable dbt gitlab workflow since dbt run is broken and workflow job is getting stuck for 6 hours.

The issue is described here:
https://github.com/Embucket/embucket/issues/1365