### PR TITLE
Fix casting values to target table schema in MERGE INTO with VALUES clause

### DIFF
--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -746,6 +746,16 @@ test_query!(
     ]
 );
 
+test_query!(
+    merge_into_with_values,
+    "SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target",
+    setup_queries = [
+        "CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR)",
+        "INSERT INTO embucket.public.merge_target VALUES (1, 'existing row'), (2, 'existing row')",
+        "MERGE INTO merge_target USING (SELECT * FROM (VALUES (2, 'updated row'), (3, 'new row')) AS source(id, description)) AS source ON merge_target.id = source.id WHEN MATCHED THEN UPDATE SET description = source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (source.id, source.description)",
+    ]
+);
+
 // TRUNCATE TABLE
 test_query!(truncate_table, "TRUNCATE TABLE employee_table");
 test_query!(

--- a/crates/core-executor/src/tests/snapshots/query_merge_into_with_values.snap
+++ b/crates/core-executor/src/tests/snapshots/query_merge_into_with_values.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target\""
+info: "Setup queries: CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR); INSERT INTO embucket.public.merge_target VALUES (1, 'existing row'), (2, 'existing row'); MERGE INTO merge_target USING (SELECT * FROM (VALUES (2, 'updated row'), (3, 'new row')) AS source(id, description)) AS source ON merge_target.id = source.id WHEN MATCHED THEN UPDATE SET description = source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (source.id, source.description)"
+---
+Ok(
+    [
+        "+---------+----------+",
+        "| updated | existing |",
+        "+---------+----------+",
+        "| 1       | 1        |",
+        "+---------+----------+",
+    ],
+)


### PR DESCRIPTION
## Summary

This PR fixes type mismatches in MERGE INTO statements with VALUES clauses by automatically casting values to match the target table schema.

## Changes

- Added `cast_if_necessary` function in `crates/core-executor/src/query.rs` that automatically casts expressions to target data types when they don't match
- Modified `collect_merge_clause_expressions` to use the new casting function for both UPDATE and INSERT operations
- Added comprehensive test case `merge_into_with_values` to verify the fix works correctly

## Problem Solved

Previously, when running MERGE INTO statements with VALUES clauses, type mismatches between the VALUES data and target table columns could cause operations to fail. This fix ensures that values are automatically cast to match the target table schema, similar to how other SQL databases handle this scenario.

## Test Case

The fix is validated by a new test that:
1. Creates a target table with INTEGER and VARCHAR columns
2. Executes a MERGE statement using VALUES clause with literal values
3. Verifies that the MERGE operation completes successfully with proper type casting

Closes #1400

🤖 Generated with [Claude Code](https://claude.ai/code)