### PR TITLE
Fix AssertCreate table requirement for Spark writeTo method

### DIFF
--- a/crates/core-metastore/src/metastore.rs
+++ b/crates/core-metastore/src/metastore.rs
@@ -666,7 +666,7 @@ impl Metastore for SlateDBMetastore {
             .requirements
             .into_iter()
             .map(TableRequirementExt::new)
-            .try_for_each(|req| req.assert(&table.metadata, true))?;
+            .try_for_each(|req| req.assert(&table.metadata))?;
 
         apply_table_updates(&mut table.metadata, update.updates)
             .context(metastore_error::IcebergSnafu)?;

--- a/crates/core-metastore/src/models/table.rs
+++ b/crates/core-metastore/src/models/table.rs
@@ -207,10 +207,10 @@ impl TableRequirementExt {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn assert(&self, metadata: &TableMetadata, exists: bool) -> Result<()> {
+    pub fn assert(&self, metadata: &TableMetadata) -> Result<()> {
         match self.inner() {
             TableRequirement::AssertCreate => {
-                if exists {
+                if !metadata.snapshots.is_empty() {
                     return Err(metastore_error::TableDataExistsSnafu {
                         path: metadata.location.to_string(),
                     }


### PR DESCRIPTION
## Summary
- Fixed table creation failure when using Spark's `writeTo().createOrReplace()` method
- Changed `AssertCreate` requirement validation to check if snapshots are empty instead of assuming table exists
- Removed hardcoded `exists=true` parameter from table requirement assertion

## Problem
When creating an Iceberg table with Spark using `df.writeTo(table_name).createOrReplace()`, Spark would fail with `AlreadyExistsException: Table data already exists at that location`. This happened because Embucket incorrectly assumed tables always exist when validating the `AssertCreate` requirement during `CommitTable` operations.

## Solution
- Modified `TableRequirementExt::assert()` to remove the hardcoded `exists` parameter
- Changed `AssertCreate` validation logic to check `metadata.snapshots.is_empty()` instead of relying on the `exists` flag
- This allows proper CREATE TABLE transactions with Spark while maintaining data integrity

Fixes #1402

🤖 Generated with [Claude Code](https://claude.ai/code)