### PR TITLE
Fix ambiguous field error for MERGE INTO statement

### DIFF
--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -723,6 +723,18 @@ test_query!(
 );
 
 test_query!(
+    merge_into_ambigious_insert,
+    "SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target",
+    setup_queries = [
+        "CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR)",
+        "CREATE TABLE embucket.public.merge_source (ID INTEGER, description VARCHAR)",
+        "INSERT INTO embucket.public.merge_target VALUES (1, 'existing row'), (2, 'existing row')",
+        "INSERT INTO embucket.public.merge_source VALUES (2, 'updated row'), (3, 'new row')",
+        "MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET description = merge_source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (id, merge_source.description)",
+    ]
+);
+
+test_query!(
     merge_into_insert_and_update_alias,
     "SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target",
     setup_queries = [

--- a/crates/core-executor/src/tests/snapshots/query_merge_into_ambigious_insert.snap
+++ b/crates/core-executor/src/tests/snapshots/query_merge_into_ambigious_insert.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target\""
+info: "Setup queries: CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR); CREATE TABLE embucket.public.merge_source (ID INTEGER, description VARCHAR); INSERT INTO embucket.public.merge_target VALUES (1, 'existing row'), (2, 'existing row'); INSERT INTO embucket.public.merge_source VALUES (2, 'updated row'), (3, 'new row'); MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET description = merge_source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (id, merge_source.description)"
+---
+Ok(
+    [
+        "+---------+----------+",
+        "| updated | existing |",
+        "+---------+----------+",
+        "| 1       | 1        |",
+        "+---------+----------+",
+    ],
+)


### PR DESCRIPTION
## Summary

Fixes #1404 - resolves ambiguous field reference error in MERGE INTO statements when column names exist in both source and target tables.

### Changes Made

- Modified `merge_clause_projection` function to accept `source_schema` parameter in `crates/core-executor/src/query.rs:2277`
- Updated INSERT clause to use `source_schema` instead of combined `schema` when resolving column references in `crates/core-executor/src/query.rs:2351`
- Added comprehensive test case `merge_into_ambigious_insert` to verify the fix works correctly

### Root Cause

The issue occurred because when processing MERGE INTO INSERT clauses, column references like `session_identifier` were being resolved against the combined schema (which includes both target and source tables), causing ambiguity when the same column name exists in both tables. The fix ensures INSERT values are resolved against the source schema only, eliminating the ambiguity.

## Test Plan

- [x] Added test case that reproduces the original error scenario
- [x] Verified test passes with the fix applied
- [x] Existing MERGE INTO tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)