### PR TITLE
update iceberg-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,7 +1936,7 @@ dependencies = [
  "iceberg-s3tables-catalog",
  "indexmap 2.10.0",
  "insta",
- "lru",
+ "lru 0.15.0",
  "object_store",
  "paste",
  "pin-project-lite",
@@ -2821,7 +2821,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=6a88004237046d4652230eda1e881301dd443432#6a88004237046d4652230eda1e881301dd443432"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bebcc716de1eea9c2e8473b24360d97fda02ef4e#bebcc716de1eea9c2e8473b24360d97fda02ef4e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=6a88004237046d4652230eda1e881301dd443432#6a88004237046d4652230eda1e881301dd443432"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bebcc716de1eea9c2e8473b24360d97fda02ef4e#bebcc716de1eea9c2e8473b24360d97fda02ef4e"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4283,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=6a88004237046d4652230eda1e881301dd443432#6a88004237046d4652230eda1e881301dd443432"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bebcc716de1eea9c2e8473b24360d97fda02ef4e#bebcc716de1eea9c2e8473b24360d97fda02ef4e"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -4296,8 +4296,8 @@ dependencies = [
  "getrandom 0.3.3",
  "iceberg-rust-spec",
  "itertools 0.14.0",
+ "lru 0.16.0",
  "object_store",
- "once_map",
  "parquet 55.2.0",
  "pin-project-lite",
  "serde",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=6a88004237046d4652230eda1e881301dd443432#6a88004237046d4652230eda1e881301dd443432"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bebcc716de1eea9c2e8473b24360d97fda02ef4e#bebcc716de1eea9c2e8473b24360d97fda02ef4e"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.2.0",
@@ -4341,7 +4341,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=6a88004237046d4652230eda1e881301dd443432#6a88004237046d4652230eda1e881301dd443432"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=bebcc716de1eea9c2e8473b24360d97fda02ef4e#bebcc716de1eea9c2e8473b24360d97fda02ef4e"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4938,6 +4938,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
+dependencies = [
+ "hashbrown 0.15.4",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5339,18 +5348,6 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "once_map"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd2cae3bec3936bbed1ccc5a3343b3738858182419f9c0522c7260c80c430b0"
-dependencies = [
- "ahash 0.8.12",
- "hashbrown 0.15.4",
- "parking_lot",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,15 +48,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "6a88004237046d4652230eda1e881301dd443432" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bebcc716de1eea9c2e8473b24360d97fda02ef4e" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "6a88004237046d4652230eda1e881301dd443432" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "6a88004237046d4652230eda1e881301dd443432" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "6a88004237046d4652230eda1e881301dd443432" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "6a88004237046d4652230eda1e881301dd443432" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bebcc716de1eea9c2e8473b24360d97fda02ef4e" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bebcc716de1eea9c2e8473b24360d97fda02ef4e" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bebcc716de1eea9c2e8473b24360d97fda02ef4e" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "bebcc716de1eea9c2e8473b24360d97fda02ef4e" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }


### PR DESCRIPTION
Update iceberg-rust to it's newest version. Improves partitioned write performance and fixes some issues with Spark compatability.