### PR TITLE
Feat/copy into external

### DIFF
--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -498,6 +498,13 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Field '{field_name}' not found in input schema"))]
+    FieldNotFoundInInputSchema {
+        field_name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 #[derive(Debug)]

--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -486,8 +486,15 @@ pub enum Error {
         location: Location,
     },
 
+
     #[snafu(display("Unexpected subquery result for set variable"))]
     UnexpectedSubqueryResultForSetVariable {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Stages are currently not supported"))]
+    StagesNotSupported {
         #[snafu(implicit)]
         location: Location,
     },

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -107,7 +107,7 @@ use sqlparser::ast::{
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
-use std::ops::{ControlFlow, Deref};
+use std::ops::ControlFlow;
 use std::result::Result as StdResult;
 use std::sync::Arc;
 use tracing_attributes::instrument;

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -1099,12 +1099,12 @@ impl UserQuery {
         self.status_response()
     }
 
-    // #[instrument(
-    //     name = "UserQuery::copy_into_snowflake_query",
-    //     level = "trace",
-    //     skip(self),
-    //     err
-    // )]
+    #[instrument(
+        name = "UserQuery::copy_into_snowflake_query",
+        level = "trace",
+        skip(self),
+        err
+    )]
     pub async fn copy_into_snowflake_query(&self, statement: Statement) -> Result<QueryResult> {
         let Statement::CopyIntoSnowflake {
             into,

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -2982,7 +2982,12 @@ pub fn cast_input_to_target_schema(
                 }
                 None
             })
-            .unwrap();
+            .ok_or_else(|| {
+                ex_error::FieldNotFoundInInputSchemaSnafu {
+                    field_name: name.to_string(),
+                }
+                .build()
+            })?;
         if input_field.data_type() == data_type {
             if input_field.name() == name {
                 projections.push(col(input_field.name()));

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -1124,7 +1124,7 @@ impl UserQuery {
         let insert_into = self.resolve_table_object_name(into.0)?;
 
         // Check if this copies from an external location
-        if let Some(location) = is_external_location(&from_obj) {
+        if let Some(location) = get_external_location(&from_obj) {
             let object_store = match (stage_params.storage_integration, stage_params.credentials) {
                 (Some(volume), _) => {
                     let volume = self
@@ -2999,7 +2999,7 @@ pub fn cast_input_to_target_schema(
 /// # Returns
 /// * `Some(&Ident)` - The identifier containing the external location if valid
 /// * `None` - If the object name doesn't represent a valid external location
-fn is_external_location(from_obj: &ObjectName) -> Option<&Ident> {
+fn get_external_location(from_obj: &ObjectName) -> Option<&Ident> {
     if let (Some(location), true, true, true) = (
         from_obj.0[0].as_ident(),
         from_obj.0.len() == 1,

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -2969,7 +2969,7 @@ pub fn cast_input_to_target_schema(
 /// - The identifier value starts with a supported scheme (s3://, gcs://, file://, or memory://)
 ///
 /// External locations allow loading files directly from cloud storage or file systems
-/// without requiring a stage. See: https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#loading-files-directly-from-an-external-location
+/// without requiring a stage. See: <https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#loading-files-directly-from-an-external-location>
 ///
 /// # Arguments
 /// * `from_obj` - The object name from the COPY INTO FROM clause

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -2995,10 +2995,7 @@ pub fn cast_input_to_target_schema(
         let (reference, input_field) = get_field(input_schema, name)?;
         if input_field.data_type() == data_type {
             if input_field.name() == name {
-                projections.push(logical_expr::Expr::Column(Column::new(
-                    reference.cloned(),
-                    input_field.name(),
-                )));
+                projections.push(col(name));
             } else {
                 projections.push(
                     logical_expr::Expr::Column(Column::new(reference.cloned(), input_field.name()))
@@ -3007,10 +3004,7 @@ pub fn cast_input_to_target_schema(
             }
         } else if input_field.name() == name {
             projections.push(DFExpr::TryCast(TryCast::new(
-                Box::new(logical_expr::Expr::Column(Column::new(
-                    reference.cloned(),
-                    input_field.name(),
-                ))),
+                Box::new(col(name)),
                 data_type.clone(),
             )));
         } else {

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -2956,18 +2956,18 @@ pub fn cast_input_to_target_schema(
 }
 
 /// Checks if the `ObjectName` indicates an external location for a Snowflake COPY INTO statement.
-/// 
+///
 /// This function validates that the object name represents a valid external location by checking:
 /// - The object name contains exactly one identifier
 /// - The identifier is single-quoted
 /// - The identifier value starts with a supported scheme (s3://, gcs://, file://, or memory://)
-/// 
+///
 /// External locations allow loading files directly from cloud storage or file systems
 /// without requiring a stage. See: https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#loading-files-directly-from-an-external-location
-/// 
+///
 /// # Arguments
 /// * `from_obj` - The object name from the COPY INTO FROM clause
-/// 
+///
 /// # Returns
 /// * `Some(&Ident)` - The identifier containing the external location if valid
 /// * `None` - If the object name doesn't represent a valid external location

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -1191,7 +1191,7 @@ impl UserQuery {
 
             let input = builder.build().context(ex_error::DataFusionSnafu)?;
 
-            let input = if input.schema().as_arrow() == into_provider.schema().deref() {
+            let input = if input.schema().as_arrow() == &*into_provider.schema() {
                 input
             } else {
                 cast_input_to_target_schema(Arc::new(input), &into_provider.schema())?
@@ -1209,17 +1209,7 @@ impl UserQuery {
 
             self.execute_logical_plan(plan).await
         } else {
-            let from_stage: Vec<ObjectNamePart> = from_obj
-                .0
-                .iter()
-                .map(|fs| ObjectNamePart::Identifier(Ident::new(fs.to_string().replace('@', ""))))
-                .collect();
-
-            let insert_from = self.resolve_table_object_name(from_stage)?;
-            // Insert data to table
-            let insert_query = format!("INSERT INTO {insert_into} SELECT * FROM {insert_from}");
-
-            self.execute_with_custom_plan(&insert_query).await
+            ex_error::StagesNotSupportedSnafu.fail()
         }
     }
 

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -37,7 +37,6 @@ use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
-use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::execution::session_state::{SessionContextProvider, SessionState};
 use datafusion::logical_expr::{self, col};
 use datafusion::logical_expr::{LogicalPlan, TableSource};
@@ -1142,14 +1141,12 @@ impl UserQuery {
                 }
             };
 
-            let url = ObjectStoreUrl::parse(&location.value).context(ex_error::DataFusionSnafu)?;
+            let url = ListingTableUrl::parse(&location.value).context(ex_error::DataFusionSnafu)?;
             self.session
                 .ctx
-                .register_object_store(url.as_ref(), object_store);
+                .register_object_store(url.object_store().as_ref(), object_store);
 
-            let table_url =
-                ListingTableUrl::parse(&location.value).context(ex_error::DataFusionSnafu)?;
-            let config = ListingTableConfig::new(table_url);
+            let config = ListingTableConfig::new(url);
             let config = if let Some(format) = create_file_format(&file_format)? {
                 config.with_listing_options(ListingOptions::new(format))
             } else {

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -3069,10 +3069,22 @@ fn create_file_format(
                 .is_some_and(|x| x.to_lowercase() == "true");
             let has_header =
                 get_kv_option(file_format, "skip_header").is_some_and(|x| x.to_lowercase() == "1");
-            Ok(Some((
-                Arc::new(CsvFormat::default().with_has_header(has_header)),
-                infer_schema,
-            )))
+
+            let csv_format = CsvFormat::default().with_has_header(has_header);
+
+            // Handle field_delimiter parameter
+            let csv_format = if let Some(delimiter) = get_kv_option(file_format, "field_delimiter")
+            {
+                if delimiter.len() == 1 {
+                    csv_format.with_delimiter(delimiter.as_bytes()[0])
+                } else {
+                    csv_format
+                }
+            } else {
+                csv_format
+            };
+
+            Ok(Some((Arc::new(csv_format), infer_schema)))
         } else if format_type.eq_ignore_ascii_case("json") {
             Ok(Some((Arc::new(JsonFormat::default()), true)))
         } else {

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -682,15 +682,6 @@ test_query!(
     ]
 );
 
-test_query!(
-    copy_into_external,
-    "SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target",
-    setup_queries = [
-        "CREATE TABLE embucket.public.copy_into_table (ID INTEGER, description VARCHAR)",
-        "COPY INTO embucket.public.copy_into_table FROM table STORAGE_INTEGRATION = test_volume FILE_FORMAT = (TYPE = CSV);",
-    ]
-);
-
 // TRUNCATE TABLE
 test_query!(truncate_table, "TRUNCATE TABLE employee_table");
 test_query!(

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -682,6 +682,15 @@ test_query!(
     ]
 );
 
+test_query!(
+    copy_into_external,
+    "SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target",
+    setup_queries = [
+        "CREATE TABLE embucket.public.copy_into_table (ID INTEGER, description VARCHAR)",
+        "COPY INTO embucket.public.copy_into_table FROM table STORAGE_INTEGRATION = test_volume FILE_FORMAT = (TYPE = CSV);",
+    ]
+);
+
 // TRUNCATE TABLE
 test_query!(truncate_table, "TRUNCATE TABLE employee_table");
 test_query!(


### PR DESCRIPTION
This is a proposal on how to implement the Snowflake COPY INTO statement for external locations. The main idea is to use the [STORAGE_INTEGRATION](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#additional-cloud-provider-parameters) parameter as a Reference for an Embucket Volume. [STORAGE_INTEGRATION](https://docs.snowflake.com/en/sql-reference/sql/create-storage-integration)s are very similar to Snowflake External Volumes and we could tell users that we automatically create STORAGE_INTEGRATIONS for all Embucket Volumes. Behind the scenes STORAGE_INTEGRATIONS and EXTERNAL VOLUMES both refer to Embucket Volumes.

```
COPY INTO mytable
  FROM 's3://mybucket/data/files'
  STORAGE_INTEGRATION = test_volume
  FILE_FORMAT = (TYPE = CSV);
```

Once we know which volume the statement refers to, we use that to load the `ObjectStore`, register the `ObjectStore` with the current context and create a Listing Table for the TableScan.

This is currently just a sketch of the solution and needs further testing. Let me know what you think.