### PR TITLE
Limit maximum number of concurrent queries

### DIFF
--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -141,10 +141,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(
-        display("DataFusion erro when building logical plan for join of merge target and source: {error}"
-        )
-    )]
+    #[snafu(display("DataFusion erro when building logical plan for join of merge target and source: {error}"))]
     DataFusionLogicalPlanMergeJoin {
         #[snafu(source(from(DataFusionError, Box::new)))]
         error: Box<DataFusionError>,

--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     #[snafu(display("Concurrency limit reached — too many concurrent queries are running"))]
     ConcurrencyLimitError {
         #[snafu(source)]
-        error: tokio::sync::AcquireError,
+        error: tokio::sync::TryAcquireError,
         #[snafu(implicit)]
         location: Location,
     },

--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -14,6 +14,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[snafu(visibility(pub))]
 #[error_stack_trace::debug]
 pub enum Error {
+    #[snafu(display("Concurrency limit reached — too many concurrent queries are running"))]
+    ConcurrencyLimitError {
+        #[snafu(source)]
+        error: tokio::sync::AcquireError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Cannot register UDF functions"))]
     RegisterUDF {
         #[snafu(source(from(DataFusionError, Box::new)))]
@@ -133,7 +141,10 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("DataFusion erro when building logical plan for join of merge target and source: {error}"))]
+    #[snafu(
+        display("DataFusion erro when building logical plan for join of merge target and source: {error}"
+        )
+    )]
     DataFusionLogicalPlanMergeJoin {
         #[snafu(source(from(DataFusionError, Box::new)))]
         error: Box<DataFusionError>,

--- a/crates/core-executor/src/service.rs
+++ b/crates/core-executor/src/service.rs
@@ -72,6 +72,7 @@ impl CoreExecutionService {
         config: Arc<Config>,
     ) -> Result<Self> {
         let catalog_list = Self::catalog_list(metastore.clone(), history_store.clone()).await?;
+        let max_concurrency_level = config.max_concurrency_level;
         let runtime_env = Self::runtime_env(&config, catalog_list.clone())?;
         Ok(Self {
             metastore,
@@ -80,7 +81,7 @@ impl CoreExecutionService {
             config,
             catalog_list,
             runtime_env,
-            concurrency_limit: Arc::new(Semaphore::new(2)),
+            concurrency_limit: Arc::new(Semaphore::new(max_concurrency_level)),
         })
     }
 

--- a/crates/core-executor/src/tests/mod.rs
+++ b/crates/core-executor/src/tests/mod.rs
@@ -3,3 +3,57 @@ pub mod query;
 pub mod service;
 pub mod snowflake_errors;
 pub mod sql;
+
+use datafusion::arrow::array::Int64Array;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::logical_expr::{ColumnarValue, ScalarUDF, Volatility};
+use datafusion_common::ScalarValue;
+use datafusion_expr::{ScalarFunctionImplementation, create_udf};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+/// Returns a custom scalar UDF named `sleep`, which simulates a delay by blocking the current thread.
+///
+/// # Purpose
+/// This UDF is intended primarily for testing purposes, to simulate long-running queries or
+/// evaluate the behavior of concurrency limits and timeout mechanisms within the query execution engine.
+///
+/// # SQL Usage
+/// ```sql
+/// SELECT sleep(5);
+/// ```
+///
+/// This will block the executing thread for 5 seconds before returning the value `5`.
+///
+/// # Notes
+/// - This UDF performs blocking (`thread::sleep`), and should **not** be used in production settings,
+///   as it will block the execution thread and may reduce system throughput.
+/// - The function is marked as `Volatile`, indicating that it has side effects (i.e., sleeping)
+///   and cannot be optimized away by the query planner.
+#[allow(clippy::unwrap_used)]
+fn sleep_udf() -> ScalarUDF {
+    let sleep_fn: ScalarFunctionImplementation = Arc::new(move |args: &[ColumnarValue]| {
+        let seconds = match &args[0] {
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(secs))) => *secs,
+            ColumnarValue::Array(array) => {
+                let array = array
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("Expected Int64Array");
+                array.value(0)
+            }
+            _ => 0,
+        };
+        thread::sleep(Duration::from_secs(seconds.try_into().unwrap()));
+        let result = Int64Array::from(vec![seconds]);
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    });
+    create_udf(
+        "sleep",
+        vec![DataType::Int64],
+        DataType::Int64,
+        Volatility::Volatile,
+        sleep_fn,
+    )
+}

--- a/crates/core-executor/src/utils.rs
+++ b/crates/core-executor/src/utils.rs
@@ -56,6 +56,14 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    #[must_use]
+    pub const fn with_max_concurrency_level(mut self, level: usize) -> Self {
+        self.max_concurrency_level = level;
+        self
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, EnumString, Display, Default)]
 #[strum(ascii_case_insensitive)]
 pub enum DataSerializationFormat {

--- a/crates/core-executor/src/utils.rs
+++ b/crates/core-executor/src/utils.rs
@@ -35,6 +35,7 @@ use strum::{Display, EnumString};
 pub struct Config {
     pub embucket_version: String,
     pub sql_parser_dialect: Option<String>,
+    pub max_concurrency_level: usize,
     pub mem_pool_type: MemPoolType,
     pub mem_pool_size_mb: Option<usize>,
     pub mem_enable_track_consumers_pool: Option<bool>,
@@ -46,6 +47,7 @@ impl Default for Config {
         Self {
             embucket_version: "0.1.0".to_string(),
             sql_parser_dialect: None,
+            max_concurrency_level: 100,
             mem_pool_type: MemPoolType::default(),
             mem_pool_size_mb: None,
             mem_enable_track_consumers_pool: None,

--- a/crates/embucketd/src/cli.rs
+++ b/crates/embucketd/src/cli.rs
@@ -158,7 +158,7 @@ pub struct CliOpts {
     #[arg(
         long,
         env = "MAX_CONCURRENCY_LEVEL",
-        default_value = "100",
+        default_value = "8",
         help = "Maximum number of running queries at the same time"
     )]
     pub max_concurrency_level: usize,

--- a/crates/embucketd/src/cli.rs
+++ b/crates/embucketd/src/cli.rs
@@ -157,6 +157,14 @@ pub struct CliOpts {
 
     #[arg(
         long,
+        env = "MAX_CONCURRENCY_LEVEL",
+        default_value = "100",
+        help = "Maximum number of running queries at the same time"
+    )]
+    pub max_concurrency_level: usize,
+
+    #[arg(
+        long,
         value_enum,
         env = "MEM_POOL_TYPE",
         default_value = "greedy",

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -106,6 +106,7 @@ async fn main() {
     let execution_cfg = ExecutionConfig {
         embucket_version: "0.1.0".to_string(),
         sql_parser_dialect: opts.sql_parser_dialect.clone(),
+        max_concurrency_level: opts.max_concurrency_level,
         mem_pool_type: opts.mem_pool_type,
         mem_pool_size_mb: opts.mem_pool_size_mb,
         mem_enable_track_consumers_pool: opts.mem_enable_track_consumers_pool,


### PR DESCRIPTION
Closes #1137 
This pull request introduces a concurrency limit mechanism to restrict the number of queries that can be executed simultaneously. The goal is to prevent system overload by limiting parallel query execution and protecting shared resources such as CPU, memory, or I/O.

### ✅ Summary of Changes
- Added a new CLI/config argument
  - This controls the maximum number of queries that can be processed simultaneously. Default: 100.
- Integrated semaphore (tokio::sync::Semaphore) logic into the query execution path

### 📌 Motivation
This addition ensures that the system is protected from overload caused by too many concurrent queries running at once. Rather than relying on downstream timeouts or resource exhaustion, we fail fast with a clear error when the concurrency limit is exceeded.
This is particularly useful for:
- Deployments under constrained environments (e.g., local development, CI, or small cloud instances).
- Preventing resource saturation due to accidental or malicious query floods.

### 🔄 Behavior
- If the number of concurrent queries is below the configured limit, the query is allowed to run.
- If the limit is reached:
  - The query fails immediately with a ConcurrencyLimitExceeded error (via try_acquire()).
  - **If blocking behavior is preferred, this can be replaced with .acquire().await.**

### 🧪 Testing
This logic was tested by submitting multiple concurrent long-running queries (e.g., SELECT sleep(5)). The semaphore behaves correctly by allowing only the configured number of simultaneous executions. Additional queries fail fast when the limit is exceeded.

