### PR TITLE
Allow subquries for set variable

### DIFF
--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -477,6 +477,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Unexpected subquery result for set variable"))]
+    UnexpectedSubqueryResultForSetVariable {
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 #[derive(Debug)]

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -91,8 +91,9 @@ use snafu::ResultExt;
 use sqlparser::ast::helpers::key_value_options::KeyValueOptions;
 use sqlparser::ast::{
     AssignmentTarget, CloudProviderParams, MergeAction, MergeClause, MergeClauseKind,
-    MergeInsertKind, ObjectNamePart, ObjectType, PivotValueSource, ShowObjects,
-    ShowStatementFilter, ShowStatementIn, TruncateTableTarget, Use, Value, visit_relations_mut,
+    MergeInsertKind, ObjectNamePart, ObjectType, OneOrManyWithParens, PivotValueSource,
+    ShowObjects, ShowStatementFilter, ShowStatementIn, TruncateTableTarget, Use, Value,
+    visit_relations_mut,
 };
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -406,25 +407,7 @@ impl UserQuery {
                 }
                 Statement::SetVariable {
                     variables, value, ..
-                } => {
-                    let values: Vec<SessionProperty> = value
-                        .iter()
-                        .map(|v| match v {
-                            Expr::Value(v) => Ok(SessionProperty::from_value(
-                                &v.value,
-                                self.session.ctx.session_id(),
-                            )),
-                            _ => ex_error::OnlyPrimitiveStatementsSnafu.fail(),
-                        })
-                        .collect::<std::result::Result<_, _>>()?;
-                    let params = variables
-                        .iter()
-                        .map(ToString::to_string)
-                        .zip(values.into_iter())
-                        .collect();
-                    self.session.set_session_variable(true, params)?;
-                    return self.status_response();
-                }
+                } => return self.set_variable(variables, value).await,
                 Statement::CreateTable { .. } => {
                     return Box::pin(self.create_table_query(*s)).await;
                 }
@@ -568,6 +551,49 @@ impl UserQuery {
                 .fail(),
             )
         }
+    }
+
+    #[instrument(name = "UserQuery::set_variable", level = "trace", skip(self), err)]
+    pub async fn set_variable(
+        &self,
+        variables: OneOrManyWithParens<ObjectName>,
+        values: Vec<Expr>,
+    ) -> Result<QueryResult> {
+        let mut session_values = Vec::new();
+        for value in values {
+            let session_value = match value {
+                Expr::Value(v) => Ok(SessionProperty::from_value(
+                    &v.value,
+                    self.session.ctx.session_id(),
+                )),
+                Expr::Subquery(query) => {
+                    let query_str = query.to_string();
+                    let res = self.execute_with_custom_plan(&query_str).await?;
+                    if res.records.is_empty()
+                        || res.records[0].num_columns() < 1
+                        || res.records[0].num_rows() < 1
+                    {
+                        return ex_error::UnexpectedSubqueryResultForSetVariableSnafu.fail();
+                    }
+                    let column = res.records[0].column(0);
+                    let scalar = ScalarValue::try_from_array(column, 0)
+                        .context(ex_error::DataFusionSnafu)?;
+                    Ok(SessionProperty::from_scalar_value(
+                        &scalar,
+                        self.session.ctx.session_id(),
+                    ))
+                }
+                _ => ex_error::OnlyPrimitiveStatementsSnafu.fail(),
+            }?;
+            session_values.push(session_value);
+        }
+        let params = variables
+            .iter()
+            .map(ToString::to_string)
+            .zip(session_values.into_iter())
+            .collect();
+        self.session.set_session_variable(true, params)?;
+        self.status_response()
     }
 
     #[instrument(name = "UserQuery::drop_query", level = "trace", skip(self), err)]

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -497,6 +497,17 @@ test_query!(
     snapshot_path = "session"
 );
 test_query!(
+    set_variable_subquery,
+    "SHOW VARIABLES",
+    setup_queries = ["SET id_threshold = (
+            SELECT COUNT(*) * 100 FROM (
+                SELECT 1 AS column1 UNION ALL SELECT 2 UNION ALL SELECT 3
+            ) AS table1
+        );"],
+    exclude_columns = ["created_on", "updated_on", "session_id"],
+    snapshot_path = "session"
+);
+test_query!(
     set_variable_system,
     "SELECT name, value FROM snowplow.information_schema.df_settings
      WHERE name = 'datafusion.execution.time_zone'",

--- a/crates/core-executor/src/tests/snapshots/session/query_set_variable_subquery.snap
+++ b/crates/core-executor/src/tests/snapshots/session/query_set_variable_subquery.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SHOW VARIABLES\""
+info: "Setup queries: SET id_threshold = (\n            SELECT COUNT(*) * 100 FROM (\n                SELECT 1 AS column1 UNION ALL SELECT 2 UNION ALL SELECT 3\n            ) AS table1\n        );"
+---
+Ok(
+    [
+        "+--------------+-------+-------+---------+",
+        "| name         | value | type  | comment |",
+        "+--------------+-------+-------+---------+",
+        "| id_threshold | 300   | fixed |         |",
+        "+--------------+-------+-------+---------+",
+    ],
+)

--- a/crates/df-catalog/src/information_schema/session_params.rs
+++ b/crates/df-catalog/src/information_schema/session_params.rs
@@ -4,9 +4,11 @@ use datafusion::logical_expr::sqlparser::ast::Value;
 use datafusion::logical_expr::sqlparser::ast::helpers::key_value_options::{
     KeyValueOption, KeyValueOptionType,
 };
+use datafusion_common::ScalarValue;
 use datafusion_common::config::{ConfigEntry, ConfigExtension, ExtensionOptions};
 use std::any::Any;
 use std::collections::HashMap;
+
 #[derive(Default, Debug, Clone)]
 pub struct SessionParams {
     pub properties: HashMap<String, SessionProperty>,
@@ -56,6 +58,25 @@ impl SessionProperty {
                 Value::Boolean(_) => "boolean".to_string(),
                 _ => "text".to_string(),
             },
+            comment: None,
+        }
+    }
+
+    #[must_use]
+    pub fn from_scalar_value(value: &ScalarValue, session_id: String) -> Self {
+        let now = Utc::now();
+        let (property_type, value) = match value {
+            ScalarValue::Boolean(Some(b)) => ("boolean".to_string(), b.to_string()),
+            ScalarValue::Int64(Some(i)) => ("fixed".to_string(), i.to_string()),
+            ScalarValue::Float64(Some(f)) => ("fixed".to_string(), f.to_string()),
+            _ => ("text".to_string(), value.to_string()),
+        };
+        Self {
+            session_id: Some(session_id),
+            created_on: now,
+            updated_on: now,
+            value,
+            property_type,
             comment: None,
         }
     }


### PR DESCRIPTION
Closes #1454

This PR allow to use subquries as variable Expr
```sql
SET id_threshold = (
    SELECT COUNT(*) * 100 FROM (
        SELECT 1 AS column1 UNION ALL SELECT 2 UNION ALL SELECT 3
    ) AS table1
);
[
    "+--------------+-------+-------+---------+",
    "| name         | value | type  | comment |",
    "+--------------+-------+-------+---------+",
    "| id_threshold | 300   | fixed |         |",
    "+--------------+-------+-------+---------+",
],
```