### PR TITLE
Allow session variables placeholders 

### DIFF
--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -508,6 +508,13 @@ test_query!(
     snapshot_path = "session"
 );
 test_query!(
+    set_variable_and_access_by_placeholder,
+    "SELECT $v1",
+    setup_queries = ["SET v1 = 'test';"],
+    exclude_columns = ["created_on", "updated_on", "session_id"],
+    snapshot_path = "session"
+);
+test_query!(
     set_variable_system,
     "SELECT name, value FROM snowplow.information_schema.df_settings
      WHERE name = 'datafusion.execution.time_zone'",

--- a/crates/core-executor/src/tests/snapshots/session/query_set_variable_and_access_by_placeholder.snap
+++ b/crates/core-executor/src/tests/snapshots/session/query_set_variable_and_access_by_placeholder.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT $v1\""
+info: "Setup queries: SET v1 = 'test';"
+---
+Ok(
+    [
+        "+------+",
+        "| $v1  |",
+        "+------+",
+        "| test |",
+        "+------+",
+    ],
+)

--- a/crates/df-catalog/src/information_schema/session_params.rs
+++ b/crates/df-catalog/src/information_schema/session_params.rs
@@ -4,14 +4,25 @@ use datafusion::logical_expr::sqlparser::ast::Value;
 use datafusion::logical_expr::sqlparser::ast::helpers::key_value_options::{
     KeyValueOption, KeyValueOptionType,
 };
-use datafusion_common::ScalarValue;
 use datafusion_common::config::{ConfigEntry, ConfigExtension, ExtensionOptions};
+use datafusion_common::{ParamValues, ScalarValue};
 use std::any::Any;
 use std::collections::HashMap;
 
 #[derive(Default, Debug, Clone)]
 pub struct SessionParams {
     pub properties: HashMap<String, SessionProperty>,
+}
+
+impl From<SessionParams> for ParamValues {
+    fn from(value: SessionParams) -> Self {
+        let map: HashMap<String, ScalarValue> = value
+            .properties
+            .into_iter()
+            .filter_map(|(key, prop)| prop.to_scalar_value().map(|scalar| (key, scalar)))
+            .collect();
+        Self::Map(map)
+    }
 }
 
 #[derive(Default, Debug, Clone)]
@@ -91,6 +102,28 @@ impl SessionProperty {
             value,
             property_type: "text".to_string(),
             comment: None,
+        }
+    }
+
+    #[must_use]
+    pub fn to_scalar_value(&self) -> Option<ScalarValue> {
+        match self.property_type.as_str() {
+            "boolean" => self
+                .value
+                .parse::<bool>()
+                .ok()
+                .map(|b| ScalarValue::Boolean(Some(b))),
+            "fixed" => {
+                if let Ok(i) = self.value.parse::<i64>() {
+                    Some(ScalarValue::Int64(Some(i)))
+                } else if let Ok(f) = self.value.parse::<f64>() {
+                    Some(ScalarValue::Float64(Some(f)))
+                } else {
+                    None
+                }
+            }
+            "text" => Some(ScalarValue::Utf8(Some(self.value.clone()))),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Closes #1459 
This PR adds support for injecting session-scoped parameter values with placeholders  into the logical plan before execution via the with_param_values API.

Session parameters can now be defined using the SET command and referenced later in SQL queries using $name. These parameters are resolved at planning time and substituted into the query plan using the values stored in the current session context.

### Example usage:
```sql
SET threshold = 100;
SELECT * FROM my_table WHERE value > $threshold;
```
In execute_with_custom_plan, we retrieve the current SessionParams from the session context and convert them to ParamValues, which are then passed to with_param_values(...). This enables full parameter binding and allows for dynamic query customization based on session state.

The changes are backward-compatible: if no parameters are defined in the session, an empty map is passed.