### PR TITLE
Add query execution timeout

### DIFF
--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -15,9 +15,15 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[error_stack_trace::debug]
 pub enum Error {
     #[snafu(display("Concurrency limit reached — too many concurrent queries are running"))]
-    ConcurrencyLimitError {
+    ConcurrencyLimit {
         #[snafu(source)]
         error: tokio::sync::TryAcquireError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Query execution exceeded timeout"))]
+    QueryTimeout {
         #[snafu(implicit)]
         location: Location,
     },

--- a/crates/core-executor/src/utils.rs
+++ b/crates/core-executor/src/utils.rs
@@ -35,6 +35,7 @@ use strum::{Display, EnumString};
 pub struct Config {
     pub embucket_version: String,
     pub sql_parser_dialect: Option<String>,
+    pub query_timeout_secs: u64,
     pub max_concurrency_level: usize,
     pub mem_pool_type: MemPoolType,
     pub mem_pool_size_mb: Option<usize>,
@@ -47,6 +48,7 @@ impl Default for Config {
         Self {
             embucket_version: "0.1.0".to_string(),
             sql_parser_dialect: None,
+            query_timeout_secs: 1200, // 20 minutes
             max_concurrency_level: 100,
             mem_pool_type: MemPoolType::default(),
             mem_pool_size_mb: None,
@@ -60,6 +62,12 @@ impl Config {
     #[must_use]
     pub const fn with_max_concurrency_level(mut self, level: usize) -> Self {
         self.max_concurrency_level = level;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_query_timeout(mut self, timeout_secs: u64) -> Self {
+        self.query_timeout_secs = timeout_secs;
         self
     }
 }

--- a/crates/embucketd/src/cli.rs
+++ b/crates/embucketd/src/cli.rs
@@ -165,6 +165,14 @@ pub struct CliOpts {
 
     #[arg(
         long,
+        env = "QUERY_TIMEOUT_SECS",
+        default_value = "1200",
+        help = "Maximum duration in seconds a single query is allowed to run"
+    )]
+    pub query_timeout_secs: u64,
+
+    #[arg(
+        long,
         value_enum,
         env = "MEM_POOL_TYPE",
         default_value = "greedy",

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -106,6 +106,7 @@ async fn main() {
     let execution_cfg = ExecutionConfig {
         embucket_version: "0.1.0".to_string(),
         sql_parser_dialect: opts.sql_parser_dialect.clone(),
+        query_timeout_secs: opts.query_timeout_secs,
         max_concurrency_level: opts.max_concurrency_level,
         mem_pool_type: opts.mem_pool_type,
         mem_pool_size_mb: opts.mem_pool_size_mb,


### PR DESCRIPTION
Closes #1465 
This PR introduces a timeout mechanism for query execution to prevent runaway or hanging queries from consuming resources indefinitely. The timeout duration is configurable via query_timeout_secs.

### Key changes:
- Wrapped query execution in tokio::time::timeout. If the timeout is exceeded, the system returns a structured QueryTimeout error.
- Ensured that all query executions — whether successful, failed, or timed out — are recorded in the history_store with appropriate status and metadata.
- This improves observability, traceability, and operational stability by guaranteeing that every query attempt is logged, even in edge cases.

### Why it matters:
- Prevents long-running queries from monopolizing system resources.
- Ensures complete auditability of all queries, even failed or aborted ones.
- Improves user feedback in cases where queries take too long.