### PR TITLE
fix unwrap in merge_query

### DIFF
--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -67,7 +67,6 @@ use datafusion_iceberg::DataFusionTable;
 use datafusion_iceberg::catalog::catalog::IcebergCatalog;
 use datafusion_iceberg::catalog::mirror::Mirror;
 use datafusion_iceberg::catalog::schema::IcebergSchema;
-use datafusion_iceberg::error::Error as DataFusionIcebergError;
 use datafusion_iceberg::table::DataFusionTableConfigBuilder;
 use df_catalog::catalog::CachingCatalog;
 use df_catalog::catalog_list::CachedEntity;
@@ -1319,8 +1318,6 @@ impl UserQuery {
                         .enable_data_file_path_column(true)
                         .enable_manifest_file_path_column(true)
                         .build()
-                        .map_err(DataFusionIcebergError::from)
-                        .map_err(IcebergError::from)
                         .context(ex_error::IcebergSnafu)?,
                 ),
             )

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -67,6 +67,7 @@ use datafusion_iceberg::DataFusionTable;
 use datafusion_iceberg::catalog::catalog::IcebergCatalog;
 use datafusion_iceberg::catalog::mirror::Mirror;
 use datafusion_iceberg::catalog::schema::IcebergSchema;
+use datafusion_iceberg::error::Error as DataFusionIcebergError;
 use datafusion_iceberg::table::DataFusionTableConfigBuilder;
 use df_catalog::catalog::CachingCatalog;
 use df_catalog::catalog_list::CachedEntity;
@@ -1314,13 +1315,13 @@ impl UserQuery {
             .get_iceberg_table_provider(
                 &target_ident,
                 Some(
-                    //TODO Return proper Error
-                    #[allow(clippy::unwrap_used)]
                     DataFusionTableConfigBuilder::default()
                         .enable_data_file_path_column(true)
                         .enable_manifest_file_path_column(true)
                         .build()
-                        .unwrap(),
+                        .map_err(DataFusionIcebergError::from)
+                        .map_err(IcebergError::from)
+                        .context(ex_error::IcebergSnafu)?,
                 ),
             )
             .await?;


### PR DESCRIPTION
## Summary
- Replace unwrap() with proper error handling in merge_query
- Add DataFusionIcebergError import and proper error chain conversion

## Test plan
- Verify build passes
- Ensure error handling flows correctly through the system

🤖 Generated with [Claude Code](https://claude.ai/code)