### PR TITLE
engine: `regexp_replace`

### DIFF
--- a/crates/embucket-functions/src/regexp/mod.rs
+++ b/crates/embucket-functions/src/regexp/mod.rs
@@ -1,10 +1,12 @@
 pub mod errors;
 pub mod regexp_instr;
+mod regexp_replace;
 mod regexp_like;
 mod regexp_substr;
 mod regexp_substr_all;
 
 use crate::regexp::regexp_instr::RegexpInstrFunc;
+use crate::regexp::regexp_replace::RegexpReplaceFunc;
 use crate::regexp::regexp_like::RegexpLikeFunc;
 use crate::regexp::regexp_substr::RegexpSubstrFunc;
 use crate::regexp::regexp_substr_all::RegexpSubstrAllFunc;
@@ -17,6 +19,7 @@ pub fn register_udfs(registry: &mut dyn FunctionRegistry) -> datafusion_common::
     let functions: Vec<Arc<ScalarUDF>> = vec![
         Arc::new(ScalarUDF::from(RegexpInstrFunc::new())),
         Arc::new(ScalarUDF::from(RegexpSubstrFunc::new())),
+        Arc::new(ScalarUDF::from(RegexpReplaceFunc::new())),
         Arc::new(ScalarUDF::from(RegexpSubstrAllFunc::new())),
         Arc::new(ScalarUDF::from(RegexpLikeFunc::new())),
     ];

--- a/crates/embucket-functions/src/regexp/mod.rs
+++ b/crates/embucket-functions/src/regexp/mod.rs
@@ -1,13 +1,13 @@
 pub mod errors;
 pub mod regexp_instr;
-mod regexp_replace;
 mod regexp_like;
+mod regexp_replace;
 mod regexp_substr;
 mod regexp_substr_all;
 
 use crate::regexp::regexp_instr::RegexpInstrFunc;
-use crate::regexp::regexp_replace::RegexpReplaceFunc;
 use crate::regexp::regexp_like::RegexpLikeFunc;
+use crate::regexp::regexp_replace::RegexpReplaceFunc;
 use crate::regexp::regexp_substr::RegexpSubstrFunc;
 use crate::regexp::regexp_substr_all::RegexpSubstrAllFunc;
 use datafusion_expr::ScalarUDF;

--- a/crates/embucket-functions/src/regexp/regexp_replace.rs
+++ b/crates/embucket-functions/src/regexp/regexp_replace.rs
@@ -1,0 +1,300 @@
+use super::errors as regexp_errors;
+use crate::utils::{pattern_to_regex, regexp};
+use datafusion::arrow::array::{StringArray, StringBuilder};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::{
+    ColumnarValue, Signature, TypeSignature, TypeSignatureClass, Volatility,
+};
+use datafusion_common::ScalarValue;
+use datafusion_common::arrow::array::Array;
+use datafusion_common::cast::as_generic_string_array;
+use datafusion_common::types::logical_string;
+use datafusion_expr::{Coercion, ScalarFunctionArgs, ScalarUDFImpl};
+use snafu::ResultExt;
+use std::any::Any;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+/// `REGEXP_REPLACE` function implementation
+///
+/// Returns the subject with the specified pattern (or all occurrences of the pattern) either removed or replaced by a replacement string.
+/// Returns a value of type VARCHAR. If no matches are found, returns the original subject.
+///
+/// Syntax: `REGEXP_REPLACE( <subject> , <pattern> [ , <replacement> , <position> , <occurrence> , <parameters> ] )`
+///
+/// Arguments:
+///
+/// `Required`:
+/// - `<subject>` the string to search for matches.
+/// - `<pattern>` pattern to match.
+///
+/// `Optional`:
+/// - `<position>` number of characters from the beginning of the string where the function starts searching for matches.
+///   Default: `1` (the search for a match starts at the first character on the left)
+/// - `<occurrence>` specifies the first occurrence of the pattern from which to start returning matches.
+///   The function skips the first occurrence - 1 matches. For example, if there are 5 matches and you specify 3 for the occurrence argument,
+///   the function ignores the first two matches and returns the third, fourth, and fifth matches.
+///   Default: `1`
+/// - `<regex_parameters>` String of one or more characters that specifies the parameters used for searching for matches.
+///   Supported values:
+///   ---------------------------------------------------------------------------
+///   | Parameter       | Description                               |
+///   |-----------------|-------------------------------------------|
+///   | c               | Case-sensitive matching                   |
+///   | i               | Case-insensitive matching                 |
+///   | m               | Multi-line mode                           |
+///   | e               | Extract submatches                        |
+///   | s               | POSIX wildcard character `.` matches `\n` |
+///   ---------------------------------------------------------------------------
+///   Default: `c`
+///
+/// Example: `REGEXP_REPLACE('nevermore1, nevermore2, nevermore3.', 'nevermore')`
+#[derive(Debug)]
+pub struct RegexpReplaceFunc {
+    signature: Signature,
+}
+
+impl Default for RegexpReplaceFunc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RegexpReplaceFunc {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    ]),
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    ]),
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Integer),
+                    ]),
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Integer),
+                        Coercion::new_exact(TypeSignatureClass::Integer),
+                    ]),
+                    TypeSignature::Coercible(vec![
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                        Coercion::new_exact(TypeSignatureClass::Integer),
+                        Coercion::new_exact(TypeSignatureClass::Integer),
+                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
+                    ]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+    #[allow(clippy::too_many_lines, clippy::unwrap_used)]
+    fn take_args_values(args: &[ColumnarValue]) -> DFResult<(&str, usize, usize, &str)> {
+        let replacement = args.get(2).map_or_else(
+            || Ok(""),
+            |value| match value {
+                ColumnarValue::Scalar(
+                    ScalarValue::Utf8(Some(value))
+                    | ScalarValue::Utf8View(Some(value))
+                    | ScalarValue::LargeUtf8(Some(value)),
+                ) => Ok(value),
+                other => regexp_errors::UnsupportedInputTypeWithPositionSnafu {
+                    data_type: other.data_type(),
+                    position: 3usize,
+                }
+                .fail(),
+            },
+        )?;
+
+        let position = args.get(3).map_or_else(
+            || Ok(0),
+            |value| match value {
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(value))) if 0 <= *value => {
+                    usize::try_from(*value - 1)
+                        .context(regexp_errors::InvalidIntegerConversionSnafu)
+                }
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(value))) if 0 > *value => {
+                    regexp_errors::WrongArgValueSnafu {
+                        got: value.to_string(),
+                        reason: "Position must be positive".to_string(),
+                    }
+                    .fail()
+                }
+                other => regexp_errors::UnsupportedInputTypeWithPositionSnafu {
+                    data_type: other.data_type(),
+                    position: 4usize,
+                }
+                .fail(),
+            },
+        )?;
+
+        let occurrence = args.get(4).map_or_else(
+            || Ok(0),
+            |value| match value {
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(value))) if 0 <= *value => {
+                    usize::try_from(*value - 1)
+                        .context(regexp_errors::InvalidIntegerConversionSnafu)
+                }
+                ColumnarValue::Scalar(ScalarValue::Int64(Some(value))) if 0 > *value => {
+                    regexp_errors::WrongArgValueSnafu {
+                        got: value.to_string(),
+                        reason: "Occurrence must be positive".to_string(),
+                    }
+                    .fail()
+                }
+                other => regexp_errors::UnsupportedInputTypeWithPositionSnafu {
+                    data_type: other.data_type(),
+                    position: 5usize,
+                }
+                .fail(),
+            },
+        )?;
+
+        let regex_parameters = args.get(5).map_or_else(
+            || Ok("c"),
+            |value| match value {
+                ColumnarValue::Scalar(
+                    ScalarValue::Utf8(Some(value))
+                    | ScalarValue::Utf8View(Some(value))
+                    | ScalarValue::LargeUtf8(Some(value)),
+                ) if value.contains(['c', 'i', 'm', 'e', 's']) => Ok(value),
+                ColumnarValue::Scalar(
+                    ScalarValue::Utf8(Some(value))
+                    | ScalarValue::Utf8View(Some(value))
+                    | ScalarValue::LargeUtf8(Some(value)),
+                ) if value.is_empty() => Ok("c"),
+                ColumnarValue::Scalar(
+                    ScalarValue::Utf8(Some(value))
+                    | ScalarValue::Utf8View(Some(value))
+                    | ScalarValue::LargeUtf8(Some(value)),
+                ) => regexp_errors::WrongArgValueSnafu {
+                    got: value.to_string(),
+                    //We just checked if value is empty, if not - this is valid, since we are getting here the excluded range so just the zeroes character
+                    reason: format!("Unknown parameter: '{}'", value.get(0..1).unwrap()),
+                }
+                .fail(),
+                other => regexp_errors::UnsupportedInputTypeWithPositionSnafu {
+                    data_type: other.data_type(),
+                    position: 6usize,
+                }
+                .fail(),
+            },
+        )?;
+
+        Ok((replacement, position, occurrence, regex_parameters))
+    }
+}
+
+impl ScalarUDFImpl for RegexpReplaceFunc {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "regexp_replace"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> DFResult<DataType> {
+        match arg_types.len() {
+            0 => regexp_errors::NotEnoughArgumentsSnafu {
+                got: 0usize,
+                at_least: 2usize,
+            }
+            .fail()?,
+            //Return type specified as Number, probably an `Integer` which is an alias to `Number(38, 0)`,
+            // we return `Int64` for better internal DF compatibility
+            n if 7 > n && 1 < n => Ok(DataType::Utf8),
+            n => regexp_errors::TooManyArgumentsSnafu {
+                got: n,
+                at_maximum: 6usize,
+            }
+            .fail()?,
+        }
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+        //Already checked that it's at least > 1
+        let subject = &args.args[0];
+        let array = match subject {
+            ColumnarValue::Array(array) => array,
+            //Can't fail (shouldn't)
+            ColumnarValue::Scalar(scalar) => &scalar.to_array()?,
+        };
+
+        //Already checked that it's at least > 1
+        let pattern = match &args.args[1] {
+            ColumnarValue::Scalar(
+                ScalarValue::Utf8(Some(pattern))
+                | ScalarValue::LargeUtf8(Some(pattern))
+                | ScalarValue::Utf8View(Some(pattern)),
+            ) => pattern,
+            other => {
+                return regexp_errors::UnsupportedInputTypeWithPositionSnafu {
+                    data_type: other.data_type(),
+                    position: 2usize,
+                }
+                .fail()?;
+            }
+        };
+
+        let (replacement, position, occurrence, regex_parameters) =
+            Self::take_args_values(&args.args)?;
+
+        //TODO: Or data_capacity: 1024
+        let mut result_array = StringBuilder::with_capacity(array.len(), array.len() * 10);
+
+        match array.data_type() {
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+                let string_array: &StringArray = as_generic_string_array(array)?;
+                let regex = pattern_to_regex(pattern, regex_parameters)
+                    .context(regexp_errors::UnsupportedRegexSnafu)?;
+                regexp(string_array, &regex, position)
+                    .enumerate()
+                    .for_each(|(index, opt_iter)| {
+                        result_array.append_option(opt_iter.and_then(|mut cap_iter| {
+                            cap_iter.nth(occurrence).map(|cap| {
+                                //Can't panic
+                                let value = string_array.value(index);
+                                //group_num == 0, means get the whole match (seems docs in regex are incorrect)
+                                if let Some(start) = cap.get(0).map(|mat| mat.start()) {
+                                    tracing::error!("Replacement: {}", replacement);
+                                    let not_changeable = &value[..(position + start)];
+                                    tracing::error!("Not changeable: {}", not_changeable);
+                                    let changeable = &value[(position + start)..];
+                                    tracing::error!("Changeable: {}", changeable);
+                                    not_changeable.to_string()
+                                        + regex.replace_all(changeable, replacement).as_ref()
+                                } else {
+                                    value.to_string()
+                                }
+                            })
+                        }));
+                    });
+            }
+            other => regexp_errors::UnsupportedInputTypeWithPositionSnafu {
+                position: 1usize,
+                data_type: other.clone(),
+            }
+            .fail()?,
+        }
+
+        Ok(ColumnarValue::Array(Arc::new(result_array.finish())))
+    }
+}

--- a/crates/embucket-functions/src/regexp/regexp_replace.rs
+++ b/crates/embucket-functions/src/regexp/regexp_replace.rs
@@ -274,11 +274,8 @@ impl ScalarUDFImpl for RegexpReplaceFunc {
                                 let value = string_array.value(index);
                                 //group_num == 0, means get the whole match (seems docs in regex are incorrect)
                                 if let Some(start) = cap.get(0).map(|mat| mat.start()) {
-                                    tracing::error!("Replacement: {}", replacement);
                                     let not_changeable = &value[..(position + start)];
-                                    tracing::error!("Not changeable: {}", not_changeable);
                                     let changeable = &value[(position + start)..];
-                                    tracing::error!("Changeable: {}", changeable);
                                     not_changeable.to_string()
                                         + regex.replace_all(changeable, replacement).as_ref()
                                 } else {

--- a/crates/embucket-functions/src/tests/regexp/mod.rs
+++ b/crates/embucket-functions/src/tests/regexp/mod.rs
@@ -1,4 +1,5 @@
 mod regexp_instr;
+mod regexp_replace;
 mod regexp_like;
 mod regexp_substr;
 mod regexp_substr_all;

--- a/crates/embucket-functions/src/tests/regexp/mod.rs
+++ b/crates/embucket-functions/src/tests/regexp/mod.rs
@@ -1,5 +1,5 @@
 mod regexp_instr;
-mod regexp_replace;
 mod regexp_like;
+mod regexp_replace;
 mod regexp_substr;
 mod regexp_substr_all;

--- a/crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+++ b/crates/embucket-functions/src/tests/regexp/regexp_replace.rs
@@ -1,0 +1,25 @@
+use crate::test_query;
+
+test_query!(
+    regexp_replace_basic,
+    "SELECT REGEXP_REPLACE('nevermore1, nevermore2, nevermore3.', 'nevermore', 'moreover')",
+    snapshot_path = "regexp_replace"
+);
+
+test_query!(
+    regexp_replace_remove,
+    "SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times',
+                      '( ){1,}',
+                      '')",
+    snapshot_path = "regexp_replace"
+);
+
+test_query!(
+    regexp_replace_occurrence,
+    "SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times',
+                      'times',
+                      'days',
+                      1,
+                      2)",
+    snapshot_path = "regexp_replace"
+);

--- a/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_basic.snap
+++ b/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_basic.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+description: "\"SELECT REGEXP_REPLACE('nevermore1, nevermore2, nevermore3.', 'nevermore', 'moreover')\""
+---
+Ok(
+    [
+        "+------------------------------------------------------------------------------------------------+",
+        "| regexp_replace(Utf8(\"nevermore1, nevermore2, nevermore3.\"),Utf8(\"nevermore\"),Utf8(\"moreover\")) |",
+        "+------------------------------------------------------------------------------------------------+",
+        "| moreover1, moreover2, moreover3.                                                               |",
+        "+------------------------------------------------------------------------------------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_occurrence.snap
+++ b/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_occurrence.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+description: "\"SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times',\n                      'times',\n                      'days',\n                      1,\n                      2)\""
+---
+Ok(
+    [
+        "+--------------------------------------------------------------------------------------------------------------------------+",
+        "| regexp_replace(Utf8(\"It was the best of times, it was the worst of times\"),Utf8(\"times\"),Utf8(\"days\"),Int64(1),Int64(2)) |",
+        "+--------------------------------------------------------------------------------------------------------------------------+",
+        "| It was the best of times, it was the worst of days                                                                       |",
+        "+--------------------------------------------------------------------------------------------------------------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_remove.snap
+++ b/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_remove.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+description: "\"SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times',\n                      '( ){1,}',\n                      '')\""
+---
+Ok(
+    [
+        "+------------------------------------------------------------------------------------------------------+",
+        "| regexp_replace(Utf8(\"It was the best of times, it was the worst of times\"),Utf8(\"( ){1,}\"),Utf8(\"\")) |",
+        "+------------------------------------------------------------------------------------------------------+",
+        "| Itwasthebestoftimes,itwastheworstoftimes                                                             |",
+        "+------------------------------------------------------------------------------------------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/visitors/functions_rewriter.rs
+++ b/crates/embucket-functions/src/visitors/functions_rewriter.rs
@@ -50,6 +50,32 @@ impl VisitorMut for FunctionsRewriter {
                             span: *span,
                         });
                     }
+                    if let FunctionArguments::List(FunctionArgumentList { args, .. }) = args
+                        && let Some(FunctionArg::Unnamed(FunctionArgExpr::Expr(replacement))) =
+                        args.get_mut(2)
+                        //third arg may be a replacement
+                        && let Expr::Value(ValueWithSpan {
+                                               value: SingleQuotedString(value),
+                                               span,
+                                           }) = replacement
+                    {
+                        let value = if let Ok(regex) = regex::Regex::new(r"\\(\d)") {
+                            tracing::error!("Made a regex: {:?}", regex);
+                            tracing::error!("The string is: {}", value);
+                            regex
+                                .replace_all(value, |caps: &regex::Captures| {
+                                    tracing::error!("Found capture: {:?}", caps);
+                                    format!("${}", &caps[1]) // Replace with `$number`.
+                                })
+                                .to_string()
+                        } else {
+                            (*value).to_string()
+                        };
+                        *replacement = Expr::Value(ValueWithSpan {
+                            value: SingleQuotedString(value),
+                            span: *span,
+                        });
+                    }
                     match func_name {
                         "rlike" => "regexp_like",
                         "regexp_extract_all" => "regexp_substr_all",

--- a/crates/embucket-functions/src/visitors/functions_rewriter.rs
+++ b/crates/embucket-functions/src/visitors/functions_rewriter.rs
@@ -60,11 +60,8 @@ impl VisitorMut for FunctionsRewriter {
                                            }) = replacement
                     {
                         let value = if let Ok(regex) = regex::Regex::new(r"\\(\d)") {
-                            tracing::error!("Made a regex: {:?}", regex);
-                            tracing::error!("The string is: {}", value);
                             regex
                                 .replace_all(value, |caps: &regex::Captures| {
-                                    tracing::error!("Found capture: {:?}", caps);
                                     format!("${}", &caps[1]) // Replace with `$number`.
                                 })
                                 .to_string()

--- a/test/sql/bronze_scope/sql-reference-functions/Regular_expressions/regexp_replace.slt
+++ b/test/sql/bronze_scope/sql-reference-functions/Regular_expressions/regexp_replace.slt
@@ -19,12 +19,12 @@ SELECT REGEXP_REPLACE('firstname middlename lastname',
                       '(.*) (.*) (.*)',
                       '\\\\3, \\\\1 \\\\2') AS name_sort
 ----
-\3, \1 \2
+lastname, firstname middlename
 
 query TT
 WITH wildcards AS (
   SELECT * FROM VALUES
-    ('\\', '?'),
+    ('\\\\', '?'),
     (NULL, 'When I am cold, I am bold.')
   AS t(w, w2)
 )
@@ -32,5 +32,5 @@ SELECT w2, REGEXP_REPLACE(w2, '(.old)', 'very \\1')
   FROM wildcards
   ORDER BY w2
 ----
-?	?
+?	NULL
 When I am cold, I am bold.	When I am very cold, I am very bold.


### PR DESCRIPTION
Closes #1488

- [x] `regexp_replace` impl
- [x] Uses an iterator approach for performance and reusability
- [x] Uses a performative string slicing approach, instead of an iterative per-match replacement
- [x] Docs
- [x] Insta tests
- [x] SLT tests

P.S. Small clippy error fixes. Also, this does not include the last reference example test since our insta tests do not register our rewriters in context

Reference: https://docs.snowflake.com/en/sql-reference/functions/regexp_substr_all   