### PR TITLE
engine: `rlike` & `regexp` exprs

### DIFF
--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -77,8 +77,8 @@ use embucket_functions::datetime::date_part_extract;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::visitors::{
     copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query,
-    json_element, qualify_in_query, select_expr_aliases, table_functions,
-    table_functions_cte_relation, timestamp, top_limit,
+    json_element, qualify_in_query, rlike_regexp_expr_rewriter, select_expr_aliases,
+    table_functions, table_functions_cte_relation, timestamp, top_limit,
     unimplemented::functions_checker::visit as unimplemented_functions_checker,
 };
 use iceberg_rust::catalog::Catalog;
@@ -353,6 +353,7 @@ impl UserQuery {
     pub fn postprocess_query_statement_with_validation(statement: &mut DFStatement) -> Result<()> {
         if let DFStatement::Statement(value) = statement {
             json_element::visit(value);
+            rlike_regexp_expr_rewriter::visit(value);
             functions_rewriter::visit(value);
             top_limit::visit(value);
             unimplemented_functions_checker(value).context(ex_error::UnimplementedFunctionSnafu)?;

--- a/crates/core-executor/src/tests/sql/commands/mod.rs
+++ b/crates/core-executor/src/tests/sql/commands/mod.rs
@@ -1,4 +1,5 @@
 mod fetch;
 mod pivot;
+mod rlike_regexp;
 mod top;
 mod unpivot;

--- a/crates/core-executor/src/tests/sql/commands/rlike_regexp.rs
+++ b/crates/core-executor/src/tests/sql/commands/rlike_regexp.rs
@@ -1,0 +1,46 @@
+use crate::test_query;
+
+const SETUP_QUERY: &str = r"CREATE OR REPLACE TABLE strings (v VARCHAR(50))
+AS SELECT * FROM VALUES
+  ('San Francisco'),
+  ('San Jose'),
+  ('Santa Clara'),
+  ('Sacramento'),
+  ('Contains embedded single \\\\backslash')";
+
+test_query!(
+    rlike_regexp_basic,
+    "SELECT v
+  FROM strings
+  WHERE v REGEXP 'San* [fF].*'
+  ORDER BY v",
+    setup_queries = [SETUP_QUERY],
+    snapshot_path = "rlike_regexp"
+);
+
+test_query!(
+    rlike_regexp_embedded_backslash,
+    r"SELECT v, v REGEXP 'San\\b.*' AS matches
+  FROM strings
+  ORDER BY v",
+    setup_queries = [SETUP_QUERY],
+    snapshot_path = "rlike_regexp"
+);
+
+test_query!(
+    rlike_regexp_embedded_backslashes,
+    r"SELECT v, v REGEXP '.*\\s\\\\.*' AS matches
+  FROM strings
+  ORDER BY v",
+    setup_queries = [SETUP_QUERY],
+    snapshot_path = "rlike_regexp"
+);
+
+test_query!(
+    rlike_regexp_string_delimiter,
+    r"SELECT v, v REGEXP $$.*\s\\.*$$ AS MATCHES
+  FROM strings
+  ORDER BY v",
+    setup_queries = [SETUP_QUERY],
+    snapshot_path = "rlike_regexp"
+);

--- a/crates/core-executor/src/tests/sql/commands/snapshots/rlike_regexp/query_rlike_regexp_basic.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/rlike_regexp/query_rlike_regexp_basic.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/sql/commands/rlike_regexp.rs
+description: "\"SELECT v\n  FROM strings\n  WHERE v REGEXP 'San* [fF].*'\n  ORDER BY v\""
+info: "Setup queries: CREATE OR REPLACE TABLE strings (v VARCHAR(50))\nAS SELECT * FROM VALUES\n  ('San Francisco'),\n  ('San Jose'),\n  ('Santa Clara'),\n  ('Sacramento'),\n  ('Contains embedded single \\backslash')"
+---
+Ok(
+    [
+        "+---------------+",
+        "| v             |",
+        "+---------------+",
+        "| San Francisco |",
+        "+---------------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/rlike_regexp/query_rlike_regexp_embedded_backslash.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/rlike_regexp/query_rlike_regexp_embedded_backslash.snap
@@ -1,0 +1,18 @@
+---
+source: crates/core-executor/src/tests/sql/commands/rlike_regexp.rs
+description: "r\"SELECT v, v REGEXP 'San\\\\b.*' AS matches\n  FROM strings\n  ORDER BY v\""
+info: "Setup queries: CREATE OR REPLACE TABLE strings (v VARCHAR(50))\nAS SELECT * FROM VALUES\n  ('San Francisco'),\n  ('San Jose'),\n  ('Santa Clara'),\n  ('Sacramento'),\n  ('Contains embedded single \\\\\\\\backslash')"
+---
+Ok(
+    [
+        "+-------------------------------------+---------+",
+        "| v                                   | matches |",
+        "+-------------------------------------+---------+",
+        "| Contains embedded single \\backslash | false   |",
+        "| Sacramento                          | false   |",
+        "| San Francisco                       | true    |",
+        "| San Jose                            | true    |",
+        "| Santa Clara                         | false   |",
+        "+-------------------------------------+---------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/rlike_regexp/query_rlike_regexp_embedded_backslashes.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/rlike_regexp/query_rlike_regexp_embedded_backslashes.snap
@@ -1,0 +1,18 @@
+---
+source: crates/core-executor/src/tests/sql/commands/rlike_regexp.rs
+description: "r\"SELECT v, v REGEXP '.*\\\\s\\\\\\\\.*' AS matches\n  FROM strings\n  ORDER BY v\""
+info: "Setup queries: CREATE OR REPLACE TABLE strings (v VARCHAR(50))\nAS SELECT * FROM VALUES\n  ('San Francisco'),\n  ('San Jose'),\n  ('Santa Clara'),\n  ('Sacramento'),\n  ('Contains embedded single \\\\\\\\backslash')"
+---
+Ok(
+    [
+        "+-------------------------------------+---------+",
+        "| v                                   | matches |",
+        "+-------------------------------------+---------+",
+        "| Contains embedded single \\backslash | true    |",
+        "| Sacramento                          | false   |",
+        "| San Francisco                       | false   |",
+        "| San Jose                            | false   |",
+        "| Santa Clara                         | false   |",
+        "+-------------------------------------+---------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/rlike_regexp/query_rlike_regexp_string_delimiter.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/rlike_regexp/query_rlike_regexp_string_delimiter.snap
@@ -1,0 +1,18 @@
+---
+source: crates/core-executor/src/tests/sql/commands/rlike_regexp.rs
+description: "r\"SELECT v, v REGEXP $$.*\\s\\\\.*$$ AS MATCHES\n  FROM strings\n  ORDER BY v\""
+info: "Setup queries: CREATE OR REPLACE TABLE strings (v VARCHAR(50))\nAS SELECT * FROM VALUES\n  ('San Francisco'),\n  ('San Jose'),\n  ('Santa Clara'),\n  ('Sacramento'),\n  ('Contains embedded single \\\\\\\\backslash')"
+---
+Ok(
+    [
+        "+-------------------------------------+---------+",
+        "| v                                   | matches |",
+        "+-------------------------------------+---------+",
+        "| Contains embedded single \\backslash | true    |",
+        "| Sacramento                          | false   |",
+        "| San Francisco                       | false   |",
+        "| San Jose                            | false   |",
+        "| Santa Clara                         | false   |",
+        "+-------------------------------------+---------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/visitors.rs
+++ b/crates/embucket-functions/src/tests/visitors.rs
@@ -113,15 +113,6 @@ fn test_functions_rewriter() -> DFResult<()> {
             "SELECT date_add(us, 100000, '2025-06-01')",
             "SELECT date_add('us', 100000, '2025-06-01')",
         ),
-        //regexp pattern and replacement (formating)
-        (
-            "SELECT REGEXP_INSTR('nevermore1, nevermore2, nevermore3.', 'nevermore\\d')",
-            "SELECT REGEXP_INSTR('nevermore1, nevermore2, nevermore3.', 'nevermore\\\\d')",
-        ),
-        (
-            "SELECT REGEXP_REPLACE('firstname middlename lastname', '(.*) (.*) (.*)', '\\3, \\1 \\2')",
-            "SELECT REGEXP_REPLACE('firstname middlename lastname', '(.*) (.*) (.*)', '$3, $1 $2')",
-        ),
         // to_char format replacements
         (
             "SELECT to_char(col::DATE, 'YYYYMMDD')",

--- a/crates/embucket-functions/src/tests/visitors.rs
+++ b/crates/embucket-functions/src/tests/visitors.rs
@@ -1,10 +1,50 @@
 use crate::visitors::{
     fetch_to_limit, functions_rewriter, inline_aliases_in_query, json_element, qualify_in_query,
-    select_expr_aliases, table_functions, table_functions_cte_relation,
+    rlike_regexp_expr_rewriter, select_expr_aliases, table_functions, table_functions_cte_relation,
 };
 use datafusion::prelude::SessionContext;
 use datafusion::sql::parser::Statement as DFStatement;
 use datafusion_common::Result as DFResult;
+
+#[test]
+fn test_rlike_regexp_expr_rewriter() -> DFResult<()> {
+    let state = SessionContext::new().state();
+    let cases = vec![
+        (
+            "SELECT 'nevermore' RLIKE 'never'",
+            "SELECT regexp_like('nevermore', 'never')",
+        ),
+        (
+            "SELECT 'nevermore' REGEXP 'never'",
+            "SELECT regexp_like('nevermore', 'never')",
+        ),
+        (
+            "SELECT 'nevermore' NOT RLIKE 'never'",
+            "SELECT NOT regexp_like('nevermore', 'never')",
+        ),
+        (
+            "SELECT 'nevermore' NOT REGEXP 'never'",
+            "SELECT NOT regexp_like('nevermore', 'never')",
+        ),
+        (
+            "SELECT column1 FROM VALUES ('San Francisco'), ('San Jose'), ('Santa Clara'), ('Sacramento') WHERE column1 RLIKE 'San* [fF].*'",
+            "SELECT column1 FROM (VALUES ('San Francisco'), ('San Jose'), ('Santa Clara'), ('Sacramento')) WHERE regexp_like(column1, 'San* [fF].*')",
+        ),
+        (
+            "SELECT column1 FROM VALUES ('San Francisco'), ('San Jose'), ('Santa Clara'), ('Sacramento') WHERE column1 NOT RLIKE 'San* [fF].*'",
+            "SELECT column1 FROM (VALUES ('San Francisco'), ('San Jose'), ('Santa Clara'), ('Sacramento')) WHERE NOT regexp_like(column1, 'San* [fF].*')",
+        ),
+    ];
+
+    for (input, expected) in cases {
+        let mut statement = state.sql_to_statement(input, "snowflake")?;
+        if let DFStatement::Statement(ref mut stmt) = statement {
+            rlike_regexp_expr_rewriter::visit(stmt);
+        }
+        assert_eq!(statement.to_string(), expected);
+    }
+    Ok(())
+}
 
 #[test]
 fn test_json_element() -> DFResult<()> {
@@ -71,6 +111,10 @@ fn test_functions_rewriter() -> DFResult<()> {
         (
             "SELECT date_add(us, 100000, '2025-06-01')",
             "SELECT date_add('us', 100000, '2025-06-01')",
+        ),
+        (
+            "SELECT REGEXP_INSTR('nevermore1, nevermore2, nevermore3.', 'nevermore\\d')",
+            "SELECT REGEXP_INSTR('nevermore1, nevermore2, nevermore3.', 'nevermore\\\\d')",
         ),
         // to_char format replacements
         (

--- a/crates/embucket-functions/src/tests/visitors.rs
+++ b/crates/embucket-functions/src/tests/visitors.rs
@@ -26,6 +26,7 @@ fn test_rlike_regexp_expr_rewriter() -> DFResult<()> {
             "SELECT 'nevermore' NOT REGEXP 'never'",
             "SELECT NOT regexp_like('nevermore', 'never')",
         ),
+        //the `values` will be put inside the `()`, not by the rewriter
         (
             "SELECT column1 FROM VALUES ('San Francisco'), ('San Jose'), ('Santa Clara'), ('Sacramento') WHERE column1 RLIKE 'San* [fF].*'",
             "SELECT column1 FROM (VALUES ('San Francisco'), ('San Jose'), ('Santa Clara'), ('Sacramento')) WHERE regexp_like(column1, 'San* [fF].*')",
@@ -112,9 +113,14 @@ fn test_functions_rewriter() -> DFResult<()> {
             "SELECT date_add(us, 100000, '2025-06-01')",
             "SELECT date_add('us', 100000, '2025-06-01')",
         ),
+        //regexp pattern and replacement (formating)
         (
             "SELECT REGEXP_INSTR('nevermore1, nevermore2, nevermore3.', 'nevermore\\d')",
             "SELECT REGEXP_INSTR('nevermore1, nevermore2, nevermore3.', 'nevermore\\\\d')",
+        ),
+        (
+            "SELECT REGEXP_REPLACE('firstname middlename lastname', '(.*) (.*) (.*)', '\\3, \\1 \\2')",
+            "SELECT REGEXP_REPLACE('firstname middlename lastname', '(.*) (.*) (.*)', '$3, $1 $2')",
         ),
         // to_char format replacements
         (

--- a/crates/embucket-functions/src/visitors/functions_rewriter.rs
+++ b/crates/embucket-functions/src/visitors/functions_rewriter.rs
@@ -38,7 +38,7 @@ impl VisitorMut for FunctionsRewriter {
                 //regexp_ udfs need `\\` in the pattern for regex, but when converting to the logical plan, it gets removed,
                 // the only way to make it stay is to make it `\\\\` or maybe use another type?
                 // Escaped blah blah String from postgres types may work, but differently
-                fn_name if fn_name.starts_with("regexp_") => {
+                fn_name if fn_name.starts_with("regexp_") || fn_name == "rlike" => {
                     if let FunctionArguments::List(FunctionArgumentList { args, .. }) = args
                         && let Some(FunctionArg::Unnamed(FunctionArgExpr::Expr(pattern))) =
                             args.get_mut(1)

--- a/crates/embucket-functions/src/visitors/mod.rs
+++ b/crates/embucket-functions/src/visitors/mod.rs
@@ -11,6 +11,7 @@ pub mod functions_rewriter;
 pub mod inline_aliases_in_query;
 pub mod json_element;
 pub mod qualify_in_query;
+pub mod rlike_regexp_expr_rewriter;
 pub mod select_expr_aliases;
 pub mod table_functions;
 pub mod table_functions_cte_relation;

--- a/crates/embucket-functions/src/visitors/rlike_regexp_expr_rewriter.rs
+++ b/crates/embucket-functions/src/visitors/rlike_regexp_expr_rewriter.rs
@@ -22,17 +22,17 @@ use std::ops::ControlFlow;
 /// - `regexp` if it is `RLIKE` or is it `REGEXP`, here it doesn't change anything, as it should.
 ///
 /// ## Example
-/// `SELECT column1 WHERE column1 RLIKE 'San* [fF].*' FROM VALUES
+/// `SELECT column1 FROM VALUES
 /// ('San Francisco'),
-///   ('San Jose'),
-///   ('Santa Clara'),
-///   ('Sacramento')`
+/// ('San Jose'),
+/// ('Santa Clara'),
+/// ('Sacramento') WHERE column1 RLIKE 'San* [fF].*'`
 /// Turns in to
-/// `SELECT column1 WHERE regexp_like(column1, 'San* [fF].*') FROM VALUES
+/// `SELECT column1 FROM VALUES
 /// ('San Francisco'),
-///   ('San Jose'),
-///   ('Santa Clara'),
-///   ('Sacramento')`
+/// ('San Jose'),
+/// ('Santa Clara'),
+/// ('Sacramento') WHERE regexp_like(column1, 'San* [fF].*')`
 /// And the result of both are the same.
 #[derive(Debug, Default)]
 pub struct RLikeRegexpExprRewriter;

--- a/crates/embucket-functions/src/visitors/rlike_regexp_expr_rewriter.rs
+++ b/crates/embucket-functions/src/visitors/rlike_regexp_expr_rewriter.rs
@@ -14,7 +14,8 @@ use std::ops::ControlFlow;
 ///
 /// ## Transformation
 /// When we get this AST node both of which are the same node, just with the `regexp` parament set to `true` or `false` respectively,
-/// we transform it to a `regexp_like` function call with the same parameters, which are:
+/// we transform it to a `regexp_like` function call (with the unary `[ NOT ]` operation if needed, ti will be made apparent further as to why)
+/// same parameters, which are:
 /// - `expr` (the inner expr) on which `RLIKE` operates, a column, another function call, a scalar, etc.
 /// - `negated` which is if this node has the `NOT` before it (it's not an unary operation here, it's part of the node itself).
 /// - `pattern` is the regex pattern on which we try to find the likeness from the `expr`

--- a/crates/embucket-functions/src/visitors/rlike_regexp_expr_rewriter.rs
+++ b/crates/embucket-functions/src/visitors/rlike_regexp_expr_rewriter.rs
@@ -1,0 +1,55 @@
+use datafusion::sql::sqlparser::ast::UnaryOperator;
+use datafusion_expr::sqlparser::ast::{
+    Expr, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments, Ident, ObjectName,
+    Statement, VisitorMut,
+};
+use datafusion_expr::sqlparser::ast::{Function, VisitMut};
+use std::ops::ControlFlow;
+
+#[derive(Debug, Default)]
+pub struct RLikeRegexpExprRewriter;
+
+impl VisitorMut for RLikeRegexpExprRewriter {
+    type Break = ();
+
+    fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
+        if let Expr::RLike {
+            expr: inner_expr,
+            negated,
+            pattern,
+            ..
+        } = expr
+        {
+            let function = Expr::Function(Function {
+                name: ObjectName::from(vec![Ident::new("regexp_like")]),
+                uses_odbc_syntax: false,
+                parameters: FunctionArguments::None,
+                args: FunctionArguments::List(FunctionArgumentList {
+                    duplicate_treatment: None,
+                    args: vec![
+                        FunctionArg::Unnamed(FunctionArgExpr::Expr(*inner_expr.clone())),
+                        FunctionArg::Unnamed(FunctionArgExpr::Expr(*pattern.clone())),
+                    ],
+                    clauses: vec![],
+                }),
+                filter: None,
+                null_treatment: None,
+                over: None,
+                within_group: vec![],
+            });
+            if *negated {
+                *expr = Expr::UnaryOp {
+                    op: UnaryOperator::Not,
+                    expr: Box::new(function),
+                };
+            } else {
+                *expr = function;
+            }
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+pub fn visit(stmt: &mut Statement) {
+    let _ = stmt.visit(&mut RLikeRegexpExprRewriter {});
+}

--- a/test/sql/bronze_scope/sql-reference-functions/Regular_expressions/regexp.slt
+++ b/test/sql/bronze_scope/sql-reference-functions/Regular_expressions/regexp.slt
@@ -20,7 +20,7 @@ WITH strings(v) AS (SELECT * FROM
     ('San Jose'),
     ('Santa Clara'),
     ('Sacramento'),
-    ('Contains embedded single \\backslash')
+    ('Contains embedded single \\\\backslash')
 )
 SELECT v, v REGEXP 'San\\b.*' AS matches
   FROM strings
@@ -39,7 +39,7 @@ WITH strings(v) AS (SELECT * FROM
     ('San Jose'),
     ('Santa Clara'),
     ('Sacramento'),
-    ('Contains embedded single \\backslash')
+    ('Contains embedded single \\\\backslash')
 )
 SELECT v, v REGEXP '.*\\s\\\\.*' AS matches
   FROM strings
@@ -58,7 +58,7 @@ WITH strings(v) AS (SELECT * FROM
     ('San Jose'),
     ('Santa Clara'),
     ('Sacramento'),
-    ('Contains embedded single \\backslash')
+    ('Contains embedded single \\\\backslash')
 )
 SELECT v, v REGEXP $$.*\s\\.*$$ AS MATCHES
   FROM strings


### PR DESCRIPTION
Closes #639 & #640

**:tada: Regular expression 100% compatibility**

- [x] `regexp` expr impl
- [x] `rlike` expr impl
- [x] Uses a simple AST Rewriter
- [x] Docs
- [x] Insta tests
- [x] SLT tests
- [x] Visitor unit tests

P.S. Small `rlike` function fix in the rewriter. Also, we'll need to fix the backslashes in the near future for all string expressions.

Reference:
- https://docs.snowflake.com/en/sql-reference/functions/rlike
- https://docs.snowflake.com/en/sql-reference/functions/regexp
