### PR TITLE
Convert REST catalog fields to lowercase

### DIFF
--- a/crates/api-iceberg-rest/src/error.rs
+++ b/crates/api-iceberg-rest/src/error.rs
@@ -92,6 +92,7 @@ impl IntoResponse for Error {
             | core_metastore::Error::SlateDB { .. }
             | core_metastore::Error::UtilSlateDB { .. }
             | core_metastore::Error::Iceberg { .. }
+            | core_metastore::Error::IcebergSpec { .. }
             | core_metastore::Error::Serde { .. }
             | core_metastore::Error::TableMetadataBuilder { .. }
             | core_metastore::Error::TableObjectStoreNotFound { .. }

--- a/crates/api-internal-rest/src/error.rs
+++ b/crates/api-internal-rest/src/error.rs
@@ -131,6 +131,7 @@ impl IntoResponse for Error {
                 | core_metastore::Error::SlateDB { .. }
                 | core_metastore::Error::UtilSlateDB { .. }
                 | core_metastore::Error::Iceberg { .. }
+                | core_metastore::Error::IcebergSpec { .. }
                 | core_metastore::Error::Serde { .. }
                 | core_metastore::Error::TableMetadataBuilder { .. }
                 | core_metastore::Error::TableObjectStoreNotFound { .. }

--- a/crates/core-metastore/src/error.rs
+++ b/crates/core-metastore/src/error.rs
@@ -229,4 +229,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Iceberg spec error: {error}"))]
+    IcebergSpec {
+        #[snafu(source)]
+        error: iceberg_rust_spec::error::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }


### PR DESCRIPTION
## Summary
- Adds field name conversion to lowercase when creating tables via REST catalog
- Implements schema field conversion for both table creation and updates
- Handles AddSchema table updates to ensure consistent lowercase field names

Closes #1510 