### PR TITLE
update iceberg-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e#35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e#35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e#35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e#35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.2.0",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e#35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "35dbf08c8c17be1a1a2d25da4ac4413fb1d24d1e" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }


### PR DESCRIPTION
Updates iceberg-rust to its most recent version. Solves issues when trying to update the schema or partition_spec with Spark.