### PR TITLE
Extend integration tests with embucket loader and restore full TPC-H benchmark

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -131,6 +131,8 @@ jobs:
           curl -O https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2025-01.parquet
           curl -O https://blobs.duckdb.org/data/tpch-sf1.db
           duckdb tpch-sf1.db -c "COPY customer TO customer.parquet (FORMAT 'PARQUET');COPY lineitem TO lineitem.parquet (FORMAT 'PARQUET');COPY nation TO nation.parquet (FORMAT 'PARQUET');COPY orders TO orders.parquet (FORMAT 'PARQUET');COPY part TO part.parquet (FORMAT 'PARQUET');COPY partsupp TO partsupp.parquet (FORMAT 'PARQUET');COPY region TO region.parquet (FORMAT 'PARQUET');COPY supplier TO supplier.parquet (FORMAT 'PARQUET');"
+          echo $PWD
+          ls -l
 
       - name: Run integration tests
         working-directory: ./test/integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,7 +85,7 @@ jobs:
             -e AWS_REGION=us-east-2 \
             -e S3_BUCKET=embucket \
             -e S3_ALLOW_HTTP=true \
-            -v ${{ github.workspace }}/test/integration:/app/data \
+            -v ${{ github.workspace }}/test/integration:/app/datasets \
             --network host \
             embucket/embucket
           echo "Starting Embucket server..."
@@ -122,7 +122,7 @@ jobs:
           echo "EMBUCKET_PASSWORD=embucket" >> $GITHUB_ENV
           echo "EMBUCKET_SCHEMA=public" >> $GITHUB_ENV
           echo "AWS_REGION=us-east-2" >> $GITHUB_ENV
-          echo "LOCAL_BASE_PATH=/app/data" >> $GITHUB_ENV
+          echo "LOCAL_BASE_PATH=/app/datasets" >> $GITHUB_ENV
 
       - name: Set up DuckDB
         uses: opt-nc/setup-duckdb-action@v1.0.14

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,7 +85,7 @@ jobs:
             -e AWS_REGION=us-east-2 \
             -e S3_BUCKET=embucket \
             -e S3_ALLOW_HTTP=true \
-            -v $(pwd)/test/integration:/app/data \
+            -v ${{ github.workspace }}/test/integration:/app/data \
             --network host \
             embucket/embucket
           echo "Starting Embucket server..."

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,6 +85,7 @@ jobs:
             -e AWS_REGION=us-east-2 \
             -e S3_BUCKET=embucket \
             -e S3_ALLOW_HTTP=true \
+            -v $(pwd)/test/integration:/app/data \
             --network host \
             embucket/embucket
           echo "Starting Embucket server..."
@@ -121,6 +122,7 @@ jobs:
           echo "EMBUCKET_PASSWORD=embucket" >> $GITHUB_ENV
           echo "EMBUCKET_SCHEMA=public" >> $GITHUB_ENV
           echo "AWS_REGION=us-east-2" >> $GITHUB_ENV
+          echo "LOCAL_BASE_PATH=/app/data" >> $GITHUB_ENV
 
       - name: Set up DuckDB
         uses: opt-nc/setup-duckdb-action@v1.0.14

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,9 @@ on:
       - Dockerfile
       - .github/workflows/**
       - test/integration/**
+  pull_request:
+    paths:
+      - test/integration/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -137,6 +137,13 @@ def embucket_bootstrap(embucket_exec):
         f"""CREATE EXTERNAL VOLUME IF NOT EXISTS {vol} STORAGE_LOCATIONS = ((NAME = '{vol}' STORAGE_PROVIDER = 's3' STORAGE_ENDPOINT = '{endpoint}' STORAGE_BASE_URL = '{bucket}' CREDENTIALS = (AWS_KEY_ID='{ak}' AWS_SECRET_KEY='{sk}' REGION='us-east-1')));
 """
     )
+    # Create local volume to enable COPY INTO for embucket
+    # create external volume if not exists local STORAGE_LOCATIONS = (( NAME = 'local' STORAGE_PROVIDER = 'FILE' STORAGE_BASE_URL = '/Users/ramp/vcs/embucket/test
+    #    /integration' ));
+    embucket_exec(
+        f"""CREATE EXTERNAL VOLUME IF NOT EXISTS local STORAGE_LOCATIONS = ((NAME = 'local' STORAGE_PROVIDER = 'FILE' STORAGE_BASE_URL = '{os.getcwd()}'));
+"""
+    )
     embucket_exec(f"CREATE DATABASE IF NOT EXISTS {db} EXTERNAL_VOLUME = '{vol}'")
     embucket_exec(f"CREATE SCHEMA IF NOT EXISTS {db}.{schema}")
 
@@ -372,7 +379,7 @@ class EmbucketEngine:
         ff = ", ".join(ff_parts)
 
         for uri in dataset.sources:
-            sql = f"COPY INTO {table_fqn} FROM '{uri}' FILE_FORMAT = ({ff})"
+            sql = f"COPY INTO {table_fqn} FROM 'file://{os.getcwd()}/{uri}' STORAGE_INTEGRATION = local FILE_FORMAT = ({ff})"
             self._exec(sql)
 
     def sql(

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -458,15 +458,21 @@ def spark_engine(spark) -> SparkEngine:
 
 # NYC Taxi Dataset Fixtures
 @pytest.fixture(scope="session")
-def embucket_nyc_taxi(embucket_engine, test_run_id):
-    return _load_dataset_fixture(
-        "nyc_taxi_yellow", embucket_engine, test_run_id, "embucket"
-    )
-
-
-@pytest.fixture(scope="session")
-def spark_nyc_taxi(spark_engine, test_run_id):
-    return _load_dataset_fixture("nyc_taxi_yellow", spark_engine, test_run_id, "spark")
+def nyc_taxi(request, test_run_id):
+    """Parameterized NYC taxi fixture that accepts engine type.
+    
+    Use with indirect=True parametrization:
+    @pytest.mark.parametrize('nyc_taxi', ['spark', 'embucket'], indirect=True)
+    """
+    engine_type = request.param
+    if engine_type == 'spark':
+        spark_engine = request.getfixturevalue('spark_engine')
+        return _load_dataset_fixture("nyc_taxi_yellow", spark_engine, test_run_id, "spark")
+    elif engine_type == 'embucket':
+        embucket_engine = request.getfixturevalue('embucket_engine')
+        return _load_dataset_fixture("nyc_taxi_yellow", embucket_engine, test_run_id, "embucket")
+    else:
+        raise ValueError(f"Unknown engine type: {engine_type}. Use 'spark' or 'embucket'.")
 
 
 # TPC-H Dataset Fixtures

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -477,142 +477,47 @@ def nyc_taxi(request, test_run_id):
 
 # TPC-H Dataset Fixtures
 @pytest.fixture(scope="session")
-def embucket_tpch_lineitem(embucket_engine, test_run_id):
-    return _load_dataset_fixture(
-        "tpch_lineitem", embucket_engine, test_run_id, "embucket"
-    )
+def tpch_table(request, test_run_id):
+    """Parameterized TPC-H table fixture that accepts (table_name, engine_type) tuple.
+    
+    Use with indirect=True parametrization:
+    @pytest.mark.parametrize('tpch_table', [('lineitem', 'spark'), ('orders', 'embucket')], indirect=True)
+    """
+    table_name, engine_type = request.param
+    dataset_name = f"tpch_{table_name}"
+    
+    if engine_type == 'spark':
+        spark_engine = request.getfixturevalue('spark_engine')
+        return _load_dataset_fixture(dataset_name, spark_engine, test_run_id, "spark")
+    elif engine_type == 'embucket':
+        embucket_engine = request.getfixturevalue('embucket_engine')
+        return _load_dataset_fixture(dataset_name, embucket_engine, test_run_id, "embucket")
+    else:
+        raise ValueError(f"Unknown engine type: {engine_type}. Use 'spark' or 'embucket'.")
 
 
 @pytest.fixture(scope="session")
-def embucket_tpch_orders(embucket_engine, test_run_id):
-    return _load_dataset_fixture(
-        "tpch_orders", embucket_engine, test_run_id, "embucket"
-    )
-
-
-@pytest.fixture(scope="session")
-def spark_tpch_lineitem(spark_engine, test_run_id):
-    return _load_dataset_fixture("tpch_lineitem", spark_engine, test_run_id, "spark")
-
-
-@pytest.fixture(scope="session")
-def spark_tpch_orders(spark_engine, test_run_id):
-    return _load_dataset_fixture("tpch_orders", spark_engine, test_run_id, "spark")
-
-
-@pytest.fixture(scope="session")
-def embucket_tpch_part(embucket_engine, test_run_id):
-    return _load_dataset_fixture("tpch_part", embucket_engine, test_run_id, "embucket")
-
-
-@pytest.fixture(scope="session")
-def spark_tpch_part(spark_engine, test_run_id):
-    return _load_dataset_fixture("tpch_part", spark_engine, test_run_id, "spark")
-
-
-@pytest.fixture(scope="session")
-def embucket_tpch_supplier(embucket_engine, test_run_id):
-    return _load_dataset_fixture(
-        "tpch_supplier", embucket_engine, test_run_id, "embucket"
-    )
-
-
-@pytest.fixture(scope="session")
-def spark_tpch_supplier(spark_engine, test_run_id):
-    return _load_dataset_fixture("tpch_supplier", spark_engine, test_run_id, "spark")
-
-
-@pytest.fixture(scope="session")
-def embucket_tpch_customer(embucket_engine, test_run_id):
-    return _load_dataset_fixture(
-        "tpch_customer", embucket_engine, test_run_id, "embucket"
-    )
-
-
-@pytest.fixture(scope="session")
-def spark_tpch_customer(spark_engine, test_run_id):
-    return _load_dataset_fixture("tpch_customer", spark_engine, test_run_id, "spark")
-
-
-@pytest.fixture(scope="session")
-def embucket_tpch_nation(embucket_engine, test_run_id):
-    return _load_dataset_fixture(
-        "tpch_nation", embucket_engine, test_run_id, "embucket"
-    )
-
-
-@pytest.fixture(scope="session")
-def spark_tpch_nation(spark_engine, test_run_id):
-    return _load_dataset_fixture("tpch_nation", spark_engine, test_run_id, "spark")
-
-
-@pytest.fixture(scope="session")
-def embucket_tpch_region(embucket_engine, test_run_id):
-    return _load_dataset_fixture(
-        "tpch_region", embucket_engine, test_run_id, "embucket"
-    )
-
-
-@pytest.fixture(scope="session")
-def spark_tpch_region(spark_engine, test_run_id):
-    return _load_dataset_fixture("tpch_region", spark_engine, test_run_id, "spark")
-
-
-@pytest.fixture(scope="session")
-def embucket_tpch_partsupp(embucket_engine, test_run_id):
-    return _load_dataset_fixture(
-        "tpch_partsupp", embucket_engine, test_run_id, "embucket"
-    )
-
-
-@pytest.fixture(scope="session")
-def spark_tpch_partsupp(spark_engine, test_run_id):
-    return _load_dataset_fixture("tpch_partsupp", spark_engine, test_run_id, "spark")
-
-
-@pytest.fixture(scope="session")
-def embucket_tpch_full(
-    embucket_tpch_lineitem,
-    embucket_tpch_orders,
-    embucket_tpch_part,
-    embucket_tpch_supplier,
-    embucket_tpch_customer,
-    embucket_tpch_nation,
-    embucket_tpch_region,
-    embucket_tpch_partsupp,
-):
-    """Complete TPC-H dataset with all 8 tables for Embucket engine."""
-    return {
-        "lineitem": embucket_tpch_lineitem,
-        "orders": embucket_tpch_orders,
-        "part": embucket_tpch_part,
-        "supplier": embucket_tpch_supplier,
-        "customer": embucket_tpch_customer,
-        "nation": embucket_tpch_nation,
-        "region": embucket_tpch_region,
-        "partsupp": embucket_tpch_partsupp,
-    }
-
-
-@pytest.fixture(scope="session")
-def spark_tpch_full(
-    spark_tpch_lineitem,
-    spark_tpch_orders,
-    spark_tpch_part,
-    spark_tpch_supplier,
-    spark_tpch_customer,
-    spark_tpch_nation,
-    spark_tpch_region,
-    spark_tpch_partsupp,
-):
-    """Complete TPC-H dataset with all 8 tables for Spark engine."""
-    return {
-        "lineitem": spark_tpch_lineitem,
-        "orders": spark_tpch_orders,
-        "part": spark_tpch_part,
-        "supplier": spark_tpch_supplier,
-        "customer": spark_tpch_customer,
-        "nation": spark_tpch_nation,
-        "region": spark_tpch_region,
-        "partsupp": spark_tpch_partsupp,
-    }
+def tpch_full(request, test_run_id):
+    """Parameterized TPC-H complete dataset fixture that accepts engine type.
+    
+    Loads all 8 TPC-H tables with the specified engine and returns as dict.
+    Use with indirect=True parametrization:
+    @pytest.mark.parametrize('tpch_full', ['spark', 'embucket'], indirect=True)
+    """
+    engine_type = request.param
+    tables = ['lineitem', 'orders', 'part', 'supplier', 'customer', 'nation', 'region', 'partsupp']
+    
+    if engine_type == 'spark':
+        engine = request.getfixturevalue('spark_engine')
+    elif engine_type == 'embucket':
+        engine = request.getfixturevalue('embucket_engine')
+    else:
+        raise ValueError(f"Unknown engine type: {engine_type}. Use 'spark' or 'embucket'.")
+    
+    # Load all tables with the specified engine
+    loaded_tables = {}
+    for table in tables:
+        dataset_name = f"tpch_{table}"
+        loaded_tables[table] = _load_dataset_fixture(dataset_name, engine, test_run_id, engine_type)
+    
+    return loaded_tables

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -131,6 +131,7 @@ def embucket_bootstrap(embucket_exec):
     ak = _get("S3_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
     sk = _get("S3_SECRET_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
     bucket = _get("S3_BUCKET", "embucket")
+    local_base_path = _get("LOCAL_BASE_PATH", os.getcwd())
 
     # Create external volume if we have enough info
     embucket_exec(
@@ -141,7 +142,7 @@ def embucket_bootstrap(embucket_exec):
     # create external volume if not exists local STORAGE_LOCATIONS = (( NAME = 'local' STORAGE_PROVIDER = 'FILE' STORAGE_BASE_URL = '/Users/ramp/vcs/embucket/test
     #    /integration' ));
     embucket_exec(
-        f"""CREATE EXTERNAL VOLUME IF NOT EXISTS local STORAGE_LOCATIONS = ((NAME = 'local' STORAGE_PROVIDER = 'FILE' STORAGE_BASE_URL = '{os.getcwd()}'));
+        f"""CREATE EXTERNAL VOLUME IF NOT EXISTS local STORAGE_LOCATIONS = ((NAME = 'local' STORAGE_PROVIDER = 'FILE' STORAGE_BASE_URL = '{local_base_path}'));
 """
     )
     embucket_exec(f"CREATE DATABASE IF NOT EXISTS {db} EXTERNAL_VOLUME = '{vol}'")
@@ -379,7 +380,8 @@ class EmbucketEngine:
         ff = ", ".join(ff_parts)
 
         for uri in dataset.sources:
-            sql = f"COPY INTO {table_fqn} FROM 'file://{os.getcwd()}/{uri}' STORAGE_INTEGRATION = local FILE_FORMAT = ({ff})"
+            local_base_path = _get("LOCAL_BASE_PATH", os.getcwd())
+            sql = f"COPY INTO {table_fqn} FROM 'file://{local_base_path}/{uri}' STORAGE_INTEGRATION = local FILE_FORMAT = ({ff})"
             self._exec(sql)
 
     def sql(

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -460,64 +460,73 @@ def spark_engine(spark) -> SparkEngine:
 @pytest.fixture(scope="session")
 def nyc_taxi(request, test_run_id):
     """Parameterized NYC taxi fixture that accepts engine type.
-    
+
     Use with indirect=True parametrization:
     @pytest.mark.parametrize('nyc_taxi', ['spark', 'embucket'], indirect=True)
     """
     engine_type = request.param
-    if engine_type == 'spark':
-        spark_engine = request.getfixturevalue('spark_engine')
-        return _load_dataset_fixture("nyc_taxi_yellow", spark_engine, test_run_id, "spark")
-    elif engine_type == 'embucket':
-        embucket_engine = request.getfixturevalue('embucket_engine')
-        return _load_dataset_fixture("nyc_taxi_yellow", embucket_engine, test_run_id, "embucket")
-    else:
-        raise ValueError(f"Unknown engine type: {engine_type}. Use 'spark' or 'embucket'.")
+    if engine_type not in ["spark", "embucket"]:
+        raise ValueError(
+            f"Unknown engine type: {engine_type}. Use 'spark' or 'embucket'."
+        )
+
+    engine = request.getfixturevalue(f"{engine_type}_engine")
+    return _load_dataset_fixture("nyc_taxi_yellow", engine, test_run_id, engine_type)
 
 
 # TPC-H Dataset Fixtures
 @pytest.fixture(scope="session")
 def tpch_table(request, test_run_id):
     """Parameterized TPC-H table fixture that accepts (table_name, engine_type) tuple.
-    
+
     Use with indirect=True parametrization:
     @pytest.mark.parametrize('tpch_table', [('lineitem', 'spark'), ('orders', 'embucket')], indirect=True)
     """
     table_name, engine_type = request.param
     dataset_name = f"tpch_{table_name}"
-    
-    if engine_type == 'spark':
-        spark_engine = request.getfixturevalue('spark_engine')
-        return _load_dataset_fixture(dataset_name, spark_engine, test_run_id, "spark")
-    elif engine_type == 'embucket':
-        embucket_engine = request.getfixturevalue('embucket_engine')
-        return _load_dataset_fixture(dataset_name, embucket_engine, test_run_id, "embucket")
-    else:
-        raise ValueError(f"Unknown engine type: {engine_type}. Use 'spark' or 'embucket'.")
+
+    if engine_type not in ["spark", "embucket"]:
+        raise ValueError(
+            f"Unknown engine type: {engine_type}. Use 'spark' or 'embucket'."
+        )
+
+    engine = request.getfixturevalue(f"{engine_type}_engine")
+    return _load_dataset_fixture(dataset_name, engine, test_run_id, engine_type)
 
 
 @pytest.fixture(scope="session")
 def tpch_full(request, test_run_id):
     """Parameterized TPC-H complete dataset fixture that accepts engine type.
-    
+
     Loads all 8 TPC-H tables with the specified engine and returns as dict.
     Use with indirect=True parametrization:
     @pytest.mark.parametrize('tpch_full', ['spark', 'embucket'], indirect=True)
     """
     engine_type = request.param
-    tables = ['lineitem', 'orders', 'part', 'supplier', 'customer', 'nation', 'region', 'partsupp']
-    
-    if engine_type == 'spark':
-        engine = request.getfixturevalue('spark_engine')
-    elif engine_type == 'embucket':
-        engine = request.getfixturevalue('embucket_engine')
-    else:
-        raise ValueError(f"Unknown engine type: {engine_type}. Use 'spark' or 'embucket'.")
-    
+    tables = [
+        "lineitem",
+        "orders",
+        "part",
+        "supplier",
+        "customer",
+        "nation",
+        "region",
+        "partsupp",
+    ]
+
+    if engine_type not in ["spark", "embucket"]:
+        raise ValueError(
+            f"Unknown engine type: {engine_type}. Use 'spark' or 'embucket'."
+        )
+
+    engine = request.getfixturevalue(f"{engine_type}_engine")
+
     # Load all tables with the specified engine
     loaded_tables = {}
     for table in tables:
         dataset_name = f"tpch_{table}"
-        loaded_tables[table] = _load_dataset_fixture(dataset_name, engine, test_run_id, engine_type)
-    
+        loaded_tables[table] = _load_dataset_fixture(
+            dataset_name, engine, test_run_id, engine_type
+        )
+
     return loaded_tables

--- a/test/integration/sql/nyc_taxi/yellow_embucket.sql
+++ b/test/integration/sql/nyc_taxi/yellow_embucket.sql
@@ -1,11 +1,11 @@
 -- Snowflake-like DDL for NYC Taxi Yellow Trips (2019-era schema)
 CREATE OR REPLACE TABLE {{TABLE_FQN}} (
-  vendor_id INT,
+  vendorid INT,
   tpep_pickup_datetime TIMESTAMP,
   tpep_dropoff_datetime TIMESTAMP,
   passenger_count INT,
   trip_distance DOUBLE,
-  ratecode_id INT,
+  ratecodeid INT,
   store_and_fwd_flag VARCHAR(1),
   pulocationid INT,
   dolocationid INT,

--- a/test/integration/sql/nyc_taxi/yellow_spark.sql
+++ b/test/integration/sql/nyc_taxi/yellow_spark.sql
@@ -1,11 +1,11 @@
 -- Spark SQL DDL for NYC Taxi Yellow Trips (Iceberg table)
 CREATE TABLE {{TABLE_FQN}} (
-  vendor_id INT,
+  vendorid INT,
   tpep_pickup_datetime TIMESTAMP,
   tpep_dropoff_datetime TIMESTAMP,
   passenger_count INT,
   trip_distance DOUBLE,
-  ratecode_id INT,
+  ratecodeid INT,
   store_and_fwd_flag STRING,
   pulocationid INT,
   dolocationid INT,

--- a/test/integration/test_unified_integration.py
+++ b/test/integration/test_unified_integration.py
@@ -94,6 +94,7 @@ def test_nyc_taxi(
 
 
 # TPC-H Benchmark Tests - Real TPC-H queries using multiple tables
+@pytest.mark.parametrize('tpch_full', ['spark', 'embucket'], indirect=True)
 @pytest.mark.parametrize(
     "query_id,query_sql",
     [
@@ -201,9 +202,9 @@ def test_nyc_taxi(
     ],
 )
 def test_tpch_benchmark_queries(
-    spark_engine, embucket_engine, spark_tpch_full, query_id, query_sql
+    spark_engine, embucket_engine, tpch_full, query_id, query_sql
 ):
-    """Test actual TPC-H benchmark queries using complete dataset with all tables."""
+    """Test actual TPC-H benchmark queries using complete dataset with all tables and different loaders."""
     _run_multi_table_test(
-        spark_engine, embucket_engine, spark_tpch_full, query_id, query_sql
+        spark_engine, embucket_engine, tpch_full, query_id, query_sql
     )

--- a/test/integration/test_unified_integration.py
+++ b/test/integration/test_unified_integration.py
@@ -50,13 +50,14 @@ def _run_multi_table_test(
     assert len(embucket_result) > 0
 
 
+@pytest.mark.parametrize('nyc_taxi', ['spark', 'embucket'], indirect=True)
 @pytest.mark.parametrize(
     "query_id,query_sql",
     [
         ("q_count", "SELECT COUNT(*) FROM {{TABLE:table}}"),
         (
             "q_vendor_counts",
-            "SELECT vendor_id, COUNT(*) AS c FROM {{TABLE:table}} GROUP BY vendor_id",
+            "SELECT vendorid, COUNT(*) AS c FROM {{TABLE:table}} GROUP BY vendorid",
         ),
         (
             "q_payment_amounts",
@@ -68,7 +69,7 @@ def _run_multi_table_test(
         ),
         (
             "q_vendor_avg_distance",
-            "SELECT vendor_id, AVG(trip_distance) AS avg_dist FROM {{TABLE:table}} GROUP BY vendor_id",
+            "SELECT vendorid, AVG(trip_distance) AS avg_dist FROM {{TABLE:table}} GROUP BY vendorid",
         ),
     ],
     ids=[
@@ -82,13 +83,13 @@ def _run_multi_table_test(
 def test_nyc_taxi(
     spark_engine,
     embucket_engine,
-    spark_nyc_taxi,
+    nyc_taxi,
     query_id,
     query_sql,
 ):
-    """Test NYC Taxi dataset with taxi-specific queries."""
+    """Test NYC Taxi dataset with taxi-specific queries using different loaders."""
     _run_cross_engine_test(
-        spark_engine, embucket_engine, spark_nyc_taxi, query_id, query_sql
+        spark_engine, embucket_engine, nyc_taxi, query_id, query_sql
     )
 
 

--- a/test/integration/test_unified_integration.py
+++ b/test/integration/test_unified_integration.py
@@ -1,5 +1,6 @@
 import pytest
 from conftest import compare_result_sets
+from tpch_queries import TPCH_QUERIES
 
 
 def _run_cross_engine_test(
@@ -95,112 +96,7 @@ def test_nyc_taxi(
 
 # TPC-H Benchmark Tests - Real TPC-H queries using multiple tables
 @pytest.mark.parametrize('tpch_full', ['spark', 'embucket'], indirect=True)
-@pytest.mark.parametrize(
-    "query_id,query_sql",
-    [
-        (
-            "tpch_q3_shipping_priority",
-            """SELECT
-                l.L_ORDERKEY,
-                SUM(l.L_EXTENDEDPRICE * (1 - l.L_DISCOUNT)) AS revenue,
-                o.O_ORDERDATE,
-                o.O_SHIPPRIORITY
-            FROM
-                {{TABLE:customer}} c,
-                {{TABLE:orders}} o,
-                {{TABLE:lineitem}} l
-            WHERE
-                c.C_MKTSEGMENT = 'BUILDING'
-                AND c.C_CUSTKEY = o.O_CUSTKEY
-                AND l.L_ORDERKEY = o.O_ORDERKEY
-                AND o.O_ORDERDATE < CAST('1995-03-15' AS DATE)
-                AND l.L_SHIPDATE > CAST('1995-03-15' AS DATE)
-            GROUP BY
-                l.L_ORDERKEY,
-                o.O_ORDERDATE,
-                o.O_SHIPPRIORITY
-            ORDER BY
-                revenue DESC,
-                o.O_ORDERDATE
-            LIMIT 10""",
-        ),
-        (
-            "tpch_q5_local_supplier_volume",
-            """SELECT
-                n.N_NAME,
-                SUM(l.L_EXTENDEDPRICE * (1 - l.L_DISCOUNT)) AS revenue
-            FROM
-                {{TABLE:customer}} c,
-                {{TABLE:orders}} o,
-                {{TABLE:lineitem}} l,
-                {{TABLE:supplier}} s,
-                {{TABLE:nation}} n,
-                {{TABLE:region}} r
-            WHERE
-                c.C_CUSTKEY = o.O_CUSTKEY
-                AND l.L_ORDERKEY = o.O_ORDERKEY
-                AND l.L_SUPPKEY = s.S_SUPPKEY
-                AND c.C_NATIONKEY = s.S_NATIONKEY
-                AND s.S_NATIONKEY = n.N_NATIONKEY
-                AND n.N_REGIONKEY = r.R_REGIONKEY
-                AND r.R_NAME = 'ASIA'
-                AND o.O_ORDERDATE >= CAST('1994-01-01' AS DATE)
-                AND o.O_ORDERDATE < CAST('1995-01-01' AS DATE)
-            GROUP BY
-                n.N_NAME
-            ORDER BY
-                revenue DESC
-            LIMIT 10""",
-        ),
-        (
-            "tpch_q8_national_market_share",
-            """SELECT
-                o_year,
-                SUM(CASE
-                    WHEN nation = 'BRAZIL' THEN volume
-                    ELSE 0
-                END) / SUM(volume) AS mkt_share
-            FROM
-                (
-                    SELECT
-                        YEAR(o.O_ORDERDATE) AS o_year,
-                        l.L_EXTENDEDPRICE * (1 - l.L_DISCOUNT) AS volume,
-                        n2.N_NAME AS nation
-                    FROM
-                        {{TABLE:part}} p,
-                        {{TABLE:supplier}} s,
-                        {{TABLE:lineitem}} l,
-                        {{TABLE:orders}} o,
-                        {{TABLE:customer}} c,
-                        {{TABLE:nation}} n1,
-                        {{TABLE:nation}} n2,
-                        {{TABLE:region}} r
-                    WHERE
-                        p.P_PARTKEY = l.L_PARTKEY
-                        AND s.S_SUPPKEY = l.L_SUPPKEY
-                        AND l.L_ORDERKEY = o.O_ORDERKEY
-                        AND o.O_CUSTKEY = c.C_CUSTKEY
-                        AND c.C_NATIONKEY = n1.N_NATIONKEY
-                        AND n1.N_REGIONKEY = r.R_REGIONKEY
-                        AND r.R_NAME = 'AMERICA'
-                        AND s.S_NATIONKEY = n2.N_NATIONKEY
-                        AND o.O_ORDERDATE >= CAST('1995-01-01' AS DATE)
-                        AND o.O_ORDERDATE <= CAST('1996-12-31' AS DATE)
-                        AND p.P_TYPE = 'ECONOMY ANODIZED STEEL'
-                ) AS all_nations
-            GROUP BY
-                o_year
-            ORDER BY
-                o_year
-            LIMIT 10""",
-        ),
-    ],
-    ids=[
-        "tpch_q3_shipping_priority",
-        "tpch_q5_local_supplier_volume",
-        "tpch_q8_national_market_share",
-    ],
-)
+@pytest.mark.parametrize("query_id,query_sql", TPCH_QUERIES, ids=[query_id for query_id, _ in TPCH_QUERIES])
 def test_tpch_benchmark_queries(
     spark_engine, embucket_engine, tpch_full, query_id, query_sql
 ):

--- a/test/integration/tpch_queries.py
+++ b/test/integration/tpch_queries.py
@@ -1,0 +1,746 @@
+"""TPC-H benchmark queries for integration testing.
+
+All 22 standard TPC-H queries with table references converted to 
+{{TABLE:tablename}} placeholders for our test framework.
+"""
+
+TPCH_QUERIES = [
+    (
+        "tpch-q1",
+        """
+        SELECT
+            l_returnflag,
+            l_linestatus,
+            SUM(l_quantity) AS sum_qty,
+            SUM(l_extendedprice) AS sum_base_price,
+            SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+            SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+            AVG(l_quantity) AS avg_qty,
+            AVG(l_extendedprice) AS avg_price,
+            AVG(l_discount) AS avg_disc,
+            COUNT(*) AS count_order
+        FROM
+            {{TABLE:lineitem}}
+        WHERE
+            l_shipdate <= DATEADD(day, -116, '1998-12-01')
+        GROUP BY
+            l_returnflag,
+            l_linestatus
+        ORDER BY
+            l_returnflag,
+            l_linestatus;
+        """
+    ),
+    (
+        "tpch-q2",
+        """
+        SELECT
+            s_acctbal,
+            s_name,
+            n_name,
+            p_partkey,
+            p_mfgr,
+            s_address,
+            s_phone,
+            s_comment
+        FROM
+            {{TABLE:part}},
+            {{TABLE:supplier}},
+            {{TABLE:partsupp}},
+            {{TABLE:nation}},
+            {{TABLE:region}}
+        WHERE
+            p_partkey = ps_partkey
+          AND s_suppkey = ps_suppkey
+          AND p_size = 15
+          AND p_type LIKE '%BRASS'
+          AND s_nationkey = n_nationkey
+          AND n_regionkey = r_regionkey
+          AND r_name = 'EUROPE'
+          AND ps_supplycost = (
+            SELECT MIN(ps_supplycost)
+            FROM
+                {{TABLE:partsupp}},
+                {{TABLE:supplier}},
+                {{TABLE:nation}},
+                {{TABLE:region}}
+            WHERE
+                p_partkey = ps_partkey
+              AND s_suppkey = ps_suppkey
+              AND s_nationkey = n_nationkey
+              AND n_regionkey = r_regionkey
+              AND r_name = 'EUROPE'
+        )
+        ORDER BY
+            s_acctbal DESC,
+            n_name,
+            s_name,
+            p_partkey
+            LIMIT 100;
+        """
+    ),
+    (
+        "tpch-q3",
+        """
+        SELECT
+            l_orderkey,
+            SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+            o_orderdate,
+            o_shippriority
+        FROM
+            {{TABLE:customer}},
+            {{TABLE:orders}},
+            {{TABLE:lineitem}}
+        WHERE
+            c_mktsegment = 'BUILDING'
+          AND c_custkey = o_custkey
+          AND l_orderkey = o_orderkey
+          AND o_orderdate < DATE '1995-03-15'
+          AND l_shipdate > DATE '1995-03-15'
+        GROUP BY
+            l_orderkey,
+            o_orderdate,
+            o_shippriority
+        ORDER BY
+            revenue DESC,
+            o_orderdate
+            LIMIT 10;
+        """
+    ),
+    (
+        "tpch-q4",
+        """
+        SELECT
+            o_orderpriority,
+            COUNT(*) AS order_count
+        FROM
+            {{TABLE:orders}}
+        WHERE
+            o_orderdate >= DATE '1993-07-01'
+          AND o_orderdate < DATEADD(month, 3, '1993-07-01')
+          AND EXISTS (
+            SELECT
+                *
+            FROM
+                {{TABLE:lineitem}}
+            WHERE
+                l_orderkey = o_orderkey
+              AND l_commitdate < l_receiptdate
+        )
+        GROUP BY
+            o_orderpriority
+        ORDER BY
+            o_orderpriority;
+        """
+    ),
+    (
+        "tpch-q5",
+        """
+        SELECT
+            n_name,
+            SUM(l_extendedprice * (1 - l_discount)) AS revenue
+        FROM
+            {{TABLE:customer}},
+            {{TABLE:orders}},
+            {{TABLE:lineitem}},
+            {{TABLE:supplier}},
+            {{TABLE:nation}},
+            {{TABLE:region}}
+        WHERE
+            c_custkey = o_custkey
+          AND l_orderkey = o_orderkey
+          AND l_suppkey = s_suppkey
+          AND c_nationkey = s_nationkey
+          AND s_nationkey = n_nationkey
+          AND n_regionkey = r_regionkey
+          AND r_name = 'ASIA'
+          AND o_orderdate >= DATE '1994-01-01'
+          AND o_orderdate < DATEADD(year, 1, '1994-01-01')
+        GROUP BY
+            n_name
+        ORDER BY
+            revenue DESC;
+        """
+    ),
+    (
+        "tpch-q6",
+        """
+        SELECT
+            SUM(l_extendedprice * l_discount) AS revenue
+        FROM
+            {{TABLE:lineitem}}
+        WHERE
+            l_shipdate >= DATE '1994-01-01'
+          AND l_shipdate < DATEADD(year, 1, '1994-01-01')
+          AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
+          AND l_quantity < 24;
+        """
+    ),
+    (
+        "tpch-q7",
+        """
+        SELECT
+            supp_nation,
+            cust_nation,
+            l_year,
+            SUM(volume) AS revenue
+        FROM
+            (
+                SELECT
+                    n1.n_name AS supp_nation,
+                    n2.n_name AS cust_nation,
+                    EXTRACT(year FROM l_shipdate) AS l_year,
+                    l_extendedprice * (1 - l_discount) AS volume
+                FROM
+                    {{TABLE:supplier}},
+                    {{TABLE:lineitem}},
+                    {{TABLE:orders}},
+                    {{TABLE:customer}},
+                    {{TABLE:nation}} n1,
+                    {{TABLE:nation}} n2
+                WHERE
+                    s_suppkey = l_suppkey
+                  AND o_orderkey = l_orderkey
+                  AND c_custkey = o_custkey
+                  AND s_nationkey = n1.n_nationkey
+                  AND c_nationkey = n2.n_nationkey
+                  AND (
+                    (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+                        OR (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
+                    )
+                  AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+            ) AS shipping
+        GROUP BY
+            supp_nation,
+            cust_nation,
+            l_year
+        ORDER BY
+            supp_nation,
+            cust_nation,
+            l_year;
+        """
+    ),
+    (
+        "tpch-q8",
+        """
+        SELECT
+            o_year,
+            SUM(CASE
+                    WHEN nation = 'BRAZIL' THEN volume
+                    ELSE 0
+                END) / SUM(volume) AS mkt_share
+        FROM
+            (
+                SELECT
+                    EXTRACT(year FROM o_orderdate) AS o_year,
+                    l_extendedprice * (1 - l_discount) AS volume,
+                    n2.n_name AS nation
+                FROM
+                    {{TABLE:part}},
+                    {{TABLE:supplier}},
+                    {{TABLE:lineitem}},
+                    {{TABLE:orders}},
+                    {{TABLE:customer}},
+                    {{TABLE:nation}} n1,
+                    {{TABLE:nation}} n2,
+                    {{TABLE:region}}
+                WHERE
+                    p_partkey = l_partkey
+                  AND s_suppkey = l_suppkey
+                  AND l_orderkey = o_orderkey
+                  AND o_custkey = c_custkey
+                  AND c_nationkey = n1.n_nationkey
+                  AND n1.n_regionkey = r_regionkey
+                  AND r_name = 'AMERICA'
+                  AND s_nationkey = n2.n_nationkey
+                  AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+                  AND p_type = 'ECONOMY ANODIZED STEEL'
+            ) AS all_nations
+        GROUP BY
+            o_year
+        ORDER BY
+            o_year;
+        """
+    ),
+    (
+        "tpch-q9",
+        """
+        SELECT
+            nation,
+            o_year,
+            SUM(amount) AS sum_profit
+        FROM
+            (
+                SELECT
+                    n_name AS nation,
+                    EXTRACT(year FROM o_orderdate) AS o_year,
+                    l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+                FROM
+                    {{TABLE:part}},
+                    {{TABLE:supplier}},
+                    {{TABLE:lineitem}},
+                    {{TABLE:partsupp}},
+                    {{TABLE:orders}},
+                    {{TABLE:nation}}
+                WHERE
+                    s_suppkey = l_suppkey
+                  AND ps_suppkey = l_suppkey
+                  AND ps_partkey = l_partkey
+                  AND p_partkey = l_partkey
+                  AND o_orderkey = l_orderkey
+                  AND s_nationkey = n_nationkey
+                  AND p_name LIKE '%green%'
+            ) AS profit
+        GROUP BY
+            nation,
+            o_year
+        ORDER BY
+            nation,
+            o_year DESC;
+        """
+    ),
+    (
+        "tpch-q10",
+        """
+        SELECT
+            ps_partkey,
+            SUM(ps_supplycost * ps_availqty) AS value
+        FROM
+            {{TABLE:partsupp}},
+            {{TABLE:supplier}},
+            {{TABLE:nation}}
+        WHERE
+            ps_suppkey = s_suppkey
+          AND s_nationkey = n_nationkey
+          AND n_name = 'GERMANY'
+        GROUP BY
+            ps_partkey
+        HAVING
+            SUM(ps_supplycost * ps_availqty) > (
+            SELECT
+            SUM(ps_supplycost * ps_availqty) * 0.0001
+            FROM
+            {{TABLE:partsupp}},
+            {{TABLE:supplier}},
+            {{TABLE:nation}}
+            WHERE
+            ps_suppkey = s_suppkey
+           AND s_nationkey = n_nationkey
+           AND n_name = 'GERMANY'
+            )
+        ORDER BY value DESC;
+        """
+    ),
+    (
+        "tpch-q11",
+        """
+        SELECT
+            l_shipmode,
+            SUM(CASE
+                    WHEN o_orderpriority = '1-URGENT'
+                        OR o_orderpriority = '2-HIGH'
+                        THEN 1
+                    ELSE 0
+                END) AS high_line_count,
+            SUM(CASE
+                    WHEN o_orderpriority <> '1-URGENT'
+                        AND o_orderpriority <> '2-HIGH'
+                        THEN 1
+                    ELSE 0
+                END) AS low_line_count
+        FROM
+            {{TABLE:orders}},
+            {{TABLE:lineitem}}
+        WHERE
+            o_orderkey = l_orderkey
+          AND l_shipmode IN ('MAIL', 'SHIP')
+          AND l_commitdate < l_receiptdate
+          AND l_shipdate < l_commitdate
+          AND l_receiptdate >= DATE '1994-01-01'
+          AND o_orderdate < DATEADD(year, 1, '1994-01-01')
+        GROUP BY
+            l_shipmode
+        ORDER BY
+            l_shipmode;
+        """
+    ),
+    (
+        "tpch-q12",
+        """
+        SELECT
+            c_count,
+            COUNT(*) AS custdist
+        FROM
+            (
+                SELECT
+                    c_custkey,
+                    COUNT(o_orderkey)
+                FROM
+                    {{TABLE:customer}} LEFT OUTER JOIN {{TABLE:orders}}
+                                             ON c_custkey = o_custkey
+                                                 AND o_comment NOT LIKE '%special%requests%'
+                GROUP BY
+                    c_custkey
+            ) AS c_orders (c_custkey, c_count)
+        GROUP BY
+            c_count
+        ORDER BY
+            custdist DESC,
+            c_count DESC;
+        """
+    ),
+    (
+        "tpch-q13",
+        """
+        SELECT
+            100.00 * SUM(CASE
+                             WHEN p_type LIKE 'PROMO%'
+                                 THEN l_extendedprice * (1 - l_discount)
+                             ELSE 0
+                END) / SUM(l_extendedprice * (1 - l_discount)) AS promo_revenue
+        FROM
+            {{TABLE:lineitem}},
+            {{TABLE:part}}
+        WHERE
+            l_partkey = p_partkey
+          AND l_shipdate >= DATE '1995-09-01'
+          AND l_shipdate < DATEADD(month, 1, '1995-09-01');
+        """
+    ),
+    (
+        "tpch-q14",
+        """
+        WITH revenue AS (
+            SELECT
+                l_suppkey AS supplier_no,
+                SUM(l_extendedprice * (1 - l_discount)) AS total_revenue
+            FROM
+                {{TABLE:lineitem}}
+            WHERE
+                l_shipdate >= TO_DATE('1996-01-01')
+              AND l_shipdate < TO_DATE('1996-04-01')
+            GROUP BY
+                l_suppkey
+        )
+        SELECT
+            s_suppkey,
+            s_name,
+            s_address,
+            s_phone,
+            total_revenue
+        FROM
+            {{TABLE:supplier}},
+            revenue
+        WHERE
+            s_suppkey = supplier_no
+          AND total_revenue = (
+            SELECT MAX(total_revenue)
+            FROM revenue
+        )
+        ORDER BY
+            s_suppkey;
+        """
+    ),
+    (
+        "tpch-q15",
+        """
+        SELECT
+            p_brand,
+            p_type,
+            p_size,
+            COUNT(DISTINCT ps_suppkey) AS supplier_cnt
+        FROM
+            {{TABLE:partsupp}},
+            {{TABLE:part}}
+        WHERE
+            p_partkey = ps_partkey
+          AND p_brand <> 'Brand#45'
+          AND p_type NOT LIKE 'MEDIUM POLISHED%'
+          AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+          AND ps_suppkey NOT IN (
+            SELECT
+                s_suppkey
+            FROM
+                {{TABLE:supplier}}
+            WHERE
+                s_comment LIKE '%Customer%Complaints%'
+        )
+        GROUP BY
+            p_brand,
+            p_type,
+            p_size
+        ORDER BY
+            supplier_cnt DESC,
+            p_brand,
+            p_type,
+            p_size;
+        """
+    ),
+    (
+        "tpch-q16",
+        """
+        SELECT
+            SUM(l_extendedprice) / 7.0 AS avg_yearly
+        FROM
+            {{TABLE:lineitem}},
+            {{TABLE:part}}
+        WHERE
+            p_partkey = l_partkey
+          AND p_brand = 'Brand#23'
+          AND p_container = 'MED BOX'
+          AND l_quantity < (
+            SELECT
+                0.2 * AVG(l_quantity)
+            FROM
+                {{TABLE:lineitem}}
+            WHERE
+                l_partkey = p_partkey
+        );
+        """
+    ),
+    (
+        "tpch-q17",
+        """
+        SELECT
+            c_name,
+            c_custkey,
+            o_orderkey,
+            o_orderdate,
+            o_totalprice,
+            SUM(l_quantity)
+        FROM
+            {{TABLE:customer}},
+            {{TABLE:orders}},
+            {{TABLE:lineitem}}
+        WHERE
+            o_orderkey IN (
+                SELECT
+                    l_orderkey
+                FROM
+                    {{TABLE:lineitem}}
+                GROUP BY
+                    l_orderkey
+                HAVING
+                    SUM(l_quantity) > 300
+            )
+          AND c_custkey = o_custkey
+          AND o_orderkey = l_orderkey
+        GROUP BY
+            c_name,
+            c_custkey,
+            o_orderkey,
+            o_orderdate,
+            o_totalprice
+        ORDER BY
+            o_totalprice DESC,
+            o_orderdate
+            LIMIT 100;
+        """
+    ),
+    (
+        "tpch-q18",
+        """
+        SELECT
+            SUM(l_extendedprice * (1 - l_discount)) AS revenue
+        FROM
+            {{TABLE:lineitem}},
+            {{TABLE:part}}
+        WHERE
+            (
+                p_partkey = l_partkey
+                    AND p_brand = 'Brand#12'
+                    AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+                    AND l_quantity >= 1 AND l_quantity <= 1 + 10
+                    AND p_size BETWEEN 1 AND 5
+                    AND l_shipmode IN ('AIR', 'AIR REG')
+                    AND l_shipinstruct = 'DELIVER IN PERSON'
+                )
+           OR
+            (
+                p_partkey = l_partkey
+                    AND p_brand = 'Brand#23'
+                    AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+                    AND l_quantity >= 10 AND l_quantity <= 10 + 10
+                    AND p_size BETWEEN 1 AND 10
+                    AND l_shipmode IN ('AIR', 'AIR REG')
+                    AND l_shipinstruct = 'DELIVER IN PERSON'
+                )
+           OR
+            (
+                p_partkey = l_partkey
+                    AND p_brand = 'Brand#34'
+                    AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+                    AND l_quantity >= 20 AND l_quantity <= 20 + 10
+                    AND p_size BETWEEN 1 AND 15
+                    AND l_shipmode IN ('AIR', 'AIR REG')
+                    AND l_shipinstruct = 'DELIVER IN PERSON'
+                );
+        """
+    ),
+    (
+        "tpch-q19",
+        """
+        SELECT
+            s_name,
+            s_address
+        FROM
+            {{TABLE:supplier}},
+            {{TABLE:nation}}
+        WHERE
+            s_suppkey IN (
+                SELECT
+                    ps_suppkey
+                FROM
+                    {{TABLE:partsupp}}
+                WHERE
+                    ps_partkey IN (
+                        SELECT
+                            p_partkey
+                        FROM
+                            {{TABLE:part}}
+                        WHERE
+                            p_name LIKE 'forest%'
+                    )
+                  AND ps_availqty > (
+                    SELECT
+                        0.5 * SUM(l_quantity)
+                    FROM
+                        {{TABLE:lineitem}}
+                    WHERE
+                        l_partkey = ps_partkey
+                      AND l_suppkey = ps_suppkey
+                      AND l_shipdate >= DATE '1994-01-01'
+                      AND l_shipdate < DATEADD(year, 1, '1994-01-01')
+                )
+            )
+          AND s_nationkey = n_nationkey
+          AND n_name = 'CANADA'
+        ORDER BY
+            s_name;
+        """
+    ),
+    (
+        "tpch-q20",
+        """
+        SELECT
+            s_name,
+            COUNT(*) AS numwait
+        FROM
+            {{TABLE:supplier}},
+            {{TABLE:lineitem}} l1,
+            {{TABLE:orders}},
+            {{TABLE:nation}}
+        WHERE
+            s_suppkey = l1.l_suppkey
+          AND o_orderkey = l1.l_orderkey
+          AND o_orderstatus = 'F'
+          AND l1.l_receiptdate > l1.l_commitdate
+          AND EXISTS (
+            SELECT
+                *
+            FROM
+                {{TABLE:lineitem}} l2
+            WHERE
+                l2.l_orderkey = l1.l_orderkey
+              AND l2.l_suppkey <> l1.l_suppkey
+        )
+          AND NOT EXISTS (
+            SELECT
+                *
+            FROM
+                {{TABLE:lineitem}} l3
+            WHERE
+                l3.l_orderkey = l1.l_orderkey
+              AND l3.l_suppkey <> l1.l_suppkey
+              AND l3.l_receiptdate > l3.l_commitdate
+        )
+          AND s_nationkey = n_nationkey
+          AND n_name = 'SAUDI ARABIA'
+        GROUP BY
+            s_name
+        ORDER BY
+            numwait DESC,
+            s_name
+            LIMIT 100;
+        """
+    ),
+    (
+        "tpch-q21",
+        """
+        SELECT
+            cntrycode,
+            COUNT(*) AS numcust,
+            SUM(c_acctbal) AS totacctbal
+        FROM
+            (
+                SELECT
+                    SUBSTRING(c_phone, 1, 2) AS cntrycode,
+                    c_acctbal
+                FROM
+                    {{TABLE:customer}}
+                WHERE
+                    SUBSTRING(c_phone, 1, 2) IN
+                    ('13', '31', '23', '29', '30', '18', '17')
+                  AND c_acctbal > (
+                    SELECT
+                        AVG(c_acctbal)
+                    FROM
+                        {{TABLE:customer}}
+                    WHERE
+                        c_acctbal > 0.00
+                      AND SUBSTRING(c_phone, 1, 2) IN
+                          ('13', '31', '23', '29', '30', '18', '17')
+                )
+                  AND NOT EXISTS (
+                    SELECT
+                        *
+                    FROM
+                        {{TABLE:orders}}
+                    WHERE
+                        o_custkey = c_custkey
+                )
+            ) AS custsale
+        GROUP BY
+            cntrycode
+        ORDER BY
+            cntrycode;
+        """
+    ),
+    (
+        "tpch-q22",
+        """
+        SELECT
+            c_custkey,
+            c_name,
+            SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+            c_acctbal,
+            n_name,
+            c_address,
+            c_phone,
+            c_comment
+        FROM
+            {{TABLE:customer}},
+            {{TABLE:orders}},
+            {{TABLE:lineitem}},
+            {{TABLE:nation}}
+        WHERE
+            c_custkey = o_custkey
+          AND l_orderkey = o_orderkey
+          AND o_orderdate >= DATE '1993-10-01'
+          AND o_orderdate < DATEADD(month, 3, '1993-10-01')
+          AND l_returnflag = 'R'
+          AND c_nationkey = n_nationkey
+        GROUP BY
+            c_custkey,
+            c_name,
+            c_acctbal,
+            c_phone,
+            n_name,
+            c_address,
+            c_comment
+        ORDER BY
+            revenue DESC
+            LIMIT 20;
+        """
+    )
+]


### PR DESCRIPTION
- **Enable embucket to upload data**
- **Unify nyc taxi dataset fixture**
- **Unify fixtures**
- **Extend queries to full TPC-H benchmark**
