### PR TITLE
Add 30-minute timeout to integration CI/CD jobs

### DIFF
--- a/.github/workflows/dbt-gitlab-run.yml
+++ b/.github/workflows/dbt-gitlab-run.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   sql-logic-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: DBT Gitlab run
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/dbt-snowplow-web-run.yml
+++ b/.github/workflows/dbt-snowplow-web-run.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   sql-logic-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: DBT Snowplow Web run
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: Run pytest integration suite
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/sql-logic-tests.yml
+++ b/.github/workflows/sql-logic-tests.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   sql-logic-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: SQL Logic Tests
     env:
       SNOWFLAKE_ACCOUNT: test


### PR DESCRIPTION
## Summary
- Set timeout-minutes: 30 for dbt runs and integration tests
- Prevents jobs from running indefinitely and provides better resource management

## Test plan
- CI/CD workflows will now timeout after 30 minutes if not completed

🤖 Generated with [Claude Code](https://claude.ai/code)