### PR TITLE
DBT github action job timeout

### DIFF
--- a/.github/workflows/dbt-gitlab-run.yml
+++ b/.github/workflows/dbt-gitlab-run.yml
@@ -16,6 +16,7 @@ jobs:
   sql-logic-tests:
     runs-on: ubuntu-latest
     name: DBT Gitlab run
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/dbt-snowplow-web-run.yml
+++ b/.github/workflows/dbt-snowplow-web-run.yml
@@ -16,6 +16,7 @@ jobs:
   sql-logic-tests:
     runs-on: ubuntu-latest
     name: DBT Snowplow Web run
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Added job timeout to prevent running for 6 hours straight. 