### PR TITLE
Fix drop table if exists

### DIFF
--- a/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_drop_table_missing.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_drop_table_missing.snap
@@ -1,0 +1,7 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/table.rs
+description: "\"DROP TABLE embucket.public.missing\""
+---
+Err(
+    "Error: Iceberg error: Table missing not found.",
+)

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_drop_table_missing_schema.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_drop_table_missing_schema.snap
@@ -1,0 +1,7 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/table.rs
+description: "\"DROP TABLE embucket.missing.table\""
+---
+Err(
+    "Error: Iceberg error: Namespace missing not found.",
+)

--- a/crates/core-executor/src/tests/sql/ddl/table.rs
+++ b/crates/core-executor/src/tests/sql/ddl/table.rs
@@ -69,3 +69,15 @@ test_query!(
     ],
     snapshot_path = "table"
 );
+
+test_query!(
+    drop_table_missing_schema,
+    "DROP TABLE embucket.missing.table",
+    snapshot_path = "table"
+);
+
+test_query!(
+    drop_table_missing,
+    "DROP TABLE embucket.public.missing",
+    snapshot_path = "table"
+);

--- a/test/dbt_integration_tests/dbt-gitlab/run.sh
+++ b/test/dbt_integration_tests/dbt-gitlab/run.sh
@@ -90,13 +90,13 @@ pip install -r requirements.txt >/dev/null 2>&1
 echo ""
 
 # Load data and create embucket catalog if the embucket is a target 
-# echo "###############################"
-# echo ""
-# echo "Creating embucket database"
-# if [ "$DBT_TARGET" = "embucket" ]; then
-#    $PYTHON_CMD upload.py
-# fi
-# echo ""
+echo "###############################"
+echo ""
+echo "Creating embucket database"
+if [ "$DBT_TARGET" = "embucket" ]; then
+  $PYTHON_CMD upload.py
+fi
+echo ""
 
 mkdir -p assets
 


### PR DESCRIPTION
https://github.com/Embucket/embucket/pull/1540/files intoduced issue when drop table query contains **if_exists** flag

We don't need to return error if drop table query contains **if_exists** flag

- If the flag and table are missing
  - check if schema exists, if not return error (e.g., **Iceberg: Namespace gitlab_dotcom22 not found.**)
  - return original Iceberg error (e.g., **Iceberg: Table gitlab_dotcom_project_repositories_dedupe_source__dbt_tmp not found.**)

Also enable dbt gitlab volume, db, schema creation.

Closes #1553

