### PR TITLE
Add basic checks to alter table

### DIFF
--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -179,7 +179,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Table {table} not found in {schema}"))]
+    #[snafu(display("Table {table} not found in schema {schema}"))]
     TableNotFound {
         schema: String,
         table: String,

--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -179,8 +179,9 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Table {table} not found"))]
+    #[snafu(display("Table {table} not found in {schema}"))]
     TableNotFound {
+        schema: String,
         table: String,
         #[snafu(implicit)]
         location: Location,

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -6,7 +6,8 @@ use super::catalog::{
 };
 use super::datafusion::planner::ExtendedSqlToRel;
 use super::error::{
-    self as ex_error, Error, ObjectType as ExistingObjectType, RefreshCatalogListSnafu, Result,
+    self as ex_error, Error, InvalidColumnIdentifierSnafu, MergeSourceNotSupportedSnafu,
+    ObjectType as ExistingObjectType, RefreshCatalogListSnafu, Result,
 };
 use super::session::UserSession;
 use super::utils::{NormalizedIdent, is_logical_plan_effectively_empty};
@@ -15,9 +16,6 @@ use crate::datafusion::physical_plan::merge::{
     DATA_FILE_PATH_COLUMN, MANIFEST_FILE_PATH_COLUMN, SOURCE_EXISTS_COLUMN, TARGET_EXISTS_COLUMN,
 };
 use crate::datafusion::rewriters::session_context::SessionContextExprRewriter;
-use crate::error::{
-    InvalidColumnIdentifierSnafu, MergeSourceNotSupportedSnafu, NotSupportedStatementSnafu,
-};
 use crate::models::{QueryContext, QueryResult};
 use arrow_schema::SchemaBuilder;
 use core_history::HistoryStore;
@@ -99,10 +97,10 @@ use snafu::{OptionExt, ResultExt};
 use sqlparser::ast::helpers::key_value_options::KeyValueOptions;
 use sqlparser::ast::helpers::stmt_data_loading::StageParamsObject;
 use sqlparser::ast::{
-    AssignmentTarget, CloudProviderParams, MergeAction, MergeClause, MergeClauseKind,
-    MergeInsertKind, ObjectNamePart, ObjectType, OneOrManyWithParens, PivotValueSource,
-    ShowObjects, ShowStatementFilter, ShowStatementIn, TruncateTableTarget, Use, Value,
-    visit_relations_mut,
+    AlterTableOperation, AssignmentTarget, CloudProviderParams, MergeAction, MergeClause,
+    MergeClauseKind, MergeInsertKind, ObjectNamePart, ObjectType, OneOrManyWithParens,
+    PivotValueSource, ShowObjects, ShowStatementFilter, ShowStatementIn, TruncateTableTarget, Use,
+    Value, visit_relations_mut,
 };
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -382,10 +380,14 @@ impl UserQuery {
                 Statement::CopyIntoSnowflake { .. } => {
                     return Box::pin(self.copy_into_snowflake_query(*s)).await;
                 }
-                Statement::AlterTable { .. } => NotSupportedStatementSnafu {
-                    statement: "ALTER TABLE".to_string(),
+                Statement::AlterTable {
+                    name,
+                    operations,
+                    if_exists,
+                    ..
+                } => {
+                    return Box::pin(self.alter_table(name, operations, if_exists)).await;
                 }
-                .fail()?,
                 Statement::StartTransaction { .. }
                 | Statement::Commit { .. }
                 | Statement::Rollback { .. }
@@ -538,6 +540,35 @@ impl UserQuery {
             session_params.insert(name, session_value);
         }
         self.session.set_session_variable(true, session_params)?;
+        self.status_response()
+    }
+
+    #[instrument(name = "UserQuery::alter_table", level = "trace", skip(self), err)]
+    #[allow(clippy::too_many_lines)]
+    pub async fn alter_table(
+        &self,
+        name: ObjectName,
+        operations: Vec<AlterTableOperation>,
+        if_exists: bool,
+    ) -> Result<QueryResult> {
+        let ident = &self.resolve_table_object_name(name.0.clone())?;
+        let resolved = self.resolve_table_ref(ident);
+        let catalog = self.get_catalog(&resolved.catalog)?;
+        let schema =
+            catalog
+                .schema(&resolved.schema)
+                .context(ex_error::SchemaNotFoundInDatabaseSnafu {
+                    schema: &resolved.schema.to_string(),
+                    db: &resolved.catalog.to_string(),
+                })?;
+        schema
+            .table(&resolved.table)
+            .await
+            .context(ex_error::DataFusionSnafu)?
+            .context(ex_error::TableNotFoundSnafu {
+                table: &resolved.table.to_string(),
+                schema: &resolved.schema.to_string(),
+            })?;
         self.status_response()
     }
 

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -561,14 +561,17 @@ impl UserQuery {
                     schema: &resolved.schema.to_string(),
                     db: &resolved.catalog.to_string(),
                 })?;
-        schema
-            .table(&resolved.table)
-            .await
-            .context(ex_error::DataFusionSnafu)?
-            .context(ex_error::TableNotFoundSnafu {
-                table: &resolved.table.to_string(),
-                schema: &resolved.schema.to_string(),
-            })?;
+        println!("schema: {schema:?}");
+        if !if_exists {
+            schema
+                .table(&resolved.table)
+                .await
+                .context(ex_error::DataFusionSnafu)?
+                .context(ex_error::TableNotFoundSnafu {
+                    table: &resolved.table.to_string(),
+                    schema: &resolved.schema.to_string(),
+                })?;
+        }
         self.status_response()
     }
 

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -561,7 +561,6 @@ impl UserQuery {
                     schema: &resolved.schema.to_string(),
                     db: &resolved.catalog.to_string(),
                 })?;
-        println!("schema: {schema:?}");
         if !if_exists {
             schema
                 .table(&resolved.table)

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -225,9 +225,6 @@ macro_rules! test_query {
     };
 }
 
-// Empty plan
-test_query!(alter_iceberg_table, "ALTER ICEBERG TABLE test ADD col INT;");
-
 // context name injection
 test_query!(
     context_name_injection,

--- a/crates/core-executor/src/tests/snapshots/query_alter_iceberg_table.snap
+++ b/crates/core-executor/src/tests/snapshots/query_alter_iceberg_table.snap
@@ -1,7 +1,0 @@
----
-source: crates/core-executor/src/tests/query.rs
-description: "\"ALTER ICEBERG TABLE test ADD col INT;\""
----
-Err(
-    "Error: Not supported statement: ALTER TABLE",
-)

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/query_alter_iceberg_table.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/query_alter_iceberg_table.snap
@@ -1,0 +1,7 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/table.rs
+description: "\"ALTER ICEBERG TABLE test ADD col INT;\""
+---
+Err(
+    "Error: Table test not found in public",
+)

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/query_alter_iceberg_table.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/query_alter_iceberg_table.snap
@@ -1,7 +1,0 @@
----
-source: crates/core-executor/src/tests/sql/ddl/table.rs
-description: "\"ALTER ICEBERG TABLE test ADD col INT;\""
----
-Err(
-    "Error: Table test not found in public",
-)

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_alter_iceberg_table.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_alter_iceberg_table.snap
@@ -1,0 +1,13 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/table.rs
+description: "\"ALTER ICEBERG TABLE test ADD col INT;\""
+info: "Setup queries: CREATE TABLE embucket.public.test (id INT) as VALUES (1), (2)"
+---
+Ok(
+    [
+        "+--------+",
+        "| status |",
+        "+--------+",
+        "+--------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_alter_missing_schema.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_alter_missing_schema.snap
@@ -1,0 +1,7 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/table.rs
+description: "\"ALTER TABLE embucket.missing.table ADD COLUMN new_col INT\""
+---
+Err(
+    "Error: Schema missing not found in database embucket",
+)

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_alter_missing_table.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_alter_missing_table.snap
@@ -1,0 +1,7 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/table.rs
+description: "\"ALTER TABLE embucket.public.missing ADD COLUMN new_col INT\""
+---
+Err(
+    "Error: Table missing not found in schema public",
+)

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_alter_table.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_alter_table.snap
@@ -1,0 +1,13 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/table.rs
+description: "\"ALTER TABLE embucket.public.test ADD COLUMN new_col INT\""
+info: "Setup queries: CREATE TABLE embucket.public.test (id INT) as VALUES (1), (2)"
+---
+Ok(
+    [
+        "+--------+",
+        "| status |",
+        "+--------+",
+        "+--------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/ddl/table.rs
+++ b/crates/core-executor/src/tests/sql/ddl/table.rs
@@ -89,10 +89,21 @@ test_query!(
     snapshot_path = "table"
 );
 
-// Empty plan
 test_query!(
     alter_iceberg_table,
     "ALTER ICEBERG TABLE test ADD col INT;",
     setup_queries = ["CREATE TABLE embucket.public.test (id INT) as VALUES (1), (2)",],
+    snapshot_path = "table"
+);
+
+test_query!(
+    alter_missing_schema,
+    "ALTER TABLE embucket.missing.table ADD COLUMN new_col INT",
+    snapshot_path = "table"
+);
+
+test_query!(
+    alter_missing_table,
+    "ALTER TABLE embucket.public.missing ADD COLUMN new_col INT",
     snapshot_path = "table"
 );

--- a/crates/core-executor/src/tests/sql/ddl/table.rs
+++ b/crates/core-executor/src/tests/sql/ddl/table.rs
@@ -81,3 +81,18 @@ test_query!(
     "DROP TABLE embucket.public.missing",
     snapshot_path = "table"
 );
+
+test_query!(
+    alter_table,
+    "ALTER TABLE embucket.public.test ADD COLUMN new_col INT",
+    setup_queries = ["CREATE TABLE embucket.public.test (id INT) as VALUES (1), (2)",],
+    snapshot_path = "table"
+);
+
+// Empty plan
+test_query!(
+    alter_iceberg_table,
+    "ALTER ICEBERG TABLE test ADD col INT;",
+    setup_queries = ["CREATE TABLE embucket.public.test (id INT) as VALUES (1), (2)",],
+    snapshot_path = "table"
+);


### PR DESCRIPTION
Closes #1563

Return a successful status response for `ALTER TABLE` when basic validation checks pass, and return an error response if any of the checks fail

Also fixed embucket catalog schema check. Metastore returns Ok(None) for missing schemas.
