### PR TITLE
engine: Backslash docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,19 @@
-# Embucket Docs
+# Embucket docs
 
 ## About
 
-Astro Starlight frontend application for the Embucket docs.
+`Astro` Starlight frontend app for the Embucket docs.
 
 ## Local development prerequisites
 
 Before you begin, make sure you have the following installed on your machine:
 
 - **Node.js** (LTS version) - [Download](https://nodejs.org)
-- **pnpm** (Package Manager) - [Installation Guide](https://pnpm.io)
+- **`pnpm`** (Package Manager) - [Installation Guide](https://pnpm.io)
 
-## Quick Start
+## Quick start
 
-Follow these steps to get the application up and running in your local development environment.
+Follow these steps to get the app up and running in your local development environment.
 
 ### 1. FE Installation and Setup (`./docs` folder)
 
@@ -35,7 +35,7 @@ To ensure everything is working correctly:
 
 - The frontend development server should be running on http://localhost:4321.
 
-### Project Structure
+### Project structure
 
 ```
 .
@@ -49,27 +49,27 @@ To ensure everything is working correctly:
 └── astro.config.mjs
 ```
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
+Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its filename.
 
 Images can be added to `src/assets/` and embedded in Markdown with a relative link.
 
-Static assets, like favicons, can be placed in the `public/` directory.
+Static assets, like `favicons`, can be placed in the `public/` directory.
 
 ## Common scripts
 
 | Command          | Action                                           |
 | :--------------- | :----------------------------------------------- |
 | `pnpm install`   | Installs dependencies                            |
-| `pnpm dev`       | Starts local dev server at `localhost:4321`      |
+| `pnpm dev`       | Starts local `dev` server at `localhost:4321`      |
 | `pnpm build`     | Build your production site to `./dist/`          |
 | `pnpm preview`   | Preview your build locally, before deploying     |
-| `pnpm astro ...` | Run CLI commands like `astro add`, `astro check` |
+| `pnpm astro ...` | Run `CLI` commands like `astro add`, `astro check` |
 | `pnpm format`    | Format with Prettier + fix errors                |
-| `pnpm ncu`       | Update repo dependencies                         |
+| `pnpm ncu`       | Update `repo` dependencies                         |
 
 ### Tech stack
 
-- [Astro Starlight](https://starlight.astro.build)
+- [`Astro` Starlight](https://starlight.astro.build)
 - [Tailwind](https://tailwindcss.com)
 - [Prettier](https://prettier.io)
 - [Vale](https://vale.sh)

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,14 +57,14 @@ Static assets, like `favicons`, can be placed in the `public/` directory.
 
 ## Common scripts
 
-| Command          | Action                                           |
-| :--------------- | :----------------------------------------------- |
-| `pnpm install`   | Installs dependencies                            |
+| Command          | Action                                             |
+| :--------------- | :------------------------------------------------- |
+| `pnpm install`   | Installs dependencies                              |
 | `pnpm dev`       | Starts local `dev` server at `localhost:4321`      |
-| `pnpm build`     | Build your production site to `./dist/`          |
-| `pnpm preview`   | Preview your build locally, before deploying     |
+| `pnpm build`     | Build your production site to `./dist/`            |
+| `pnpm preview`   | Preview your build locally, before deploying       |
 | `pnpm astro ...` | Run `CLI` commands like `astro add`, `astro check` |
-| `pnpm format`    | Format with Prettier + fix errors                |
+| `pnpm format`    | Format with Prettier + fix errors                  |
 | `pnpm ncu`       | Update `repo` dependencies                         |
 
 ### Tech stack

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -77,7 +77,7 @@ These technology choices differ structurally:
 ### Backslash escaping
 
 - **Backslash escaping differentiates**: Snowflake doesn't support backslash escaping for special characters in string literals by using `\` as an escape character (broken symbols). Embucket supports backslash escaping for special characters in string literals by using `\` as an escape character (but the symbols are not shown), also it supports `\\` as an escape character for other symbols.
-- **Backslash reception number differentiates**: In Snowflake to get `\b` you need to write `\\b`. In Embucket to get `\b` you need to write `\\\\b`.
+- **Backslash repetition number differentiates**: In Snowflake to get `\b` you need to write `\\b`. In Embucket to get `\b` you need to write `\\\\b`.
 
 | Example                            | Embucket                                                | Snowflake                           |
 |------------------------------------|---------------------------------------------------------|-------------------------------------|

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -80,7 +80,7 @@ These technology choices differ structurally:
 - **Backslash repetition number differentiates**: In Snowflake to get `\b` you need to write `\\b`. In Embucket to get `\b` you need to write `\\\\b`.
 
 | Example                               | Embucket                                             | Snowflake                           |
-|---------------------------------------|------------------------------------------------------|-------------------------------------|
+| ------------------------------------- | ---------------------------------------------------- | ----------------------------------- |
 | **`SELECT \* FROM VALUES ('\b')`**    | **`\x08`** (nothing shows or a broken symbol in UI)  | **`\x08`** (broken symbol)          |
 | **`SELECT \* FROM VALUES ('\\b')`**   | **`\u{8}`** (nothing shows or a broken symbol in UI) | **`\b`**                            |
 | **`SELECT \* FROM VALUES ('\\\b')`**  | **`\u{8}`** (nothing shows or a broken symbol in UI) | **`\\x08`** (slash + broken symbol) |

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -74,6 +74,19 @@ These technology choices differ structurally:
 
 - **Different error format**: Error messages don't match Snowflake's format
 
+### Backslash escaping
+
+- **Backslash escaping differentiates**: Snowflake doesn't support backslash escaping for special characters in string literals by using `\` as an escape character (broken symbols). Embucket supports backslash escaping for special characters in string literals by using `\` as an escape character (but the symbols are not shown).
+- **Backslash reception number differentiates**: In Snowflake to get `\b` you need to write `\\b`. In Embucket to get `\b` you need to write `\\\\b`.
+
+| Example                            | Embucket                                                | Snowflake                           |
+|------------------------------------|---------------------------------------------------------|-------------------------------------|
+| **SELECT * FROM VALUES ('\b')**    | **`\x08`** (nothing is shown or a broken symbol in UI)  | **`\x08`** (broken symbol)          |
+| **SELECT * FROM VALUES ('\\b')**   | **`\u{8}`** (nothing is shown or a broken symbol in UI) | **`\b`**                            |
+| **SELECT * FROM VALUES ('\\\b')**  | **`\u{8}`** (nothing is shown or a broken symbol in UI) | **`\\x08`** (slash + broken symbol) |
+| **SELECT * FROM VALUES ('\\\\b')** | **`\b`**                                                | **`\\b`**                           |
+
+
 ## VARIANT data type support
 
 Embucket implements VARIANT as JSON-serialized `TEXT` on the storage layer. This approach becomes necessary because Parquet, Iceberg, and Arrow don't support VARIANT natively.

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -87,12 +87,14 @@ Embucket handles backslash escaping in string literals differently than Snowflak
 #### Getting literal backslashes
 
 **Snowflake:**
+
 ```sql
 SELECT * FROM VALUES ('\\b');
 -- Returns: \b
 ```
 
 **Embucket:**
+
 ```sql
 SELECT * FROM VALUES ('\\\\b');
 -- Returns: \b
@@ -101,12 +103,14 @@ SELECT * FROM VALUES ('\\\\b');
 #### Handling special characters
 
 **Snowflake:**
+
 ```sql
 SELECT * FROM VALUES ('\b');
 -- Returns: \x08 (backspace character, may appear as broken symbol)
 ```
 
 **Embucket:**
+
 ```sql
 SELECT * FROM VALUES ('\b');
 -- Returns: \x08 (backspace character, may not display in UI)
@@ -115,17 +119,18 @@ SELECT * FROM VALUES ('\b');
 #### Single trailing backslash
 
 **Snowflake:**
+
 ```sql
 SELECT * FROM VALUES ('\\');
 -- Returns: \
 ```
 
 **Embucket:**
+
 ```sql
 SELECT * FROM VALUES ('\\');
 -- Error: Unterminated string literal
 ```
-
 
 ## VARIANT data type support
 

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -76,15 +76,15 @@ These technology choices differ structurally:
 
 ### Backslash escaping
 
-- **Backslash escaping differentiates**: Snowflake doesn't support backslash escaping for special characters in string literals by using `\` as an escape character (broken symbols). Embucket supports backslash escaping for special characters in string literals by using `\` as an escape character (but the symbols are not shown), also it supports `\\` as an escape character for other symbols.
+- **Backslash escaping differentiates**: Snowflake doesn't support backslash escaping for special characters in string literals by using `\` as an escape character (broken symbols). Embucket supports backslash escaping for special characters in string literals by using `\` as an escape character (but the symbols don't show), also it supports `\\` as an escape character for other symbols.
 - **Backslash repetition number differentiates**: In Snowflake to get `\b` you need to write `\\b`. In Embucket to get `\b` you need to write `\\\\b`.
 
-| Example                             | Embucket                                                | Snowflake                           |
-| ----------------------------------- | ------------------------------------------------------- | ----------------------------------- |
-| **SELECT \* FROM VALUES ('\b')**    | **`\x08`** (nothing is shown or a broken symbol in UI)  | **`\x08`** (broken symbol)          |
-| **SELECT \* FROM VALUES ('\\b')**   | **`\u{8}`** (nothing is shown or a broken symbol in UI) | **`\b`**                            |
-| **SELECT \* FROM VALUES ('\\\b')**  | **`\u{8}`** (nothing is shown or a broken symbol in UI) | **`\\x08`** (slash + broken symbol) |
-| **SELECT \* FROM VALUES ('\\\\b')** | **`\b`**                                                | **`\\b`**                           |
+| Example                               | Embucket                                             | Snowflake                           |
+|---------------------------------------|------------------------------------------------------|-------------------------------------|
+| **`SELECT \* FROM VALUES ('\b')`**    | **`\x08`** (nothing shows or a broken symbol in UI)  | **`\x08`** (broken symbol)          |
+| **`SELECT \* FROM VALUES ('\\b')`**   | **`\u{8}`** (nothing shows or a broken symbol in UI) | **`\b`**                            |
+| **`SELECT \* FROM VALUES ('\\\b')`**  | **`\u{8}`** (nothing shows or a broken symbol in UI) | **`\\x08`** (slash + broken symbol) |
+| **`SELECT \* FROM VALUES ('\\\\b')`** | **`\b`**                                             | **`\\b`**                           |
 
 ## VARIANT data type support
 

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -79,13 +79,12 @@ These technology choices differ structurally:
 - **Backslash escaping differentiates**: Snowflake doesn't support backslash escaping for special characters in string literals by using `\` as an escape character (broken symbols). Embucket supports backslash escaping for special characters in string literals by using `\` as an escape character (but the symbols are not shown), also it supports `\\` as an escape character for other symbols.
 - **Backslash repetition number differentiates**: In Snowflake to get `\b` you need to write `\\b`. In Embucket to get `\b` you need to write `\\\\b`.
 
-| Example                            | Embucket                                                | Snowflake                           |
-|------------------------------------|---------------------------------------------------------|-------------------------------------|
-| **SELECT * FROM VALUES ('\b')**    | **`\x08`** (nothing is shown or a broken symbol in UI)  | **`\x08`** (broken symbol)          |
-| **SELECT * FROM VALUES ('\\b')**   | **`\u{8}`** (nothing is shown or a broken symbol in UI) | **`\b`**                            |
-| **SELECT * FROM VALUES ('\\\b')**  | **`\u{8}`** (nothing is shown or a broken symbol in UI) | **`\\x08`** (slash + broken symbol) |
-| **SELECT * FROM VALUES ('\\\\b')** | **`\b`**                                                | **`\\b`**                           |
-
+| Example                             | Embucket                                                | Snowflake                           |
+| ----------------------------------- | ------------------------------------------------------- | ----------------------------------- |
+| **SELECT \* FROM VALUES ('\b')**    | **`\x08`** (nothing is shown or a broken symbol in UI)  | **`\x08`** (broken symbol)          |
+| **SELECT \* FROM VALUES ('\\b')**   | **`\u{8}`** (nothing is shown or a broken symbol in UI) | **`\b`**                            |
+| **SELECT \* FROM VALUES ('\\\b')**  | **`\u{8}`** (nothing is shown or a broken symbol in UI) | **`\\x08`** (slash + broken symbol) |
+| **SELECT \* FROM VALUES ('\\\\b')** | **`\b`**                                                | **`\\b`**                           |
 
 ## VARIANT data type support
 

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -78,6 +78,7 @@ These technology choices differ structurally:
 
 - **Backslash escaping differentiates**: Snowflake doesn't support backslash escaping for special characters in string literals by using `\` as an escape character (broken symbols). Embucket supports backslash escaping for special characters in string literals by using `\` as an escape character (but the symbols don't show), also it supports `\\` as an escape character for other symbols.
 - **Backslash repetition number differentiates**: In Snowflake to get `\b` you need to write `\\b`. In Embucket to get `\b` you need to write `\\\\b`.
+- **The limitation cause**: DataFusion `SqlParser` `tokenizer` works with escaping, although on per dialect bases, it's still rather inflexible in itself.
 
 | Example                               | Embucket                                             | Snowflake                           |
 | ------------------------------------- | ---------------------------------------------------- | ----------------------------------- |

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -76,7 +76,7 @@ These technology choices differ structurally:
 
 ### Backslash escaping
 
-- **Backslash escaping differentiates**: Snowflake doesn't support backslash escaping for special characters in string literals by using `\` as an escape character (broken symbols). Embucket supports backslash escaping for special characters in string literals by using `\` as an escape character (but the symbols are not shown).
+- **Backslash escaping differentiates**: Snowflake doesn't support backslash escaping for special characters in string literals by using `\` as an escape character (broken symbols). Embucket supports backslash escaping for special characters in string literals by using `\` as an escape character (but the symbols are not shown), also it supports `\\` as an escape character for other symbols.
 - **Backslash reception number differentiates**: In Snowflake to get `\b` you need to write `\\b`. In Embucket to get `\b` you need to write `\\\\b`.
 
 | Example                            | Embucket                                                | Snowflake                           |

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -76,17 +76,56 @@ These technology choices differ structurally:
 
 ### Backslash escaping
 
-- **Backslash escaping differentiates**: Snowflake doesn't support backslash escaping for special characters in string literals by using `\` as an escape character (broken symbols). Embucket supports backslash escaping for special characters in string literals by using `\` as an escape character (but the symbols don't show), also it supports `\\` as an escape character for other symbols.
-- **Backslash repetition number differentiates**: In Snowflake to get `\b` you need to write `\\b`. In Embucket to get `\b` you need to write `\\\\b`.
-- **The limitation cause**: DataFusion `SqlParser` `tokenizer` works with escaping, although on per dialect bases, it's still rather inflexible in itself.
+Embucket handles backslash escaping in string literals differently than Snowflake. This affects how you write queries that include backslashes or special characters in strings.
 
-| Example                               | Embucket                                             | Snowflake                           |
-| ------------------------------------- | ---------------------------------------------------- | ----------------------------------- |
-| **`SELECT \* FROM VALUES ('\b')`**    | **`\x08`** (nothing shows or a broken symbol in UI)  | **`\x08`** (broken symbol)          |
-| **`SELECT \* FROM VALUES ('\\b')`**   | **`\u{8}`** (nothing shows or a broken symbol in UI) | **`\b`**                            |
-| **`SELECT \* FROM VALUES ('\\\b')`**  | **`\u{8}`** (nothing shows or a broken symbol in UI) | **`\\x08`** (slash + broken symbol) |
-| **`SELECT \* FROM VALUES ('\\\\b')`** | **`\b`**                                             | **`\\b`**                           |
-| **`SELECT \* FROM VALUES ('\\')`**    | **`Error: ...`**                                     | **`\`**                             |
+**Key differences:**
+
+- **Escape character interpretation**: Snowflake treats single backslashes literally in most cases, while Embucket interprets them as escape characters
+- **Backslash repetition**: You need more backslashes in Embucket to achieve the same result as Snowflake
+- **Error handling**: Some backslash patterns that work in Snowflake cause errors in Embucket
+
+#### Getting literal backslashes
+
+**Snowflake:**
+```sql
+SELECT * FROM VALUES ('\\b');
+-- Returns: \b
+```
+
+**Embucket:**
+```sql
+SELECT * FROM VALUES ('\\\\b');
+-- Returns: \b
+```
+
+#### Handling special characters
+
+**Snowflake:**
+```sql
+SELECT * FROM VALUES ('\b');
+-- Returns: \x08 (backspace character, may appear as broken symbol)
+```
+
+**Embucket:**
+```sql
+SELECT * FROM VALUES ('\b');
+-- Returns: \x08 (backspace character, may not display in UI)
+```
+
+#### Single trailing backslash
+
+**Snowflake:**
+```sql
+SELECT * FROM VALUES ('\\');
+-- Returns: \
+```
+
+**Embucket:**
+```sql
+SELECT * FROM VALUES ('\\');
+-- Error: Unterminated string literal
+```
+
 
 ## VARIANT data type support
 

--- a/docs/src/content/docs/essentials/snowflake.mdx
+++ b/docs/src/content/docs/essentials/snowflake.mdx
@@ -86,6 +86,7 @@ These technology choices differ structurally:
 | **`SELECT \* FROM VALUES ('\\b')`**   | **`\u{8}`** (nothing shows or a broken symbol in UI) | **`\b`**                            |
 | **`SELECT \* FROM VALUES ('\\\b')`**  | **`\u{8}`** (nothing shows or a broken symbol in UI) | **`\\x08`** (slash + broken symbol) |
 | **`SELECT \* FROM VALUES ('\\\\b')`** | **`\b`**                                             | **`\\b`**                           |
+| **`SELECT \* FROM VALUES ('\\')`**    | **`Error: ...`**                                     | **`\`**                             |
 
 ## VARIANT data type support
 


### PR DESCRIPTION
Related to #1504 

- The problem is explained in docs and in the issue.
- There is a way to turn off the backslash escaping (inside the dialect of the parser) and then `\b` -> `\b`, closer to snowflake's `\\b` -> `\b`