### PR TITLE
fix merging into empty table

### DIFF
--- a/crates/core-executor/src/datafusion/physical_plan/merge.rs
+++ b/crates/core-executor/src/datafusion/physical_plan/merge.rs
@@ -181,14 +181,23 @@ impl ExecutionPlan for MergeIntoCOWSinkExec {
                     })?
                 };
 
-                if !datafiles.is_empty() && !matching_files.is_empty() {
+                if !datafiles.is_empty() {
                     // Commit transaction on Iceberg table
-                    table
-                        .new_transaction(branch.as_deref())
-                        .overwrite(datafiles, matching_files)
-                        .commit()
-                        .await
-                        .map_err(DataFusionIcebergError::from)?;
+                    if matching_files.is_empty() {
+                        table
+                            .new_transaction(branch.as_deref())
+                            .append_data(datafiles)
+                            .commit()
+                            .await
+                            .map_err(DataFusionIcebergError::from)?;
+                    } else {
+                        table
+                            .new_transaction(branch.as_deref())
+                            .overwrite(datafiles, matching_files)
+                            .commit()
+                            .await
+                            .map_err(DataFusionIcebergError::from)?;
+                    }
                 }
 
                 Ok(RecordBatch::new_empty(schema))
@@ -414,7 +423,7 @@ impl Stream for MergeCOWFilterStream {
                 }
 
                 if matching_data_and_manifest_files.is_empty() {
-                    Poll::Pending
+                    Poll::Ready(Some(Ok(batch)))
                 } else {
                     let file_predicate = matching_data_files
                         .iter()
@@ -583,14 +592,20 @@ fn unique_values(array: &dyn Array) -> Result<HashSet<String>, DataFusionError> 
 
     let strings = downcast_array::<StringArray>(&unique);
 
-    let result = strings
-        .iter()
-        .fold(HashSet::from_iter([first]), |mut acc, x| {
-            if let Some(x) = x {
-                acc.insert(x.to_owned());
-            }
-            acc
-        });
+    let init = if first.is_empty() {
+        HashSet::new()
+    } else {
+        HashSet::from_iter([first])
+    };
+
+    let result = strings.iter().fold(init, |mut acc, x| {
+        if let Some(x) = x
+            && !x.is_empty()
+        {
+            acc.insert(x.to_owned());
+        }
+        acc
+    });
 
     Ok(result)
 }
@@ -641,15 +656,24 @@ fn unique_files_and_manifests(
     let file_strings = downcast_array::<StringArray>(&unique_files);
     let manifest_strings = downcast_array::<StringArray>(&unique_manifests);
 
-    let result = manifest_strings.iter().zip(file_strings.iter()).fold(
-        HashMap::from_iter([(first_file, first_manifest)]),
-        |mut acc, (manifest, file)| {
-            if let (Some(manifest), Some(file)) = (manifest, file) {
-                acc.insert(file.to_owned(), manifest.to_owned());
-            }
-            acc
-        },
-    );
+    let init = if first_file.is_empty() {
+        HashMap::new()
+    } else {
+        HashMap::from_iter([(first_file, first_manifest)])
+    };
+
+    let result =
+        manifest_strings
+            .iter()
+            .zip(file_strings.iter())
+            .fold(init, |mut acc, (manifest, file)| {
+                if let (Some(manifest), Some(file)) = (manifest, file)
+                    && !file.is_empty()
+                {
+                    acc.insert(file.to_owned(), manifest.to_owned());
+                }
+                acc
+            });
 
     Ok(result)
 }

--- a/crates/core-executor/src/datafusion/physical_plan/merge.rs
+++ b/crates/core-executor/src/datafusion/physical_plan/merge.rs
@@ -27,6 +27,7 @@ use iceberg_rust::{
 };
 use lru::LruCache;
 use pin_project_lite::pin_project;
+use snafu::ResultExt;
 use std::{
     collections::{HashMap, HashSet},
     num::NonZeroUsize,
@@ -189,14 +190,14 @@ impl ExecutionPlan for MergeIntoCOWSinkExec {
                             .append_data(datafiles)
                             .commit()
                             .await
-                            .map_err(DataFusionIcebergError::from)?;
+                            .context(error::IcebergSnafu)?;
                     } else {
                         table
                             .new_transaction(branch.as_deref())
                             .overwrite(datafiles, matching_files)
                             .commit()
                             .await
-                            .map_err(DataFusionIcebergError::from)?;
+                            .context(error::IcebergSnafu)?;
                     }
                 }
 

--- a/crates/core-executor/src/error.rs
+++ b/crates/core-executor/src/error.rs
@@ -587,3 +587,9 @@ impl Display for ObjectType {
         }
     }
 }
+
+impl From<Error> for datafusion_common::DataFusionError {
+    fn from(value: Error) -> Self {
+        Self::External(Box::new(value))
+    }
+}

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -717,6 +717,17 @@ test_query!(
     ]
 );
 
+test_query!(
+    merge_into_empty_table,
+    "SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target",
+    setup_queries = [
+        "CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR)",
+        "CREATE TABLE embucket.public.merge_source (ID INTEGER, description VARCHAR)",
+        "INSERT INTO embucket.public.merge_source VALUES (2, 'updated row'), (3, 'new row')",
+        "MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET description = merge_source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (merge_source.id, merge_source.description)",
+    ]
+);
+
 // TRUNCATE TABLE
 test_query!(truncate_table, "TRUNCATE TABLE employee_table");
 test_query!(

--- a/crates/core-executor/src/tests/snapshots/query_merge_into_empty_table.snap
+++ b/crates/core-executor/src/tests/snapshots/query_merge_into_empty_table.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target\""
+info: "Setup queries: CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR); CREATE TABLE embucket.public.merge_source (ID INTEGER, description VARCHAR); INSERT INTO embucket.public.merge_source VALUES (2, 'updated row'), (3, 'new row'); MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET description = merge_source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (merge_source.id, merge_source.description)"
+---
+Ok(
+    [
+        "+---------+----------+",
+        "| updated | existing |",
+        "+---------+----------+",
+        "| 1       | 0        |",
+        "+---------+----------+",
+    ],
+)


### PR DESCRIPTION
## Summary
- Fixed MERGE INTO operation when target table is empty
- Changed from using overwrite to append_data when no matching files exist
- Fixed stream polling to return data instead of pending when no matches found
- Added proper handling for empty strings in unique value collection

## Closes
Closes #1571