### PR TITLE
Allow float values in dateadd

### DIFF
--- a/crates/embucket-functions/src/datetime/date_add.rs
+++ b/crates/embucket-functions/src/datetime/date_add.rs
@@ -1,14 +1,13 @@
+use crate::datetime::is_datetime_like;
 use datafusion::arrow::array::{Array, ArrayRef};
 use datafusion::arrow::compute::kernels::numeric::add_wrapping;
 use datafusion::arrow::datatypes::DataType;
-use datafusion::arrow::datatypes::TimeUnit::Nanosecond;
 use datafusion::common::{Result, plan_err};
-use datafusion::logical_expr::TypeSignature::Coercible;
-use datafusion::logical_expr::TypeSignatureClass;
-use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
+use datafusion::logical_expr::Volatility::Immutable;
+use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature};
 use datafusion::scalar::ScalarValue;
-use datafusion_common::types::{NativeType, logical_date, logical_int64, logical_string};
-use datafusion_expr::Coercion;
+use datafusion_common::utils::take_function_args;
+use rust_decimal::prelude::ToPrimitive;
 use std::any::Any;
 use std::sync::Arc;
 
@@ -29,30 +28,7 @@ impl DateAddFunc {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            signature: Signature::one_of(
-                vec![
-                    Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_int64())),
-                        Coercion::new_implicit(
-                            TypeSignatureClass::Timestamp,
-                            vec![TypeSignatureClass::Native(logical_string())],
-                            NativeType::Timestamp(Nanosecond, None),
-                        ),
-                    ]),
-                    Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_int64())),
-                        Coercion::new_exact(TypeSignatureClass::Time),
-                    ]),
-                    Coercible(vec![
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_string())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_int64())),
-                        Coercion::new_exact(TypeSignatureClass::Native(logical_date())),
-                    ]),
-                ],
-                Volatility::Immutable,
-            ),
+            signature: Signature::user_defined(Immutable),
             aliases: vec![
                 String::from("date_add"),
                 String::from("time_add"),
@@ -95,30 +71,30 @@ impl DateAddFunc {
     }
 }
 
-// dateadd SQL function
-// Syntax: `DATEADD(<date_or_time_part>, <value>, <date_or_time_expr>)`
-// - <date_or_time_part>: This indicates the units of time that you want to add.
-// For example if you want to add two days, then specify day. This unit of measure must be one of the values listed in Supported date and time parts.
-// - <value>: This is the number of units of time that you want to add.
-// For example, if the units of time is day, and you want to add two days, specify 2. If you want to subtract two days, specify -2.
-// - <date_or_time_expr>: Must evaluate to a date, time, or timestamp.
-// This is the date, time, or timestamp to which you want to add.
-// For example, if you want to add two days to August 1, 2024, then specify '2024-08-01'::DATE.
-// If the data type is TIME, then the date_or_time_part must be in units of hours or smaller, not days or bigger.
-// If the input data type is DATE, and the date_or_time_part is hours or smaller, the input value will not be rejected,
-// but instead will be treated as a TIMESTAMP with hours, minutes, seconds, and fractions of a second all initially set to 0 (e.g. midnight on the specified date).
-//
-// Note: `dateadd` returns
-// If date_or_time_expr is a time, then the return data type is a time.
-// If date_or_time_expr is a timestamp, then the return data type is a timestamp.
-// If date_or_time_expr is a date:
-// - If date_or_time_part is day or larger (for example, month, year), the function returns a DATE value.
-// - If date_or_time_part is smaller than a day (for example, hour, minute, second), the function returns a TIMESTAMP_NTZ value, with 00:00:00.000 as the starting time for the date.
-// Usage notes:
-// - When date_or_time_part is year, quarter, or month (or any of their variations),
-// if the result month has fewer days than the original day of the month, the result day of the month might be different from the original day.
-// Examples
-// - dateadd(day, 30, CAST('2024-12-26' AS TIMESTAMP))
+/// dateadd SQL function
+/// Syntax: `DATEADD(<date_or_time_part>, <value>, <date_or_time_expr>)`
+/// - <`date_or_time_part`>: This indicates the units of time that you want to add.
+///   For example if you want to add two days, then specify day. This unit of measure must be one of the values listed in Supported date and time parts.
+/// - <value>: This is the number of units of time that you want to add.
+///   For example, if the units of time is day, and you want to add two days, specify 2. If you want to subtract two days, specify -2.
+/// - <`date_or_time_expr`>: Must evaluate to a date, time, or timestamp.
+///   This is the date, time, or timestamp to which you want to add.
+///   For example, if you want to add two days to August 1, 2024, then specify '2024-08-01'`::DATE`.
+///   If the data type is TIME, then the `date_or_time_part` must be in units of hours or smaller, not days or bigger.
+///   If the input data type is DATE, and the `date_or_time_part` is hours or smaller, the input value will not be rejected,
+///   but instead will be treated as a TIMESTAMP with hours, minutes, seconds, and fractions of a second all initially set to 0 (e.g. midnight on the specified date).
+///
+/// Note: `dateadd` returns
+/// - If `date_or_time_expr` is a time, then the return data type is a time.
+/// - If `date_or_time_expr` is a timestamp, then the return data type is a timestamp.
+/// - If `date_or_time_expr` is a date:
+/// - If `date_or_time_part` is day or larger (for example, month, year), the function returns a DATE value.
+/// - If `date_or_time_part` is smaller than a day (for example, hour, minute, second), the function returns a `TIMESTAMP_NTZ` value, with 00:00:00.000 as the starting time for the date.
+///   Usage notes:
+/// - When `date_or_time_part` is year, quarter, or month (or any of their variations),
+///   if the result month has fewer days than the original day of the month, the result day of the month might be different from the original day.
+///   Examples
+/// - dateadd(day, 30, CAST('2024-12-26' AS TIMESTAMP))
 impl ScalarUDFImpl for DateAddFunc {
     fn as_any(&self) -> &dyn Any {
         self
@@ -138,6 +114,33 @@ impl ScalarUDFImpl for DateAddFunc {
         }
         Ok(arg_types[2].clone())
     }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        let [units, value, expr] = take_function_args(self.name(), arg_types)?;
+        let units = match units {
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Null => DataType::Utf8,
+            other => {
+                return plan_err!("First argument must be a string, but found {:?}", other);
+            }
+        };
+        if !is_datetime_like(expr) {
+            return plan_err!("third arguments must be date, time, timestamp or string");
+        }
+
+        let value = match value.clone() {
+            v if v.is_integer() => DataType::Int64,
+            v if v.is_numeric() => DataType::Float64,
+            other => {
+                return plan_err!("Second argument must be a number, but found {:?}", other);
+            }
+        };
+
+        // `value` is the number of units of time that you want to add.
+        // For example, if the units of time is day, and you want to add two days, specify 2.
+        // If you want to subtract two days, specify -2. It should be an integer.
+        Ok(vec![units, value, expr.clone()])
+    }
+
     fn invoke_with_args(&self, args: datafusion_expr::ScalarFunctionArgs) -> Result<ColumnarValue> {
         let args = args.args;
         if args.len() != 3 {
@@ -150,6 +153,10 @@ impl ScalarUDFImpl for DateAddFunc {
 
         let value = match &args[1] {
             ColumnarValue::Scalar(ScalarValue::Int64(Some(val))) => *val,
+            ColumnarValue::Scalar(ScalarValue::Float64(Some(val))) => val
+                .round()
+                .to_i64()
+                .map_or_else(|| plan_err!("Value out of range"), Ok)?,
             _ => return plan_err!("Invalid value type"),
         };
         let (is_scalar, date_or_time_expr) = match &args[2] {
@@ -209,107 +216,50 @@ crate::macros::make_udf_function!(DateAddFunc);
 #[allow(clippy::unwrap_in_result, clippy::unwrap_used)]
 mod tests {
     use super::DateAddFunc;
-    use datafusion_common::ScalarValue;
-    use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl};
-    use std::sync::Arc;
+    use datafusion::common::Result as DFResult;
+    use datafusion::prelude::SessionContext;
+    use datafusion_common::assert_batches_eq;
+    use datafusion_expr::ScalarUDF;
 
-    #[test]
-    fn test_date_add_days_timestamp() {
-        let args = vec![
-            ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("days")))),
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(5i64))),
-            ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-                Some(1_736_168_400_000_000_i64),
-                Some(Arc::from(String::from("+00").into_boxed_str())),
-            )),
-        ];
-        let fn_args = ScalarFunctionArgs {
-            args,
-            number_rows: 0,
-            return_type: &datafusion::arrow::datatypes::DataType::Timestamp(
-                datafusion::arrow::datatypes::TimeUnit::Microsecond,
-                Some(Arc::from(String::from("+00").into_boxed_str())),
-            ),
-        };
-        match DateAddFunc::new().invoke_with_args(fn_args) {
-            Ok(ColumnarValue::Scalar(result)) => {
-                let expected = ScalarValue::TimestampMicrosecond(
-                    Some(1_736_600_400_000_000_i64),
-                    Some(Arc::from(String::from("+00").into_boxed_str())),
-                );
-                assert_eq!(&result, &expected, "date_add created a wrong value");
-            }
-            _ => panic!("Conversion failed"),
-        }
-    }
-    #[test]
-    fn test_date_add_days_timestamp_array() {
-        let args = vec![
-            ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("days")))),
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(5i64))),
-            ColumnarValue::Array(
-                ScalarValue::TimestampMicrosecond(
-                    Some(1_736_168_400_000_000_i64),
-                    Some(Arc::from(String::from("+00").into_boxed_str())),
-                )
-                .to_array()
-                .unwrap(),
-            ),
-        ];
-        let fn_args = ScalarFunctionArgs {
-            args,
-            number_rows: 0,
-            return_type: &datafusion::arrow::datatypes::DataType::Timestamp(
-                datafusion::arrow::datatypes::TimeUnit::Microsecond,
-                Some(Arc::from(String::from("+00").into_boxed_str())),
-            ),
-        };
-        match DateAddFunc::new().invoke_with_args(fn_args) {
-            Ok(ColumnarValue::Array(result)) => {
-                let expected = ScalarValue::TimestampMicrosecond(
-                    Some(1_736_600_400_000_000_i64),
-                    Some(Arc::from(String::from("+00").into_boxed_str())),
-                )
-                .to_array()
-                .unwrap();
-                assert_eq!(&result, &expected, "date_add created a wrong value");
-            }
-            _ => panic!("Conversion failed"),
-        }
-    }
-    #[test]
-    fn test_date_add_days_timestamp_array_multiple_values() {
-        let args = vec![
-            ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::from("days")))),
-            ColumnarValue::Scalar(ScalarValue::Int64(Some(5i64))),
-            ColumnarValue::Array(
-                ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-                    Some(1_736_168_400_000_000_i64),
-                    Some(Arc::from(String::from("+00").into_boxed_str())),
-                ))
-                .to_array(2)
-                .unwrap(),
-            ),
-        ];
-        let fn_args = ScalarFunctionArgs {
-            args,
-            number_rows: 0,
-            return_type: &datafusion::arrow::datatypes::DataType::Timestamp(
-                datafusion::arrow::datatypes::TimeUnit::Microsecond,
-                Some(Arc::from(String::from("+00").into_boxed_str())),
-            ),
-        };
-        match DateAddFunc::new().invoke_with_args(fn_args) {
-            Ok(ColumnarValue::Array(result)) => {
-                let expected = ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
-                    Some(1_736_600_400_000_000_i64),
-                    Some(Arc::from(String::from("+00").into_boxed_str())),
-                ))
-                .to_array(2)
-                .unwrap();
-                assert_eq!(&result, &expected, "date_add created a wrong value");
-            }
-            _ => panic!("Conversion failed"),
-        }
+    #[tokio::test]
+    async fn test_date_add_days_timestamp() -> DFResult<()> {
+        let ctx = SessionContext::new();
+        ctx.register_udf(ScalarUDF::from(DateAddFunc::new()));
+        let sql = r#"SELECT DATEADD('days', 5, 1735678800::TIMESTAMP) as res"#;
+        let result = ctx.sql(sql).await?.collect().await?;
+
+        assert_batches_eq!(
+            &[
+                "+---------------------+",
+                "| res                 |",
+                "+---------------------+",
+                "| 2025-01-05T21:00:00 |",
+                "+---------------------+",
+            ],
+            &result
+        );
+
+        let ctx = SessionContext::new();
+        ctx.register_udf(ScalarUDF::from(DateAddFunc::new()));
+        let sql = r"
+            WITH vals AS (SELECT * FROM VALUES (1735678800),(1735678800) AS t(num))
+            SELECT 
+                DATEADD('days', 5, num::TIMESTAMP) as c1,
+                DATEADD('days', 5.6, num::TIMESTAMP) as c2
+            FROM vals as res";
+        let result = ctx.sql(sql).await?.collect().await?;
+
+        assert_batches_eq!(
+            &[
+                "+---------------------+---------------------+",
+                "| c1                  | c2                  |",
+                "+---------------------+---------------------+",
+                "| 2025-01-05T21:00:00 | 2025-01-06T21:00:00 |",
+                "| 2025-01-05T21:00:00 | 2025-01-06T21:00:00 |",
+                "+---------------------+---------------------+",
+            ],
+            &result
+        );
+        Ok(())
     }
 }

--- a/crates/embucket-functions/src/datetime/date_add.rs
+++ b/crates/embucket-functions/src/datetime/date_add.rs
@@ -108,7 +108,11 @@ impl DateAddFunc {
         let part = unit.to_lowercase();
         if matches!(expr_type, DataType::Date32 | DataType::Date64) {
             match part.as_str() {
-                "hour" | "minute" | "second" => {
+                "hour" | "h" | "hh" | "hr" | "hours" | "hrs" | "minute" | "m" | "mi" | "min"
+                | "minutes" | "mins" | "second" | "s" | "sec" | "seconds" | "secs"
+                | "millisecond" | "ms" | "msec" | "milliseconds" | "microsecond" | "us"
+                | "usec" | "microseconds" | "nanosecond" | "ns" | "nsec" | "nanosec"
+                | "nsecond" | "nanoseconds" | "nanosecs" | "nseconds" => {
                     return_type = DataType::Timestamp(TimeUnit::Nanosecond, None);
                 }
                 _ => {}

--- a/crates/embucket-functions/src/datetime/errors.rs
+++ b/crates/embucket-functions/src/datetime/errors.rs
@@ -53,6 +53,11 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("return_type_from_args should be called"))]
+    ReturnTypeFromArgsShouldBeCalled {
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 // Enum variants from this error return DataFusionError

--- a/crates/embucket-functions/src/datetime/errors.rs
+++ b/crates/embucket-functions/src/datetime/errors.rs
@@ -47,6 +47,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Invalid argument: {description}"))]
+    InvalidArgument {
+        description: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 // Enum variants from this error return DataFusionError

--- a/crates/embucket-functions/src/datetime/mod.rs
+++ b/crates/embucket-functions/src/datetime/mod.rs
@@ -1,3 +1,4 @@
+use arrow_schema::DataType;
 use datafusion_expr::ScalarUDF;
 use datafusion_expr::registry::FunctionRegistry;
 use std::sync::Arc;
@@ -48,4 +49,18 @@ pub fn register_udfs(
         session_params.to_owned(),
     ))))?;
     Ok(())
+}
+
+const fn is_datetime_like(dt: &DataType) -> bool {
+    matches!(
+        dt,
+        DataType::Timestamp(_, _)
+            | DataType::Date32
+            | DataType::Date64
+            | DataType::Time32(_)
+            | DataType::Time64(_)
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Null
+    )
 }

--- a/crates/embucket-functions/src/datetime/mod.rs
+++ b/crates/embucket-functions/src/datetime/mod.rs
@@ -1,4 +1,3 @@
-use arrow_schema::DataType;
 use datafusion_expr::ScalarUDF;
 use datafusion_expr::registry::FunctionRegistry;
 use std::sync::Arc;
@@ -49,18 +48,4 @@ pub fn register_udfs(
         session_params.to_owned(),
     ))))?;
     Ok(())
-}
-
-const fn is_datetime_like(dt: &DataType) -> bool {
-    matches!(
-        dt,
-        DataType::Timestamp(_, _)
-            | DataType::Date32
-            | DataType::Date64
-            | DataType::Time32(_)
-            | DataType::Time64(_)
-            | DataType::Utf8
-            | DataType::LargeUtf8
-            | DataType::Null
-    )
 }


### PR DESCRIPTION
Close #1574 
Added coerce_types to dateadd
to support sql with floating values (it should be rounded to i64)
```sql
 select dateadd(s, 23.7, '2021-03-03T00:00:00'::TIMESTAMP);
2021-03-03 00:00:24

 select dateadd(s, 23.2, '2021-03-03T00:00:00'::TIMESTAMP);
2021-03-03 00:00:23    
```

Badge generated with 82.0% success rate
