### PR TITLE
Fix aggregate functions on empty tables by preserving AggregateExec in optimizer

### DIFF
--- a/crates/core-executor/src/tests/sql/functions/aggregate/count.rs
+++ b/crates/core-executor/src/tests/sql/functions/aggregate/count.rs
@@ -13,3 +13,10 @@ test_query!(
     setup_queries = ["CREATE TABLE empty_table (id INT)"],
     snapshot_path = "aggregate"
 );
+
+test_query!(
+    count_cte_with_group_by,
+    "SELECT COUNT(*) FROM empty_table GROUP BY id",
+    setup_queries = ["CREATE TABLE empty_table (id INT)"],
+    snapshot_path = "aggregate"
+);

--- a/crates/core-executor/src/tests/sql/functions/aggregate/count.rs
+++ b/crates/core-executor/src/tests/sql/functions/aggregate/count.rs
@@ -1,0 +1,8 @@
+use crate::test_query;
+
+test_query!(
+    count,
+    "SELECT COUNT(*) FROM empty_table",
+    setup_queries = ["CREATE TABLE empty_table (id INT)"],
+    snapshot_path = "aggregate"
+);

--- a/crates/core-executor/src/tests/sql/functions/aggregate/count.rs
+++ b/crates/core-executor/src/tests/sql/functions/aggregate/count.rs
@@ -6,3 +6,10 @@ test_query!(
     setup_queries = ["CREATE TABLE empty_table (id INT)"],
     snapshot_path = "aggregate"
 );
+
+test_query!(
+    count_cte,
+    "WITH c as (SELECT COUNT(*) FROM empty_table) SELECT * FROM c",
+    setup_queries = ["CREATE TABLE empty_table (id INT)"],
+    snapshot_path = "aggregate"
+);

--- a/crates/core-executor/src/tests/sql/functions/aggregate/mod.rs
+++ b/crates/core-executor/src/tests/sql/functions/aggregate/mod.rs
@@ -1,2 +1,3 @@
+mod count;
 mod grouping_id;
 mod variance;

--- a/crates/core-executor/src/tests/sql/functions/aggregate/snapshots/aggregate/query_count.snap
+++ b/crates/core-executor/src/tests/sql/functions/aggregate/snapshots/aggregate/query_count.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/sql/functions/aggregate/count.rs
+description: "\"SELECT COUNT(*) FROM empty_table\""
+info: "Setup queries: CREATE TABLE empty_table (id INT)"
+---
+Ok(
+    [
+        "+----------+",
+        "| count(*) |",
+        "+----------+",
+        "| 0        |",
+        "+----------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/functions/aggregate/snapshots/aggregate/query_count_cte.snap
+++ b/crates/core-executor/src/tests/sql/functions/aggregate/snapshots/aggregate/query_count_cte.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/sql/functions/aggregate/count.rs
+description: "\"WITH c as (SELECT COUNT(*) FROM empty_table) SELECT * FROM c\""
+info: "Setup queries: CREATE TABLE empty_table (id INT)"
+---
+Ok(
+    [
+        "+----------+",
+        "| count(*) |",
+        "+----------+",
+        "| 0        |",
+        "+----------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/functions/aggregate/snapshots/aggregate/query_count_cte_with_group_by.snap
+++ b/crates/core-executor/src/tests/sql/functions/aggregate/snapshots/aggregate/query_count_cte_with_group_by.snap
@@ -1,0 +1,11 @@
+---
+source: crates/core-executor/src/tests/sql/functions/aggregate/count.rs
+description: "\"SELECT COUNT(*) FROM empty_table GROUP BY id\""
+info: "Setup queries: CREATE TABLE empty_table (id INT)"
+---
+Ok(
+    [
+        "++",
+        "++",
+    ],
+)


### PR DESCRIPTION
## Summary

Fixes a critical regression where aggregate functions like COUNT(*) on empty tables were returning empty result sets instead of the correct SQL-compliant results.

## Problem

The `RemoveExecAboveEmpty` physical optimizer rule introduced in commit 671d82ce was incorrectly replacing **all** execution plan nodes above empty tables with `EmptyExec`, including aggregate operations. This violated SQL standards where:

- `COUNT(*)` on empty tables should return `0`
- `SUM/AVG/MIN/MAX` on empty tables should return `NULL`

Instead, queries like `SELECT COUNT(*) FROM empty_table` were returning completely empty result sets.

## Root Cause

The original implementation in #756 included comprehensive tests for various execution plan types (Sort, Filter, Projection, Join, Limit) but **completely missed testing aggregate operations**. This oversight allowed the bug to slip through.

## Solution

Modified the `RemoveExecAboveEmpty` optimizer rule to exclude `AggregateExec` operations from being replaced with `EmptyExec`. Aggregate functions have special semantics and must be preserved even when their inputs are empty.

### Changes Made

1. **Fixed the optimizer rule** (`remove_exec_above_empty.rs`):
   - Added import for `AggregateExec`
   - Added logic to preserve aggregate operations when inputs are empty
   - Updated documentation to reflect the new behavior

2. **Added missing test coverage** (`count.rs`):
   - Added `COUNT(*)` test case that was missing from the original implementation
   - Includes proper snapshot testing for the expected output format

## Test Results

**Before fix:**
```
"++"
"++"
```

**After fix:**
```
"+----------+"
"| count(*) |"
"+----------+"
"| 0        |"
"+----------+"
```

## Impact

- Fixes COUNT(*) and other aggregate functions on empty tables
- Maintains performance optimizations for non-aggregate operations
- Adds test coverage to prevent future regressions
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)