### PR TITLE
engine: `LIKE ANY`

### DIFF
--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -73,7 +73,7 @@ use df_catalog::catalog_list::CachedEntity;
 use df_catalog::table::CachingTable;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::session_params::SessionProperty;
-use embucket_functions::visitors::{copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query, like_ilike_any, rlike_regexp_expr_rewriter, select_expr_aliases, table_functions, table_functions_cte_relation, timestamp, top_limit, unimplemented::functions_checker::visit as unimplemented_functions_checker};
+use embucket_functions::visitors::{copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query, like_any, rlike_regexp_expr_rewriter, select_expr_aliases, table_functions, table_functions_cte_relation, timestamp, top_limit, unimplemented::functions_checker::visit as unimplemented_functions_checker};
 use iceberg_rust::catalog::Catalog;
 use iceberg_rust::catalog::create::CreateTableBuilder;
 use iceberg_rust::catalog::identifier::Identifier;
@@ -259,7 +259,7 @@ impl UserQuery {
         if let DFStatement::Statement(value) = statement {
             rlike_regexp_expr_rewriter::visit(value);
             functions_rewriter::visit(value);
-            like_ilike_any::visit(value);
+            like_any::visit(value);
             top_limit::visit(value);
             unimplemented_functions_checker(value).context(ex_error::UnimplementedFunctionSnafu)?;
             copy_into_identifiers::visit(value);

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -73,7 +73,12 @@ use df_catalog::catalog_list::CachedEntity;
 use df_catalog::table::CachingTable;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::session_params::SessionProperty;
-use embucket_functions::visitors::{copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query, like_any, rlike_regexp_expr_rewriter, select_expr_aliases, table_functions, table_functions_cte_relation, timestamp, top_limit, unimplemented::functions_checker::visit as unimplemented_functions_checker};
+use embucket_functions::visitors::{
+    copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query, like_any,
+    rlike_regexp_expr_rewriter, select_expr_aliases, table_functions, table_functions_cte_relation,
+    timestamp, top_limit,
+    unimplemented::functions_checker::visit as unimplemented_functions_checker,
+};
 use iceberg_rust::catalog::Catalog;
 use iceberg_rust::catalog::create::CreateTableBuilder;
 use iceberg_rust::catalog::identifier::Identifier;

--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -73,12 +73,7 @@ use df_catalog::catalog_list::CachedEntity;
 use df_catalog::table::CachingTable;
 use embucket_functions::semi_structured::variant::visitors::visit_all;
 use embucket_functions::session_params::SessionProperty;
-use embucket_functions::visitors::{
-    copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query,
-    rlike_regexp_expr_rewriter, select_expr_aliases, table_functions, table_functions_cte_relation,
-    timestamp, top_limit,
-    unimplemented::functions_checker::visit as unimplemented_functions_checker,
-};
+use embucket_functions::visitors::{copy_into_identifiers, fetch_to_limit, functions_rewriter, inline_aliases_in_query, like_ilike_any, rlike_regexp_expr_rewriter, select_expr_aliases, table_functions, table_functions_cte_relation, timestamp, top_limit, unimplemented::functions_checker::visit as unimplemented_functions_checker};
 use iceberg_rust::catalog::Catalog;
 use iceberg_rust::catalog::create::CreateTableBuilder;
 use iceberg_rust::catalog::identifier::Identifier;
@@ -264,6 +259,7 @@ impl UserQuery {
         if let DFStatement::Statement(value) = statement {
             rlike_regexp_expr_rewriter::visit(value);
             functions_rewriter::visit(value);
+            like_ilike_any::visit(value);
             top_limit::visit(value);
             unimplemented_functions_checker(value).context(ex_error::UnimplementedFunctionSnafu)?;
             copy_into_identifiers::visit(value);

--- a/crates/core-executor/src/tests/sql/commands/like_any.rs
+++ b/crates/core-executor/src/tests/sql/commands/like_any.rs
@@ -1,0 +1,91 @@
+use crate::test_query;
+
+test_query!(
+    like_any_even,
+    "SELECT * FROM VALUES
+                ('John  Dddoe'),
+                ('Joe   Doe'),
+                ('John_down'),
+                ('Joe down'),
+                ('Tom   Doe'),
+                ('Tim down'),
+                (NULL)
+            WHERE column1 LIKE ANY ('%Jo%oe%','T%e')
+            ORDER BY column1",
+    snapshot_path = "like_any"
+);
+
+test_query!(
+    like_any_odd,
+    "SELECT * FROM VALUES
+                ('John  Dddoe'),
+                ('Joe   Doe'),
+                ('John_down'),
+                ('Joe down'),
+                ('Tom   Doe'),
+                ('Tim down'),
+                (NULL)
+            WHERE column1 LIKE ANY ('%Jo%oe%','T%e', '%Tim%')
+            ORDER BY column1",
+    snapshot_path = "like_any"
+);
+
+test_query!(
+    like_any_odd_wrong,
+    "SELECT * FROM VALUES
+                ('John  Dddoe'),
+                ('Joe   Doe'),
+                ('John_down'),
+                ('Joe down'),
+                ('Tom   Doe'),
+                ('Tim down'),
+                (NULL)
+            WHERE column1 LIKE ANY ('%Jo%oe%','T%e', '%Tim%', '%YES%')
+            ORDER BY column1",
+    snapshot_path = "like_any"
+);
+
+test_query!(
+    like_any_even_wrong,
+    "SELECT * FROM VALUES
+                ('John  Dddoe'),
+                ('Joe   Doe'),
+                ('John_down'),
+                ('Joe down'),
+                ('Tom   Doe'),
+                ('Tim down'),
+                (NULL)
+            WHERE column1 LIKE ANY ('%Jo%oe%', '%YES%')
+            ORDER BY column1",
+    snapshot_path = "like_any"
+);
+
+test_query!(
+    like_any_one,
+    "SELECT * FROM VALUES
+                ('John  Dddoe'),
+                ('Joe   Doe'),
+                ('John_down'),
+                ('Joe down'),
+                ('Tom   Doe'),
+                ('Tim down'),
+                (NULL)
+            WHERE column1 LIKE ANY ('%Jo%oe%')
+            ORDER BY column1",
+    snapshot_path = "like_any"
+);
+
+test_query!(
+    like_any_one_wrong,
+    "SELECT * FROM VALUES
+                ('John  Dddoe'),
+                ('Joe   Doe'),
+                ('John_down'),
+                ('Joe down'),
+                ('Tom   Doe'),
+                ('Tim down'),
+                (NULL)
+            WHERE column1 LIKE ANY ('%YES%')
+            ORDER BY column1",
+    snapshot_path = "like_any"
+);

--- a/crates/core-executor/src/tests/sql/commands/mod.rs
+++ b/crates/core-executor/src/tests/sql/commands/mod.rs
@@ -1,4 +1,5 @@
 mod fetch;
+mod like_any;
 mod pivot;
 mod rlike_regexp;
 mod show;

--- a/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_even.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_even.snap
@@ -1,0 +1,15 @@
+---
+source: crates/core-executor/src/tests/sql/commands/like_any.rs
+description: "\"SELECT * FROM VALUES\n                ('John  Dddoe'),\n                ('Joe   Doe'),\n                ('John_down'),\n                ('Joe down'),\n                ('Tom   Doe'),\n                ('Tim down'),\n                (NULL)\n            WHERE column1 LIKE ANY ('%Jo%oe%','T%e')\n            ORDER BY column1\""
+---
+Ok(
+    [
+        "+-------------+",
+        "| column1     |",
+        "+-------------+",
+        "| Joe   Doe   |",
+        "| John  Dddoe |",
+        "| Tom   Doe   |",
+        "+-------------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_even_wrong.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_even_wrong.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/sql/commands/like_any.rs
+description: "\"SELECT * FROM VALUES\n                ('John  Dddoe'),\n                ('Joe   Doe'),\n                ('John_down'),\n                ('Joe down'),\n                ('Tom   Doe'),\n                ('Tim down'),\n                (NULL)\n            WHERE column1 LIKE ANY ('%Jo%oe%', '%YES%')\n            ORDER BY column1\""
+---
+Ok(
+    [
+        "+-------------+",
+        "| column1     |",
+        "+-------------+",
+        "| Joe   Doe   |",
+        "| John  Dddoe |",
+        "+-------------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_odd.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_odd.snap
@@ -1,0 +1,16 @@
+---
+source: crates/core-executor/src/tests/sql/commands/like_any.rs
+description: "\"SELECT * FROM VALUES\n                ('John  Dddoe'),\n                ('Joe   Doe'),\n                ('John_down'),\n                ('Joe down'),\n                ('Tom   Doe'),\n                ('Tim down'),\n                (NULL)\n            WHERE column1 LIKE ANY ('%Jo%oe%','T%e', '%Tim%')\n            ORDER BY column1\""
+---
+Ok(
+    [
+        "+-------------+",
+        "| column1     |",
+        "+-------------+",
+        "| Joe   Doe   |",
+        "| John  Dddoe |",
+        "| Tim down    |",
+        "| Tom   Doe   |",
+        "+-------------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_odd_wrong.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_odd_wrong.snap
@@ -1,0 +1,16 @@
+---
+source: crates/core-executor/src/tests/sql/commands/like_any.rs
+description: "\"SELECT * FROM VALUES\n                ('John  Dddoe'),\n                ('Joe   Doe'),\n                ('John_down'),\n                ('Joe down'),\n                ('Tom   Doe'),\n                ('Tim down'),\n                (NULL)\n            WHERE column1 LIKE ANY ('%Jo%oe%','T%e', '%Tim%', '%YES%')\n            ORDER BY column1\""
+---
+Ok(
+    [
+        "+-------------+",
+        "| column1     |",
+        "+-------------+",
+        "| Joe   Doe   |",
+        "| John  Dddoe |",
+        "| Tim down    |",
+        "| Tom   Doe   |",
+        "+-------------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_one.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_one.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/sql/commands/like_any.rs
+description: "\"SELECT * FROM VALUES\n                ('John  Dddoe'),\n                ('Joe   Doe'),\n                ('John_down'),\n                ('Joe down'),\n                ('Tom   Doe'),\n                ('Tim down'),\n                (NULL)\n            WHERE column1 LIKE ANY ('%Jo%oe%')\n            ORDER BY column1\""
+---
+Ok(
+    [
+        "+-------------+",
+        "| column1     |",
+        "+-------------+",
+        "| Joe   Doe   |",
+        "| John  Dddoe |",
+        "+-------------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_one_wrong.snap
+++ b/crates/core-executor/src/tests/sql/commands/snapshots/like_any/query_like_any_one_wrong.snap
@@ -1,0 +1,10 @@
+---
+source: crates/core-executor/src/tests/sql/commands/like_any.rs
+description: "\"SELECT * FROM VALUES\n                ('John  Dddoe'),\n                ('Joe   Doe'),\n                ('John_down'),\n                ('Joe down'),\n                ('Tom   Doe'),\n                ('Tim down'),\n                (NULL)\n            WHERE column1 LIKE ANY ('%YES%')\n            ORDER BY column1\""
+---
+Ok(
+    [
+        "++",
+        "++",
+    ],
+)

--- a/crates/embucket-functions/src/visitors/like_any.rs
+++ b/crates/embucket-functions/src/visitors/like_any.rs
@@ -18,11 +18,8 @@ impl VisitorMut for LikeILikeAny {
                 tracing::error!("Pattern: {:?}", *pattern);
             }
             tracing::error!("AST expr: {:?}", expr);
-        } else if let Expr::ILike { negated, any, expr: inner_expr, pattern, escape_char, } = expr {
-            if *any {
-                tracing::error!("Pattern:  {:?}", *pattern);
-            }
-            tracing::error!("AST expr: {:?}", expr);
+            //For even number of patterns in `any` its: patterns / 2 = binary expr of like or
+            //For ood number of patterns in `any` its: (patterns / 2) + 1 = binary expr of like or
         }
         ControlFlow::Continue(())
     }

--- a/crates/embucket-functions/src/visitors/like_any.rs
+++ b/crates/embucket-functions/src/visitors/like_any.rs
@@ -1,30 +1,62 @@
-use datafusion::sql::sqlparser::ast::UnaryOperator;
-use datafusion_expr::sqlparser::ast::{
-    Expr, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments, Ident, ObjectName,
-    Statement, VisitorMut,
-};
-use datafusion_expr::sqlparser::ast::{Function, VisitMut};
-use std::ops::ControlFlow;
+use datafusion_expr::sqlparser::ast::VisitMut;
+use datafusion_expr::sqlparser::ast::{BinaryOperator, Expr, Statement, VisitorMut};
+use std::ops::{ControlFlow, Deref};
 
 #[derive(Debug, Default)]
-pub struct LikeILikeAny;
+pub struct LikeAny;
 
-impl VisitorMut for LikeILikeAny {
+impl VisitorMut for LikeAny {
     type Break = ();
 
     fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
-        if let Expr::Like { negated, any, expr: inner_expr, pattern, escape_char, } = expr {
-            if *any {
-                tracing::error!("Pattern: {:?}", *pattern);
+        if let Expr::Like {
+            negated,
+            any,
+            expr: inner_expr,
+            pattern,
+            escape_char,
+        } = expr
+            && *any
+        {
+            if let Expr::Tuple(patterns) = pattern.deref().deref() {
+                let mut new_expr = Expr::Like {
+                    negated: *negated,
+                    any: false,
+                    expr: inner_expr.clone(),
+                    pattern: Box::new(patterns[patterns.len() - 1].clone()),
+                    escape_char: escape_char.clone(),
+                };
+                //For even number of patterns in `any` its: patterns / 2 = binary expr of like or
+                //For ood number of patterns in `any` its: (patterns / 2) + 1 = binary expr of like or
+                patterns.iter().rev().skip(1).for_each(|expr| {
+                    new_expr = Expr::BinaryOp {
+                        left: Box::new(Expr::Like {
+                            negated: *negated,
+                            any: false,
+                            expr: inner_expr.clone(),
+                            pattern: Box::new(expr.clone()),
+                            escape_char: escape_char.clone(),
+                        }),
+                        op: BinaryOperator::Or,
+                        right: Box::new(new_expr.clone()),
+                    };
+                });
+                *expr = new_expr;
+            } else if let Expr::Nested(pattern) = pattern.deref().deref() {
+                let new_expr = Expr::Like {
+                    negated: *negated,
+                    any: false,
+                    expr: inner_expr.clone(),
+                    pattern: pattern.clone(),
+                    escape_char: escape_char.clone(),
+                };
+                *expr = new_expr;
             }
-            tracing::error!("AST expr: {:?}", expr);
-            //For even number of patterns in `any` its: patterns / 2 = binary expr of like or
-            //For ood number of patterns in `any` its: (patterns / 2) + 1 = binary expr of like or
         }
         ControlFlow::Continue(())
     }
 }
 
 pub fn visit(stmt: &mut Statement) {
-    let _ = stmt.visit(&mut LikeILikeAny {});
+    let _ = stmt.visit(&mut LikeAny {});
 }

--- a/crates/embucket-functions/src/visitors/like_ilike_any.rs
+++ b/crates/embucket-functions/src/visitors/like_ilike_any.rs
@@ -1,0 +1,33 @@
+use datafusion::sql::sqlparser::ast::UnaryOperator;
+use datafusion_expr::sqlparser::ast::{
+    Expr, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments, Ident, ObjectName,
+    Statement, VisitorMut,
+};
+use datafusion_expr::sqlparser::ast::{Function, VisitMut};
+use std::ops::ControlFlow;
+
+#[derive(Debug, Default)]
+pub struct LikeILikeAny;
+
+impl VisitorMut for LikeILikeAny {
+    type Break = ();
+
+    fn post_visit_expr(&mut self, expr: &mut Expr) -> ControlFlow<Self::Break> {
+        if let Expr::Like { negated, any, expr: inner_expr, pattern, escape_char, } = expr {
+            if *any {
+                tracing::error!("Pattern: {:?}", *pattern);
+            }
+            tracing::error!("AST expr: {:?}", expr);
+        } else if let Expr::ILike { negated, any, expr: inner_expr, pattern, escape_char, } = expr {
+            if *any {
+                tracing::error!("Pattern:  {:?}", *pattern);
+            }
+            tracing::error!("AST expr: {:?}", expr);
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+pub fn visit(stmt: &mut Statement) {
+    let _ = stmt.visit(&mut LikeILikeAny {});
+}

--- a/crates/embucket-functions/src/visitors/mod.rs
+++ b/crates/embucket-functions/src/visitors/mod.rs
@@ -10,6 +10,7 @@ pub mod fetch_to_limit;
 pub mod functions_rewriter;
 pub mod inline_aliases_in_query;
 pub mod json_element;
+pub mod like_any;
 pub mod rlike_regexp_expr_rewriter;
 pub mod select_expr_aliases;
 pub mod table_functions;
@@ -17,7 +18,6 @@ pub mod table_functions_cte_relation;
 pub mod timestamp;
 pub mod top_limit;
 pub mod unimplemented;
-pub mod like_any;
 
 #[must_use]
 pub fn query_with_body(inner_select: Select) -> Query {

--- a/crates/embucket-functions/src/visitors/mod.rs
+++ b/crates/embucket-functions/src/visitors/mod.rs
@@ -17,7 +17,7 @@ pub mod table_functions_cte_relation;
 pub mod timestamp;
 pub mod top_limit;
 pub mod unimplemented;
-pub mod like_ilike_any;
+pub mod like_any;
 
 #[must_use]
 pub fn query_with_body(inner_select: Select) -> Query {

--- a/crates/embucket-functions/src/visitors/mod.rs
+++ b/crates/embucket-functions/src/visitors/mod.rs
@@ -17,6 +17,7 @@ pub mod table_functions_cte_relation;
 pub mod timestamp;
 pub mod top_limit;
 pub mod unimplemented;
+pub mod like_ilike_any;
 
 #[must_use]
 pub fn query_with_body(inner_select: Select) -> Query {


### PR DESCRIPTION
Closes #1606 

- AST rewriter `LIKE ANY`
- `column_name LIKE ANY(..., ...)` -> `column_name LIKE ... OR column_name LIKE ...`
- Insta test + unit tests
- Gitlab error
- Escape char change is not supported by `DataFusion` (to be investigated #1618) 
- `ILIKE ANY` will follow in a different PR

P.S. I put this AST visitor (rewriter) in **embucket-functions** since all our visitors live there. But it's not a functions visitor.