### PR TITLE
fix timestamps optimize_projections

### DIFF
--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -610,6 +610,11 @@ test_query!(
 );
 
 test_query!(
+    timestamp_with_timezone_to_timestamp,
+    "SELECT TO_TIMESTAMP(CONVERT_TIMEZONE('UTC', '2024-12-31 10:00:00.000'::TIMESTAMP)) as model_tstamp;"
+);
+
+test_query!(
     timestamp_timezone,
     "SELECT TO_TIMESTAMP(1000000000)",
     setup_queries = ["ALTER SESSION SET timestamp_input_mapping = 'timestamp_tz'"]

--- a/crates/core-executor/src/tests/snapshots/query_timestamp_with_timezone_to_timestamp.snap
+++ b/crates/core-executor/src/tests/snapshots/query_timestamp_with_timezone_to_timestamp.snap
@@ -1,0 +1,13 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT TO_TIMESTAMP(CONVERT_TIMEZONE('UTC', '2024-12-31 10:00:00.000'::TIMESTAMP)) as model_tstamp;\""
+---
+Ok(
+    [
+        "+----------------------+",
+        "| model_tstamp         |",
+        "+----------------------+",
+        "| 2024-12-31T10:00:00Z |",
+        "+----------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/conversion/to_timestamp.rs
+++ b/crates/embucket-functions/src/conversion/to_timestamp.rs
@@ -205,6 +205,11 @@ impl ScalarUDFImpl for ToTimestampFunc {
             }
         }
 
+        // If the first argument is already a timestamp type, return it as is (with its timezone).
+        if matches!(args.arg_types[0], DataType::Timestamp(_, _)) {
+            return Ok(ReturnInfo::new_nullable(args.arg_types[0].clone()));
+        }
+
         Ok(ReturnInfo::new_nullable(DataType::Timestamp(
             TimeUnit::Nanosecond,
             self.timezone(),


### PR DESCRIPTION
Closes #1612
Closes #1604 

If the input in to_timestamp func is already a timestamp, we don't need to change it type since during execution it will be used as is with initial type. 
By this we avoid optimize_projections error when cheking return type and actual result type for the function call.