### PR TITLE
Update iceberg rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=617ab94b6f81d07bb76f060a381ee855ea6ec3ce#617ab94b6f81d07bb76f060a381ee855ea6ec3ce"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4511,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=617ab94b6f81d07bb76f060a381ee855ea6ec3ce#617ab94b6f81d07bb76f060a381ee855ea6ec3ce"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4536,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=617ab94b6f81d07bb76f060a381ee855ea6ec3ce#617ab94b6f81d07bb76f060a381ee855ea6ec3ce"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -4569,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=617ab94b6f81d07bb76f060a381ee855ea6ec3ce#617ab94b6f81d07bb76f060a381ee855ea6ec3ce"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.2.0",
@@ -4594,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=617ab94b6f81d07bb76f060a381ee855ea6ec3ce#617ab94b6f81d07bb76f060a381ee855ea6ec3ce"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2928,6 +2928,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.14",
  "tokio",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -4510,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4535,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -4568,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.2.0",
@@ -4593,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4511,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4536,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -4569,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.2.0",
@@ -4594,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=1769a060af4ab5e9ac8faae2accb1553f5c2b9c9#1769a060af4ab5e9ac8faae2accb1553f5c2b9c9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=45df1be99400c709c74164f067fc923a64217f93#45df1be99400c709c74164f067fc923a64217f93"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2921,6 +2921,7 @@ dependencies = [
  "futures",
  "iceberg-rust",
  "itertools 0.14.0",
+ "lru 0.16.0",
  "object_store",
  "pin-project-lite",
  "regex",
@@ -4509,7 +4510,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4534,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -4567,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
 dependencies = [
  "apache-avro",
  "arrow-schema 55.2.0",
@@ -4592,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=17d126f4278a43edefcbef852dfd3eb4a97d62c6#17d126f4278a43edefcbef852dfd3eb4a97d62c6"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=13e10d451ef3cdee4bd4bd66d011b8a1785836f8#13e10d451ef3cdee4bd4bd66d011b8a1785836f8"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "1769a060af4ab5e9ac8faae2accb1553f5c2b9c9" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "617ab94b6f81d07bb76f060a381ee855ea6ec3ce" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "45df1be99400c709c74164f067fc923a64217f93" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "617ab94b6f81d07bb76f060a381ee855ea6ec3ce" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "617ab94b6f81d07bb76f060a381ee855ea6ec3ce" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "617ab94b6f81d07bb76f060a381ee855ea6ec3ce" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "617ab94b6f81d07bb76f060a381ee855ea6ec3ce" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "47.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "4a431bc89fb88731685609618799d392cb0a74e7" }
 datafusion-macros = { version = "47.0.0" }
 datafusion-physical-plan = { version = "47.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "17d126f4278a43edefcbef852dfd3eb4a97d62c6" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "13e10d451ef3cdee4bd4bd66d011b8a1785836f8" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -26,11 +26,15 @@ use embucket_functions::session_params::{SessionParams, SessionProperty};
 use embucket_functions::table::register_udtfs;
 use snafu::ResultExt;
 use std::collections::HashMap;
+use std::num::NonZero;
 use std::sync::Arc;
 use std::sync::atomic::AtomicI64;
+use std::thread::available_parallelism;
 use time::{Duration, OffsetDateTime};
 
 pub const SESSION_INACTIVITY_EXPIRATION_SECONDS: i64 = 5 * 60;
+static MINIMUM_PARALLEL_OUTPUT_FILES: usize = 1;
+static PARALLEL_ROW_GROUP_RATIO: usize = 4;
 
 #[must_use]
 pub const fn to_unix(t: OffsetDateTime) -> i64 {
@@ -66,6 +70,8 @@ impl UserSession {
         // That's a hack to use our custom expr planner first and default ones later. We probably need to get rid of default planners at some point.
         expr_planners.insert(0, Arc::new(CustomExprPlanner));
 
+        let parallelism_opt = available_parallelism().ok().map(NonZero::get);
+
         let session_params = SessionParams::default();
         let session_params_arc = Arc::new(session_params.clone());
         let state = SessionStateBuilder::new()
@@ -82,10 +88,13 @@ impl UserSession {
                         true,
                     )
                     .set_bool("datafusion.sql_parser.parse_float_as_decimal", true)
-                    .set_usize("datafusion.execution.minimum_parallel_output_files", 1)
+                    .set_usize(
+                        "datafusion.execution.minimum_parallel_output_files",
+                        MINIMUM_PARALLEL_OUTPUT_FILES,
+                    )
                     .set_usize(
                         "datafusion.execution.parquet.maximum_parallel_row_group_writers",
-                        4,
+                        parallelism_opt.map_or(1, |x| x / PARALLEL_ROW_GROUP_RATIO),
                     ),
             )
             .with_default_features()

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -81,7 +81,12 @@ impl UserSession {
                         "datafusion.execution.skip_physical_aggregate_schema_check",
                         true,
                     )
-                    .set_bool("datafusion.sql_parser.parse_float_as_decimal", true),
+                    .set_bool("datafusion.sql_parser.parse_float_as_decimal", true)
+                    .set_usize("datafusion.execution.minimum_parallel_output_files", 1)
+                    .set_usize(
+                        "datafusion.execution.parquet.maximum_parallel_row_group_writers",
+                        4,
+                    ),
             )
             .with_default_features()
             .with_runtime_env(runtime_env)

--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -95,6 +95,10 @@ impl UserSession {
                     .set_usize(
                         "datafusion.execution.parquet.maximum_parallel_row_group_writers",
                         parallelism_opt.map_or(1, |x| x / PARALLEL_ROW_GROUP_RATIO),
+                    )
+                    .set_usize(
+                        "datafusion.execution.parquet.maximum_buffered_record_batches_per_stream",
+                        parallelism_opt.map_or(1, |x| 1 + (x / PARALLEL_ROW_GROUP_RATIO)),
                     ),
             )
             .with_default_features()

--- a/crates/core-metastore/src/metastore.rs
+++ b/crates/core-metastore/src/metastore.rs
@@ -556,11 +556,11 @@ impl Metastore for SlateDBMetastore {
                     .build()
                 })?;
 
+                let schema = url_encode(&ident.schema);
+                let table = url_encode(&ident.table);
+
                 let prefix = volume.prefix();
-                format!(
-                    "{prefix}/{}/{}/{}",
-                    ident.database, ident.schema, ident.table
-                )
+                format!("{prefix}/{}/{}/{}", ident.database, schema, table)
             };
 
             let metadata_part = format!("metadata/{}", Self::generate_metadata_filename());
@@ -919,6 +919,10 @@ fn convert_add_schema_update_to_lowercase(updates: &mut Vec<IcebergTableUpdate>)
         }
     }
     Ok(())
+}
+
+fn url_encode(input: &str) -> String {
+    url::form_urlencoded::byte_serialize(input.as_bytes()).collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Updates iceberg-rust to its most recent version. Introduces a new parquet writer that uses the datafusion [ParquetSink](https://docs.rs/datafusion/latest/datafusion/datasource/file_format/parquet/struct.ParquetSink.html).

Writing data currently still has the issue that the query restarts after approx. 1 min. However, this issue is not introduced by this PR as it already existed before (I tested the main branch).