### PR TITLE
Update view table source when scaning

### DIFF
--- a/crates/core-executor/src/snowflake_error.rs
+++ b/crates/core-executor/src/snowflake_error.rs
@@ -530,6 +530,16 @@ fn datafusion_error(df_error: &DataFusionError, subtext: &[&str]) -> SnowflakeEr
                         status_code,
                     }
                     .build(),
+                    DFCatalogExternalDFError::CannotResolveViewReference { .. } => CustomSnafu {
+                        message,
+                        status_code,
+                    }
+                    .build(),
+                    DFCatalogExternalDFError::SessionDowncast { .. } => CustomSnafu {
+                        message,
+                        status_code,
+                    }
+                    .build(),
                     DFCatalogExternalDFError::ObjectStoreNotFound { .. } => CustomSnafu {
                         message,
                         status_code,

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/view/query_view_from_table.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/view/query_view_from_table.snap
@@ -1,0 +1,15 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/view.rs
+description: "\"SELECT * FROM view ORDER BY id\""
+info: "Setup queries: CREATE TABLE view_source (ID INTEGER, name VARCHAR); CREATE OR REPLACE VIEW view AS SELECT * FROM view_source; INSERT INTO view_source VALUES (1, 'Alice'), (2, 'Bob')"
+---
+Ok(
+    [
+        "+----+-------+",
+        "| id | name  |",
+        "+----+-------+",
+        "| 1  | Alice |",
+        "| 2  | Bob   |",
+        "+----+-------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/ddl/view.rs
+++ b/crates/core-executor/src/tests/sql/ddl/view.rs
@@ -24,3 +24,14 @@ test_query!(
     ],
     snapshot_path = "view"
 );
+
+test_query!(
+    view_from_table,
+    "SELECT * FROM view ORDER BY id",
+    setup_queries = [
+        "CREATE TABLE view_source (ID INTEGER, name VARCHAR)",
+        "CREATE OR REPLACE VIEW view AS SELECT * FROM view_source",
+        "INSERT INTO view_source VALUES (1, 'Alice'), (2, 'Bob')",
+    ],
+    snapshot_path = "view"
+);

--- a/crates/df-catalog/src/df_error.rs
+++ b/crates/df-catalog/src/df_error.rs
@@ -48,6 +48,17 @@ pub enum DFExternalError {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Cannot resolve view reference '{reference}'"))]
+    CannotResolveViewReference {
+        reference: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+    #[snafu(display("Failed to downcast Session to SessionState"))]
+    SessionDowncast {
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 impl From<DFExternalError> for datafusion_common::DataFusionError {

--- a/crates/df-catalog/src/table.rs
+++ b/crates/df-catalog/src/table.rs
@@ -1,11 +1,17 @@
+use crate::df_error;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::catalog::{Session, TableProvider};
+use datafusion::datasource::{ViewTable, provider_as_source};
+use datafusion::execution::SessionState;
+use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_expr::dml::InsertOp;
-use datafusion_expr::{Expr, TableType};
+use datafusion_expr::{Expr, LogicalPlan, TableScan, TableType};
 use datafusion_physical_plan::ExecutionPlan;
 use once_cell::sync::OnceCell;
+use snafu::OptionExt;
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct CachingTable {
@@ -62,6 +68,13 @@ impl TableProvider for CachingTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        if self.table.table_type() == TableType::View
+            && let Some(view) = self.table.as_any().downcast_ref::<ViewTable>()
+        {
+            let new_view_plan = rewrite_view_source(state, view.logical_plan().clone()).await?;
+            let updated_view = ViewTable::new(new_view_plan, view.definition().cloned());
+            return updated_view.scan(state, projection, filters, limit).await;
+        }
         self.table.scan(state, projection, filters, limit).await
     }
 
@@ -73,4 +86,68 @@ impl TableProvider for CachingTable {
     ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
         self.table.insert_into(state, input, insert_op).await
     }
+}
+
+async fn rewrite_view_source(
+    state: &dyn Session,
+    plan: LogicalPlan,
+) -> datafusion_common::Result<LogicalPlan> {
+    let state = state
+        .as_any()
+        .downcast_ref::<SessionState>()
+        .context(df_error::SessionDowncastSnafu)?;
+
+    // Collect all table scans in the plan
+    let mut scans = vec![];
+    plan.clone().transform_up(|plan| {
+        if let LogicalPlan::TableScan(ref scan) = plan {
+            scans.push(scan.clone());
+        }
+        Ok(Transformed::no(plan))
+    })?;
+
+    // Resolve each table scan to its actual table provider with async calls
+    let mut replacements: HashMap<String, TableScan> = HashMap::new();
+    for scan in scans {
+        let resolved = state.resolve_table_ref(scan.table_name.clone());
+        let table = state
+            .catalog_list()
+            .catalog(&resolved.catalog)
+            .context(df_error::CatalogNotFoundSnafu {
+                name: resolved.catalog.to_string(),
+            })?
+            .schema(&resolved.schema)
+            .context(df_error::CannotResolveViewReferenceSnafu {
+                reference: resolved.to_string(),
+            })?
+            .table(&resolved.table)
+            .await?
+            .context(df_error::CannotResolveViewReferenceSnafu {
+                reference: resolved.to_string(),
+            })?;
+        replacements.insert(
+            scan.table_name.to_string(),
+            TableScan {
+                source: provider_as_source(table),
+                ..scan
+            },
+        );
+    }
+
+    // Rewrite the plan with the updated table scans
+    let new_plan = plan
+        .clone()
+        .transform_up(|ref plan| {
+            if let LogicalPlan::TableScan(scan) = plan {
+                if let Some(new_scan) = replacements.get(&scan.table_name.to_string()) {
+                    Ok(Transformed::yes(LogicalPlan::TableScan(new_scan.clone())))
+                } else {
+                    Ok(Transformed::no(plan.clone()))
+                }
+            } else {
+                Ok(Transformed::no(plan.clone()))
+            }
+        })?
+        .data;
+    Ok(new_plan)
 }

--- a/crates/df-catalog/src/table.rs
+++ b/crates/df-catalog/src/table.rs
@@ -153,12 +153,10 @@ async fn rewrite_view_source(
     let new_plan = plan
         .clone()
         .transform_up(|ref plan| {
-            if let LogicalPlan::TableScan(scan) = plan {
-                if let Some(new_scan) = replacements.get(&scan.table_name.to_string()) {
-                    Ok(Transformed::yes(LogicalPlan::TableScan(new_scan.clone())))
-                } else {
-                    Ok(Transformed::no(plan.clone()))
-                }
+            if let LogicalPlan::TableScan(scan) = plan
+                && let Some(new_scan) = replacements.get(&scan.table_name.to_string())
+            {
+                Ok(Transformed::yes(LogicalPlan::TableScan(new_scan.clone())))
             } else {
                 Ok(Transformed::no(plan.clone()))
             }


### PR DESCRIPTION
Closes #1601 

If this table is a View, we need to ensure it reflects the latest state of its underlying tables.

ViewTable contains a logical plan that references the snapshot of the source tables it the time the view was created. Without updating TableScan nodes, the view would continue to reference stale data. Here we reconstruct the logical plan with updated TableScan nodes so that any query on the view sees the latest snapshots of the source tables.