### PR TITLE
fix timestamps optimize_projections

### DIFF
--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -615,6 +615,11 @@ test_query!(
     setup_queries = ["ALTER SESSION SET timestamp_input_mapping = 'timestamp_tz'"]
 );
 
+test_query!(
+    timestamp_with_timezone_to_timestamp,
+    "SELECT TO_TIMESTAMP(CONVERT_TIMEZONE('UTC', '2024-12-31 10:00:00.000'::TIMESTAMP)) as model_tstamp;"
+);
+
 // Basic date part extraction tests
 test_query!(
     date_part_extract_basic,

--- a/crates/core-executor/src/tests/snapshots/query_timestamp_with_timezone_to_timestamp.snap
+++ b/crates/core-executor/src/tests/snapshots/query_timestamp_with_timezone_to_timestamp.snap
@@ -1,0 +1,13 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT TO_TIMESTAMP(CONVERT_TIMEZONE('UTC', '2024-12-31 10:00:00.000'::TIMESTAMP)) as model_tstamp;\""
+---
+Ok(
+    [
+        "+----------------------+",
+        "| model_tstamp         |",
+        "+----------------------+",
+        "| 2024-12-31T10:00:00Z |",
+        "+----------------------+",
+    ],
+)


### PR DESCRIPTION
Closes https://github.com/Embucket/embucket/issues/1612
Closes https://github.com/Embucket/embucket/issues/1604
Also fixed previous PR https://github.com/Embucket/embucket/pull/1622

If the input in to_timestamp func is already a timestamp, we don't need to change it type since during execution it will be used as is with initial type.
By this we avoid optimize_projections error when cheking return type and actual result type for the function call.
```
dbt-gitlab Badge generated with 90.3% success rate
dbt-snowplow Badge generated with 100.0% success rate (first run)
dbt-snowplow Badge generated with 100.0% success rate (second run)
```