### PR TITLE
Add merge test infrastructure and comprehensive test coverage

### DIFF
--- a/crates/core-executor/src/datafusion/physical_plan/merge.rs
+++ b/crates/core-executor/src/datafusion/physical_plan/merge.rs
@@ -988,12 +988,13 @@ mod tests {
         )
     }
 
-    fn build_input_stream(sequence: &[usize]) -> Vec<Result<RecordBatch, DataFusionError>> {
+    fn build_input_stream(
+        sequence: &[(usize, usize)],
+    ) -> Vec<Result<RecordBatch, DataFusionError>> {
         sequence
             .iter()
-            .enumerate()
             .map(|(n, i)| {
-                let n: i32 = n.try_into().unwrap();
+                let n: i32 = (*n).try_into().unwrap();
                 match i {
                     1 => Ok(build_record_batch(&[generate_target(n)])),
                     2 => Ok(build_record_batch(&[generate_source(n)])),
@@ -1047,7 +1048,7 @@ mod tests {
         assert_eq!(result, expected);
     }
 
-    test_source_exist_filter_stream!(single_target, &[1], 0);
-    test_source_exist_filter_stream!(single_source, &[2], 10);
-    test_source_exist_filter_stream!(single_matching, &[4], 10);
+    test_source_exist_filter_stream!(single_target, &[(1, 1)], 0);
+    test_source_exist_filter_stream!(single_source, &[(1, 2)], 10);
+    test_source_exist_filter_stream!(single_matching, &[(1, 4)], 10);
 }

--- a/crates/core-executor/src/datafusion/physical_plan/merge.rs
+++ b/crates/core-executor/src/datafusion/physical_plan/merge.rs
@@ -943,6 +943,8 @@ mod tests {
             .collect()
     }
 
+    /// Builds a test record batch from a sequence of input data.
+    #[allow(clippy::type_complexity)]
     fn build_record_batch(
         input: &[(
             Vec<bool>,
@@ -980,6 +982,8 @@ mod tests {
         .expect("Failed to build record batch")
     }
 
+    // Creates test data for the target table where __source_exists is NULL ==> NOT MATCHED
+    #[allow(clippy::type_complexity)]
     fn generate_target(
         i: i32,
     ) -> (
@@ -1006,6 +1010,9 @@ mod tests {
         )
     }
 
+    // Creates test data for the source table where __data_file_path & __manifest_file_path are
+    // NULL ==> NOT MATCHED
+    #[allow(clippy::type_complexity)]
     fn generate_source(
         i: i32,
     ) -> (
@@ -1022,6 +1029,8 @@ mod tests {
         )
     }
 
+    // Creates MATCHED test data for target and source table
+    #[allow(clippy::type_complexity)]
     fn generate_matching(
         i: i32,
     ) -> (

--- a/crates/core-executor/src/datafusion/physical_plan/merge.rs
+++ b/crates/core-executor/src/datafusion/physical_plan/merge.rs
@@ -908,6 +908,11 @@ mod tests {
         assert!(total_rows == 9);
     }
 
+    /// Generates test record batches from a sequence of scenario identifiers.
+    ///
+    /// Each tuple in the sequence contains (index, scenario_type) where scenario_type maps to:
+    /// 1. Target-only data, 2. Source-only data, 3. Target+Source, 4. Matching data,
+    /// 5. Target+Matching, 6. Source+Matching, 7. Target+Source+Matching
     fn build_input_stream(
         sequence: &[(usize, usize)],
     ) -> Vec<Result<RecordBatch, DataFusionError>> {

--- a/crates/core-executor/src/tests/query.rs
+++ b/crates/core-executor/src/tests/query.rs
@@ -448,6 +448,22 @@ test_query!(
 );
 
 test_query!(
+    merge_into_ctas_source_multi_insert_target,
+    "SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target",
+    setup_queries = [
+        "CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR)",
+        "INSERT INTO embucket.public.merge_target VALUES (1, 'existing row'), (2, 'existing row'), (3, 'existing row'), (4, 'existing row'), (5, 'existing row')",
+        "INSERT INTO embucket.public.merge_target VALUES (6, 'existing row'), (7, 'existing row'), (8, 'existing row'), (9, 'existing row')",
+        "INSERT INTO embucket.public.merge_target VALUES (11, 'existing row'), (12, 'existing row'), (13, 'existing row'), (14, 'existing row'), (15, 'existing row')",
+        "INSERT INTO embucket.public.merge_target VALUES (16, 'existing row'), (17, 'existing row'), (18, 'existing row'), (19, 'existing row')",
+        "CREATE OR REPLACE TABLE embucket.public.merge_source AS SELECT column1 as id, column2 as description FROM VALUES (1, 'updated row'), (10, 'new row')",
+        "MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET description = merge_source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (merge_source.id, merge_source.description)",
+        "CREATE OR REPLACE TABLE embucket.public.merge_source AS SELECT column1 as id, column2 as description FROM VALUES (11, 'updated row'), (20, 'new row')",
+        "MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET description = merge_source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (merge_source.id, merge_source.description)",
+    ]
+);
+
+test_query!(
     merge_into_ambigious_insert,
     "SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target",
     setup_queries = [

--- a/crates/core-executor/src/tests/snapshots/query_merge_into_ctas_source_multi_insert_target.snap
+++ b/crates/core-executor/src/tests/snapshots/query_merge_into_ctas_source_multi_insert_target.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/query.rs
+description: "\"SELECT count(CASE WHEN description = 'updated row' THEN 1 ELSE NULL END) updated, count(CASE WHEN description = 'existing row' THEN 1 ELSE NULL END) existing FROM embucket.public.merge_target\""
+info: "Setup queries: CREATE TABLE embucket.public.merge_target (ID INTEGER, description VARCHAR); INSERT INTO embucket.public.merge_target VALUES (1, 'existing row'), (2, 'existing row'), (3, 'existing row'), (4, 'existing row'), (5, 'existing row'); INSERT INTO embucket.public.merge_target VALUES (6, 'existing row'), (7, 'existing row'), (8, 'existing row'), (9, 'existing row'); INSERT INTO embucket.public.merge_target VALUES (11, 'existing row'), (12, 'existing row'), (13, 'existing row'), (14, 'existing row'), (15, 'existing row'); INSERT INTO embucket.public.merge_target VALUES (16, 'existing row'), (17, 'existing row'), (18, 'existing row'), (19, 'existing row'); CREATE OR REPLACE TABLE embucket.public.merge_source AS SELECT column1 as id, column2 as description FROM VALUES (1, 'updated row'), (10, 'new row'); MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET description = merge_source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (merge_source.id, merge_source.description); CREATE OR REPLACE TABLE embucket.public.merge_source AS SELECT column1 as id, column2 as description FROM VALUES (11, 'updated row'), (20, 'new row'); MERGE INTO merge_target USING merge_source ON merge_target.id = merge_source.id WHEN MATCHED THEN UPDATE SET description = merge_source.description WHEN NOT MATCHED THEN INSERT (id, description) VALUES (merge_source.id, merge_source.description)"
+---
+Ok(
+    [
+        "+---------+----------+",
+        "| updated | existing |",
+        "+---------+----------+",
+        "| 2       | 16       |",
+        "+---------+----------+",
+    ],
+)


### PR DESCRIPTION
## Summary
- Create macro for merge tests to reduce code duplication
- Add helper functions for building test data and record batches
- Implement comprehensive test coverage for MergeCOWFilterStream with different data combinations
- Add new test case for multi-insert merge scenarios

## Test plan
- [x] All existing tests continue to pass
- [x] New macro-generated tests cover various merge scenarios (target only, source only, matching data, combinations)
- [x] Multi-insert merge test validates behavior across multiple operations