### PR TITLE
engine: Arrow null fix

### DIFF
--- a/crates/core-executor/src/datafusion/physical_plan/merge.rs
+++ b/crates/core-executor/src/datafusion/physical_plan/merge.rs
@@ -910,7 +910,7 @@ mod tests {
 
     /// Generates test record batches from a sequence of scenario identifiers.
     ///
-    /// Each tuple in the sequence contains (index, scenario_type) where scenario_type maps to:
+    /// Each tuple in the sequence contains (index, `scenario_type`) where `scenario_type` maps to:
     /// 1. Target-only data, 2. Source-only data, 3. Target+Source, 4. Matching data,
     /// 5. Target+Matching, 6. Source+Matching, 7. Target+Source+Matching
     fn build_input_stream(

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_create_table_as_select.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_create_table_as_select.snap
@@ -1,0 +1,16 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/table.rs
+description: "\"SELECT * FROM embucket.public.testtable\""
+info: "Setup queries: CREATE OR REPLACE TABLE embucket.public.testtable AS SELECT NULL AS DEFAULT; INSERT INTO embucket.public.testtable VALUES (null), ('fff')"
+---
+Ok(
+    [
+        "+---------+",
+        "| default |",
+        "+---------+",
+        "|         |",
+        "|         |",
+        "| fff     |",
+        "+---------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_create_table_as_select_from_values.snap
+++ b/crates/core-executor/src/tests/sql/ddl/snapshots/table/query_create_table_as_select_from_values.snap
@@ -1,0 +1,16 @@
+---
+source: crates/core-executor/src/tests/sql/ddl/table.rs
+description: "\"SELECT * FROM embucket.public.testtable\""
+info: "Setup queries: CREATE OR REPLACE TABLE embucket.public.testtable AS SELECT * FROM VALUES (null); INSERT INTO embucket.public.testtable VALUES (null), ('fff')"
+---
+Ok(
+    [
+        "+---------+",
+        "| column1 |",
+        "+---------+",
+        "|         |",
+        "|         |",
+        "| fff     |",
+        "+---------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/ddl/table.rs
+++ b/crates/core-executor/src/tests/sql/ddl/table.rs
@@ -30,6 +30,26 @@ test_query!(
 );
 
 test_query!(
+    create_table_as_select,
+    "SELECT * FROM embucket.public.testtable",
+    setup_queries = [
+        "CREATE OR REPLACE TABLE embucket.public.testtable AS SELECT NULL AS DEFAULT",
+        "INSERT INTO embucket.public.testtable VALUES (null), ('fff')",
+    ],
+    snapshot_path = "table"
+);
+
+test_query!(
+    create_table_as_select_from_values,
+    "SELECT * FROM embucket.public.testtable",
+    setup_queries = [
+        "CREATE OR REPLACE TABLE embucket.public.testtable AS SELECT * FROM VALUES (null)",
+        "INSERT INTO embucket.public.testtable VALUES (null), ('fff')",
+    ],
+    snapshot_path = "table"
+);
+
+test_query!(
     create_table_quoted_identifiers,
     "SELECT * FROM embucket.\"test public\".\"test table\"",
     setup_queries = [


### PR DESCRIPTION
Closes #1651

- [x] DataType::Null for **CREATE** -> `DataType::Utf8`
- [x] Rewrite schema for `create_iceberg_table`
- [x] Insta test
- [x] dbt-gitlab tested