### PR TITLE
Clarify TPC-DS benchmarking legality and usage

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,11 +1,16 @@
-
-# Snowflake TPCDS Benchmark
-
-A comprehensive benchmark tool for testing Snowflake performance using TPC-DS queries with proper cache isolation.
-
 ## Overview
 
-This benchmark tool executes TPC-DS queries against Snowflake with warehouse suspend/resume operations to ensure clean, cache-free performance measurements. It provides detailed timing metrics including compilation time, execution time, and total elapsed time.
+This benchmark tool executes queries derived from TPC-DS against Snowflake with warehouse suspend/resume operations to ensure clean, cache-free performance measurements. It provides detailed timing metrics including compilation time, execution time, and total elapsed time.
+
+## TPC Legal Considerations
+
+It is important to know that TPC benchmarks are copyrighted IP of the Transaction Processing Council. Only members of the TPC consortium are allowed to publish TPC benchmark results. Fun fact: only four companies have published official TPC-DS benchmark results so far, and those results can be seen [here](https://www.tpc.org/tpcds/results/tpcds_results5.asp?orderby=dbms&version=3).
+
+However, anyone is welcome to create derivative benchmarks under the TPC's fair use policy, and that is what we are doing here. We do not aim to run a true TPC benchmark (which is a significant endeavor). We are just running the individual queries and recording the timings.
+
+Throughout this document and when talking about these benchmarks, you will see the term "derived from TPC-DS". We are required to use this terminology and this is explained in the [fair-use policy (PDF)](https://www.tpc.org/tpc_documents_current_versions/pdf/tpc_fair_use_quick_reference_v1.0.0.pdf).
+
+**This benchmark is a Non-TPC Benchmark. Any comparison between official TPC Results with non-TPC workloads is prohibited by the TPC.**
 
 ## Features
 
@@ -48,7 +53,7 @@ python benchmark.py
 
 The benchmark will:
 1. Connect to Snowflake using your configuration
-2. Execute each TPC-DS query with warehouse restart for cache isolation
+2. Execute each query derived from TPC-DS with warehouse restart for cache isolation
 3. Collect performance metrics from query history
 4. Display results in a formatted table
 5. Save detailed results to `query_results.csv`
@@ -64,10 +69,10 @@ The benchmark provides:
 
 - `benchmark.py` - Main benchmark script
 - `config.py` - Snowflake configuration management
-- `tpcds_queries.py` - TPC-DS query definitions
+- `tpcds_queries.py` - Query definitions derived from TPC-DS
 - `data_preparation.py` - Data setup utilities
 - `requirements.txt` - Python dependencies
-- `tpcds_ddl/` - TPC-DS DDL scripts
+- `tpcds_ddl/` - DDL scripts derived from TPC-DS
 
 ## Requirements
 


### PR DESCRIPTION
Based on https://github.com/apache/datafusion-benchmarks
We would also need to use the same terminology for TCP-H