### PR TITLE
Add iceberg-rust and datafusion_iceberg to tracing targets

### DIFF
--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -68,7 +68,7 @@ use utoipa_swagger_ui::SwaggerUi;
 #[global_allocator]
 static ALLOCATOR: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
-const TARGETS: [&str; 12] = [
+const TARGETS: [&str; 13] = [
     "embucketd",
     "api_ui",
     "api_sessions",

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -79,6 +79,7 @@ const TARGETS: [&str; 12] = [
     "core_history",
     "core_metastore",
     "df_catalog",
+    "datafusion",
     "iceberg_rust",
     "datafusion_iceberg",
 ];

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -68,7 +68,7 @@ use utoipa_swagger_ui::SwaggerUi;
 #[global_allocator]
 static ALLOCATOR: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
-const TARGETS: [&str; 10] = [
+const TARGETS: [&str; 12] = [
     "embucketd",
     "api_ui",
     "api_sessions",
@@ -79,6 +79,8 @@ const TARGETS: [&str; 10] = [
     "core_history",
     "core_metastore",
     "df_catalog",
+    "iceberg_rust",
+    "datafusion_iceberg",
 ];
 
 #[tokio::main]


### PR DESCRIPTION
## Summary
• Added iceberg-rust and datafusion_iceberg to the TARGETS array for tracing
• Updated array size from 10 to 12 elements