### PR TITLE
update iceberg-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "50.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "439cbd2282504c3ffaf262f1ffdb530a0fb1a151" }
 datafusion-macros = { version = "50.0.0" }
 datafusion-physical-plan = { version = "50.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "c32743d1bfb820a977d336a280130d9a2d021c7c" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "ad0e65fce766751ec9a68f98adeca3840cd9997e" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "c32743d1bfb820a977d336a280130d9a2d021c7c" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "c32743d1bfb820a977d336a280130d9a2d021c7c" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "c32743d1bfb820a977d336a280130d9a2d021c7c" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "c32743d1bfb820a977d336a280130d9a2d021c7c" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "ad0e65fce766751ec9a68f98adeca3840cd9997e" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "ad0e65fce766751ec9a68f98adeca3840cd9997e" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "ad0e65fce766751ec9a68f98adeca3840cd9997e" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "ad0e65fce766751ec9a68f98adeca3840cd9997e" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }


### PR DESCRIPTION
Updates iceberg-rust to its latest version. Adds more detailed traces to the library.