### PR TITLE
Fix panic on COPY INTO with small instances

### DIFF
--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -98,11 +98,11 @@ impl UserSession {
                     )
                     .set_usize(
                         "datafusion.execution.parquet.maximum_parallel_row_group_writers",
-                        parallelism_opt.map_or(1, |x| x / PARALLEL_ROW_GROUP_RATIO),
+                        parallelism_opt.map_or(1, |x| (x / PARALLEL_ROW_GROUP_RATIO).max(1)),
                     )
                     .set_usize(
                         "datafusion.execution.parquet.maximum_buffered_record_batches_per_stream",
-                        parallelism_opt.map_or(1, |x| 1 + (x / PARALLEL_ROW_GROUP_RATIO)),
+                        parallelism_opt.map_or(1, |x| 1 + (x / PARALLEL_ROW_GROUP_RATIO).max(1)),
                     ),
             )
             .with_default_features()


### PR DESCRIPTION
## Summary
Fixes a panic that occurs when running COPY INTO operations on small instances (e.g., c7i.large with 2 CPU/4GB). The panic was caused by DataFusion's parquet writer configuration being set to 0, which violates the requirement that mpsc bounded channels must have buffer > 0.

## Root Cause
On small instances with few CPU cores, the calculation `parallelism / PARALLEL_ROW_GROUP_RATIO` could result in 0 when parallelism is less than 4. This caused two DataFusion configuration values to be set to 0:
- `datafusion.execution.parquet.maximum_parallel_row_group_writers`
- `datafusion.execution.parquet.maximum_buffered_record_batches_per_stream`

When DataFusion tries to create mpsc channels with these buffer sizes of 0, it panics with "mpsc bounded channel requires buffer > 0".

## Solution
Added `.max(1)` to both configuration calculations to ensure they are always at least 1, preventing the panic while maintaining reasonable parallelism settings.

## Reproduction
This issue can be reproduced on any instance with 2-3 CPU cores by running:
```sql
COPY INTO customer FROM 's3://embucket-testdata/tpch_data/sf_01/customer.parquet' FILE_FORMAT = (TYPE = PARQUET)
```

Related to #1731