### PR TITLE
update iceberg-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "datafusion_iceberg"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9#f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=5664a94fcd7350c5e381aaeaf018bc0b20ce03b6#5664a94fcd7350c5e381aaeaf018bc0b20ce03b6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rest-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9#f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=5664a94fcd7350c5e381aaeaf018bc0b20ce03b6#5664a94fcd7350c5e381aaeaf018bc0b20ce03b6"
 dependencies = [
  "async-trait",
  "aws-sigv4 0.3.1",
@@ -4900,7 +4900,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9#f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=5664a94fcd7350c5e381aaeaf018bc0b20ce03b6#5664a94fcd7350c5e381aaeaf018bc0b20ce03b6"
 dependencies = [
  "apache-avro 0.18.0",
  "arrow 56.2.0",
@@ -4935,7 +4935,7 @@ dependencies = [
 [[package]]
 name = "iceberg-rust-spec"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9#f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=5664a94fcd7350c5e381aaeaf018bc0b20ce03b6#5664a94fcd7350c5e381aaeaf018bc0b20ce03b6"
 dependencies = [
  "apache-avro 0.18.0",
  "arrow-schema 56.2.0",
@@ -4960,7 +4960,7 @@ dependencies = [
 [[package]]
 name = "iceberg-s3tables-catalog"
 version = "0.8.0"
-source = "git+https://github.com/Embucket/iceberg-rust.git?rev=f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9#f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9"
+source = "git+https://github.com/Embucket/iceberg-rust.git?rev=5664a94fcd7350c5e381aaeaf018bc0b20ce03b6#5664a94fcd7350c5e381aaeaf018bc0b20ce03b6"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ datafusion-expr = { version = "50.0.0" }
 datafusion-functions-json = { git = "https://github.com/Embucket/datafusion-functions-json.git", rev = "439cbd2282504c3ffaf262f1ffdb530a0fb1a151" }
 datafusion-macros = { version = "50.0.0" }
 datafusion-physical-plan = { version = "50.0.0" }
-datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9" }
+datafusion_iceberg = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "5664a94fcd7350c5e381aaeaf018bc0b20ce03b6" }
 futures = { version = "0.3" }
 http = "1.2"
 http-body-util = "0.1.0"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev="7a5ad1fcaf00d4638857812bab788105f6c60573"}
-iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9" }
-iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9" }
-iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9" }
-iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "f04fbf4ed33da4dc8f2cf4ca7c046c8c4964b3b9" }
+iceberg-rest-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "5664a94fcd7350c5e381aaeaf018bc0b20ce03b6" }
+iceberg-rust = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "5664a94fcd7350c5e381aaeaf018bc0b20ce03b6" }
+iceberg-rust-spec = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "5664a94fcd7350c5e381aaeaf018bc0b20ce03b6" }
+iceberg-s3tables-catalog = { git = "https://github.com/Embucket/iceberg-rust.git", rev = "5664a94fcd7350c5e381aaeaf018bc0b20ce03b6" }
 indexmap = "2.7.1"
 jsonwebtoken = "9.3.1"
 lazy_static = { version = "1.5" }


### PR DESCRIPTION
This PR updates iceberg-rust to its latest version. It includes performance improvements and more traces.