### PR TITLE
Benchmark datafusion

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -572,7 +572,7 @@ def run_benchmark(run_number: int, system_enum: Optional[SystemType], no_cache: 
 def parse_args():
     """Parse command line arguments for benchmark configuration."""
     parser = argparse.ArgumentParser(description="Run benchmarks on Snowflake and/or Embucket")
-    parser.add_argument("--system", choices=["snowflake", "embucket", "both"], default="both")
+    parser.add_argument("--system", choices=["snowflake", "embucket", "datafusion", "both"], default="both")
     parser.add_argument("--runs", type=int, default=3)
     parser.add_argument("--benchmark-type", choices=["tpch", "clickbench", "tpcds"], default=os.environ.get("BENCHMARK_TYPE", "tpch"))
     parser.add_argument("--dataset-path", help="Override the DATASET_PATH environment variable")

--- a/benchmark/calculate_average.py
+++ b/benchmark/calculate_average.py
@@ -49,6 +49,8 @@ def calculate_benchmark_averages(dataset, warehouse, system, benchmark_type, cac
         search_dir = f'result/embucket_{benchmark_type}_results/{dataset}/{warehouse}/{cache_folder}'
     elif system == SystemType.SNOWFLAKE:
         search_dir = f'result/snowflake_{benchmark_type}_results/{dataset}/{warehouse}/{cache_folder}'
+    elif system == SystemType.DATAFUSION:
+        search_dir = f'result/datafusion_{benchmark_type}_results/{dataset}/{warehouse}/{cache_folder}'
     else:
         raise ValueError("Unsupported system")
 
@@ -66,9 +68,9 @@ def calculate_benchmark_averages(dataset, warehouse, system, benchmark_type, cac
     instance_files = {}
     for file in all_csv_files:
         # Extract pattern type using regex
-        match = re.search(r'(embucket|snowflake)_results(?:_run_(\d+))?', os.path.basename(file))
+        match = re.search(r'(embucket|snowflake|datafusion)_results(?:_run_(\d+))?', os.path.basename(file))
         if match:
-            pattern_type = match.group(1)  # embucket or snowflake
+            pattern_type = match.group(1)  # embucket, snowflake, or datafusion
             if pattern_type not in instance_files:
                 instance_files[pattern_type] = []
             instance_files[pattern_type].append(file)

--- a/benchmark/constants.py
+++ b/benchmark/constants.py
@@ -4,3 +4,4 @@ from enum import Enum
 class SystemType(Enum):
     EMBUCKET = "embucket"
     SNOWFLAKE = "snowflake"
+    DATAFUSION = "datafusion"

--- a/benchmark/datafusion_cursor.py
+++ b/benchmark/datafusion_cursor.py
@@ -1,0 +1,47 @@
+import os
+from datafusion import SessionContext
+from datafusion.object_store import AmazonS3
+
+s3 = AmazonS3(
+    bucket_name="embucket-testdata",
+    region="us-east-2",
+    access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+    secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+)
+
+
+class DataFusionCursor:
+    """Cursor-like wrapper for DataFusion SessionContext to match database cursor interface."""
+
+    def __init__(self, session_context: SessionContext):
+        self.ctx = session_context
+        self._results = None
+
+    def execute(self, query: str):
+        """Execute a SQL query and store the results."""
+        self._results = self.ctx.sql(query)
+        return self
+
+    def fetchall(self):
+        """Fetch all results from the last executed query."""
+        if self._results is None:
+            return []
+        return self._results.collect()
+
+    def fetchone(self):
+        """Fetch one result from the last executed query."""
+        if self._results is None:
+            return None
+        results = self._results.collect()
+        return results[0] if results else None
+
+    def close(self):
+        """Close the cursor (no-op for DataFusion)."""
+        pass
+
+
+def create_datafusion_cursor():
+    """Create a DataFusion cursor with a new session context."""
+    ctx = SessionContext()
+    ctx.register_object_store("s3://", s3, None)
+    return DataFusionCursor(ctx)

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -5,3 +5,4 @@ pandas>=1.5.0
 matplotlib>=3.5.0
 numpy>=1.21.0
 requests>=2.25.0
+datafusion>=50.0.0


### PR DESCRIPTION
This PR adds datafusion as an additional system to the benchmark suite. It currently uses the same queries as snowflake and embucket which leads to the error that the function "dateadd" is not supported by datafusion.

However, I though this currently provides a solution for most queries and we can tackle the different SQL dialect (support for dateadd) in another PR.