### PR TITLE
Load DataFusion config options from environment variables

### DIFF
--- a/crates/core-executor/src/session.rs
+++ b/crates/core-executor/src/session.rs
@@ -15,6 +15,7 @@ use crate::running_queries::RunningQueries;
 use crate::utils::Config;
 use core_history::history_store::HistoryStore;
 use core_metastore::Metastore;
+use datafusion::config::ConfigOptions;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::execution::{SessionStateBuilder, SessionStateDefaults};
 use datafusion::prelude::{SessionConfig, SessionContext};
@@ -78,9 +79,12 @@ impl UserSession {
 
         let session_params = SessionParams::default();
         let session_params_arc = Arc::new(session_params.clone());
+
+        let config_options = ConfigOptions::from_env().context(ex_error::DataFusionSnafu)?;
+
         let state = SessionStateBuilder::new()
             .with_config(
-                SessionConfig::new()
+                SessionConfig::from(config_options)
                     .with_option_extension(session_params)
                     .with_information_schema(true)
                     // Cannot create catalog (database) automatic since it requires default volume


### PR DESCRIPTION
## Summary
Load DataFusion configuration options from environment variables on session initialization.

## Changes
This PR modifies the session creation to use `ConfigOptions::from_env()`, allowing DataFusion configuration to be set via environment variables. This enables runtime configuration of DataFusion settings without code changes.

Should solve #1800 