### PR TITLE
engine: Fix snowplow_web window function

### DIFF
--- a/crates/embucket-functions/src/visitors/inline_aliases_in_query.rs
+++ b/crates/embucket-functions/src/visitors/inline_aliases_in_query.rs
@@ -47,9 +47,6 @@ impl VisitorMut for InlineAliasesInSelect {
                 match item {
                     SelectItem::ExprWithAlias { expr, alias } => {
                         substitute_aliases(expr, &alias_expr_map, Some(&alias.value), None);
-                        //NOTE: if other aggregate functions happen (without over) - we have no way of knowing,
-                        // like just calling last_value with an alias,
-                        // perhaps this will need to be extended in the logical planning phase later
                         alias_expr_map.insert(alias.value.clone(), expr.clone());
                     }
                     SelectItem::UnnamedExpr(expr) => {
@@ -61,6 +58,9 @@ impl VisitorMut for InlineAliasesInSelect {
 
             // Rewrite WHERE
             if let Some(selection) = select.selection.as_mut() {
+                //NOTE: if other aggregate functions happen (without over) - we have no way of knowing,
+                // like just calling last_value with an alias,
+                // perhaps this will need to be extended in the logical planning phase later
                 substitute_aliases(
                     selection,
                     &alias_expr_map,

--- a/crates/embucket-functions/src/visitors/inline_aliases_in_query.rs
+++ b/crates/embucket-functions/src/visitors/inline_aliases_in_query.rs
@@ -46,16 +46,14 @@ impl VisitorMut for InlineAliasesInSelect {
             for item in &mut select.projection {
                 match item {
                     SelectItem::ExprWithAlias { expr, alias } => {
-                        substitute_aliases(expr, &alias_expr_map, Some(&alias.value));
+                        substitute_aliases(expr, &alias_expr_map, Some(&alias.value), None);
                         //NOTE: if other aggregate functions happen (without over) - we have no way of knowing,
                         // like just calling last_value with an alias,
                         // perhaps this will need to be extended in the logical planning phase later
-                        if !matches!(expr, Expr::Function(Function { over: Some(_), .. })) {
-                            alias_expr_map.insert(alias.value.clone(), expr.clone());
-                        }
+                        alias_expr_map.insert(alias.value.clone(), expr.clone());
                     }
                     SelectItem::UnnamedExpr(expr) => {
-                        substitute_aliases(expr, &alias_expr_map, None);
+                        substitute_aliases(expr, &alias_expr_map, None, None);
                     }
                     _ => {}
                 }
@@ -63,12 +61,17 @@ impl VisitorMut for InlineAliasesInSelect {
 
             // Rewrite WHERE
             if let Some(selection) = select.selection.as_mut() {
-                substitute_aliases(selection, &alias_expr_map, None);
+                substitute_aliases(
+                    selection,
+                    &alias_expr_map,
+                    None,
+                    Some(&|e| matches!(e, Expr::Function(Function { over: Some(_), .. }))),
+                );
             }
 
             // Rewrite QUALIFY
             if let Some(qualify) = select.qualify.as_mut() {
-                substitute_aliases(qualify, &alias_expr_map, None);
+                substitute_aliases(qualify, &alias_expr_map, None, None);
             }
         }
 
@@ -87,6 +90,7 @@ fn substitute_aliases(
     expr: &mut Expr,
     alias_map: &HashMap<String, Expr>,
     forbidden_alias: Option<&str>,
+    forbidden_predicate: Option<&dyn Fn(&Expr) -> bool>,
 ) {
     let _ = visit_expressions_mut(expr, &mut |e: &mut Expr| {
         match e {
@@ -95,6 +99,11 @@ fn substitute_aliases(
                     return ControlFlow::<()>::Continue(());
                 }
                 if let Some(subst) = alias_map.get(&ident.value) {
+                    if let Some(pred) = forbidden_predicate
+                        && pred(subst)
+                    {
+                        return ControlFlow::<()>::Continue(());
+                    }
                     *e = subst.clone();
                 }
             }


### PR DESCRIPTION
Closes #1763

- snowplow_web runs 100%
- it was an issue with aliasing
- actually no aggregate functions can be substitutes in the where clause for an alias, but at the AST leve we canno infer the type of the function reliablly (something to fix later)
- This fixes the issue at hand
- dbt gitlab locally gives 93.2%
- visitors tests added