### PR TITLE
Use SlateDB Settings::load() API for configuration

### DIFF
--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -47,9 +47,7 @@ use opentelemetry_sdk::trace::BatchSpanProcessor;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor as BatchSpanProcessorAsyncRuntime;
 use slatedb::DbBuilder;
-use slatedb::Settings;
-use slatedb::config::GarbageCollectorDirectoryOptions;
-use slatedb::config::{CompactorOptions, GarbageCollectorOptions};
+use slatedb::config::Settings;
 use std::fs;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -333,23 +331,9 @@ async fn async_main(opts: cli::CliOpts, tracing_provider: SdkTracerProvider) {
         .expect("TracerProvider should shutdown successfully");
 }
 
+#[allow(clippy::expect_used)]
 fn slatedb_default_settings() -> Settings {
-    let mut slatedb_settings = Settings::from_env("SLATEDB_").unwrap_or_default();
-
-    // Ensure compactor options are set if not already configured
-    if slatedb_settings.compactor_options.is_none() {
-        slatedb_settings.compactor_options = Some(CompactorOptions::default());
-    }
-
-    // Ensure garbage collector options are set if not already configured
-    if slatedb_settings.garbage_collector_options.is_none() {
-        slatedb_settings.garbage_collector_options = Some(GarbageCollectorOptions {
-            manifest_options: Some(GarbageCollectorDirectoryOptions::default()),
-            wal_options: Some(GarbageCollectorDirectoryOptions::default()),
-            compacted_options: Some(GarbageCollectorDirectoryOptions::default()),
-        });
-    }
-    slatedb_settings
+    Settings::load().expect("Failed to load SlateDB settings")
 }
 
 #[allow(clippy::expect_used, clippy::redundant_closure_for_method_calls)]


### PR DESCRIPTION
## Summary
- Replace `Settings::from_env()` with `Settings::load()` API
- Simplifies configuration loading with built-in defaults
- Supports loading from slatedb.toml or environment variables

## Test plan
- [x] Tested with default settings - settings printed correctly
- [x] Tested with custom slatedb.toml configuration - max_sst_size changed from 256MB to 1GB
- [x] Verified graceful SIGTERM shutdown works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)