### PR TITLE
Allow to change PREFER_HASH_JOIN flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3518,6 +3518,9 @@ version = "0.0.0"
 dependencies = [
  "cfg-if",
  "core-executor",
+ "core-history",
+ "core-metastore",
+ "core-utils",
  "datafusion",
  "env_logger",
  "log",
@@ -3525,6 +3528,7 @@ dependencies = [
  "parquet 56.2.0",
  "serde",
  "serde_json",
+ "slatedb",
  "snmalloc-rs",
  "structopt",
  "tokio",

--- a/crates/benchmarks/.gitignore
+++ b/crates/benchmarks/.gitignore
@@ -1,3 +1,4 @@
 data
 results
 venv
+slatedb_prefix

--- a/crates/benchmarks/Cargo.toml
+++ b/crates/benchmarks/Cargo.toml
@@ -14,6 +14,10 @@ mimalloc = ["dep:mimalloc"]
 
 [dependencies]
 core-executor = { path = "../core-executor" }
+core-metastore = { path = "../core-metastore" }
+core-history = { path = "../core-history" }
+core-utils = { path = "../core-utils" }
+slatedb = { workspace = true }
 datafusion = { workspace = true, default-features = true }
 env_logger = { version = "0.11.8" }
 log = { version = "0.4.28" }

--- a/crates/benchmarks/README.md
+++ b/crates/benchmarks/README.md
@@ -49,22 +49,103 @@ To run for specific query, for example Q21
 ```shell
 ./bench.sh run tpch10 21
 ```
+
+## Comparing performance of main and a branch
+
+```shell
+git checkout main
+
+# Create the data
+./benchmarks/bench.sh data tpch
+
+# Gather baseline data for tpch benchmark
+./benchmarks/bench.sh run tpch
+
+# Switch to the branch named mybranch and gather data
+git checkout mybranch
+./benchmarks/bench.sh run tpch
+
+# Compare results in the two branches:
+./bench.sh compare main mybranch
+```
+
+This produces results like:
+
+```shell
+Comparing main and mybranch
+--------------------
+Benchmark tpch.json
+--------------------
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
+┃ Query        ┃         main ┃     mybranch ┃        Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
+│ QQuery 1     │    2520.52ms │    2795.09ms │  1.11x slower │
+│ QQuery 2     │     222.37ms │     216.01ms │     no change │
+│ QQuery 3     │     248.41ms │     239.07ms │     no change │
+│ QQuery 4     │     144.01ms │     129.28ms │ +1.11x faster │
+│ QQuery 5     │     339.54ms │     327.53ms │     no change │
+│ QQuery 6     │     147.59ms │     138.73ms │ +1.06x faster │
+│ QQuery 7     │     605.72ms │     631.23ms │     no change │
+│ QQuery 8     │     326.35ms │     372.12ms │  1.14x slower │
+│ QQuery 9     │     579.02ms │     634.73ms │  1.10x slower │
+│ QQuery 10    │     403.38ms │     420.39ms │     no change │
+│ QQuery 11    │     201.94ms │     212.12ms │  1.05x slower │
+│ QQuery 12    │     235.94ms │     254.58ms │  1.08x slower │
+│ QQuery 13    │     738.40ms │     789.67ms │  1.07x slower │
+│ QQuery 14    │     198.73ms │     206.96ms │     no change │
+│ QQuery 15    │     183.32ms │     179.53ms │     no change │
+│ QQuery 16    │     168.57ms │     186.43ms │  1.11x slower │
+│ QQuery 17    │    2032.57ms │    2108.12ms │     no change │
+│ QQuery 18    │    1912.80ms │    2134.82ms │  1.12x slower │
+│ QQuery 19    │     391.64ms │     368.53ms │ +1.06x faster │
+│ QQuery 20    │     648.22ms │     691.41ms │  1.07x slower │
+│ QQuery 21    │     866.25ms │    1020.37ms │  1.18x slower │
+│ QQuery 22    │     115.94ms │     117.27ms │     no change │
+└──────────────┴──────────────┴──────────────┴───────────────┘
+--------------------
+Benchmark tpch_mem.json
+--------------------
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
+┃ Query        ┃         main ┃     mybranch ┃        Change ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
+│ QQuery 1     │    2182.44ms │    2390.39ms │  1.10x slower │
+│ QQuery 2     │     181.16ms │     153.94ms │ +1.18x faster │
+│ QQuery 3     │      98.89ms │      95.51ms │     no change │
+│ QQuery 4     │      61.43ms │      66.15ms │  1.08x slower │
+│ QQuery 5     │     260.20ms │     283.65ms │  1.09x slower │
+│ QQuery 6     │      24.24ms │      23.39ms │     no change │
+│ QQuery 7     │     545.87ms │     653.34ms │  1.20x slower │
+│ QQuery 8     │     147.48ms │     136.00ms │ +1.08x faster │
+│ QQuery 9     │     371.53ms │     363.61ms │     no change │
+│ QQuery 10    │     197.91ms │     190.37ms │     no change │
+│ QQuery 11    │     197.91ms │     183.70ms │ +1.08x faster │
+│ QQuery 12    │     100.32ms │     103.08ms │     no change │
+│ QQuery 13    │     428.02ms │     440.26ms │     no change │
+│ QQuery 14    │      38.50ms │      27.11ms │ +1.42x faster │
+│ QQuery 15    │     101.15ms │      63.25ms │ +1.60x faster │
+│ QQuery 16    │     171.15ms │     142.44ms │ +1.20x faster │
+│ QQuery 17    │    1885.05ms │    1953.58ms │     no change │
+│ QQuery 18    │    1549.92ms │    1914.06ms │  1.23x slower │
+│ QQuery 19    │     106.53ms │     104.28ms │     no change │
+│ QQuery 20    │     532.11ms │     610.62ms │  1.15x slower │
+│ QQuery 21    │     723.39ms │     823.34ms │  1.14x slower │
+│ QQuery 22    │      91.84ms │      89.89ms │     no change │
+└──────────────┴──────────────┴──────────────┴───────────────┘
+```
 ### Running Benchmarks Manually
 
 Assuming data is in the `data` directory, the `tpch` benchmark can be run with a command like this:
 
 ```bash
-cargo run --release --bin dfbench -- tpch --iterations 3 --path ./data  --query 1
+cargo run --release --bin embench -- tpch --iterations 3 --path ./data  --query 1
 ```
-
-See the help for more details.
 
 ### Different features
 
 You can enable `mimalloc` or `snmalloc` (to use either the mimalloc or snmalloc allocator) as features by passing them in as `--features`. For example:
 
 ```shell
-cargo run --release --features "mimalloc" --bin tpch -- benchmark datafusion --iterations 3 --path ./data --query 1
+cargo run --release --features "mimalloc" --bin embench -- tpch --iterations 3 --path ./data --query 1
 ```
 
 # Writing a new benchmark

--- a/crates/benchmarks/bench.sh
+++ b/crates/benchmarks/bench.sh
@@ -327,7 +327,7 @@ run_clickbench_1() {
     RESULTS_FILE="${RESULTS_DIR}/clickbench_1.json"
     echo "RESULTS_FILE: ${RESULTS_FILE}"
     echo "Running clickbench (1 file) benchmark..."
-    $CARGO_COMMAND --bin embench -- clickbench  --iterations 3 --output-files-number 1 --path "${DATA_DIR}/hits" --queries-path "${SCRIPT_DIR}/queries/clickbench/queries.sql" -o "${RESULTS_FILE}"
+    $CARGO_COMMAND --bin embench -- clickbench  --iterations 3 --output_files_number 1 --prefer_hash_join "${PREFER_HASH_JOIN}" --path "${DATA_DIR}/hits" --queries-path "${SCRIPT_DIR}/queries/clickbench/queries.sql" -o "${RESULTS_FILE}"
 }
 
  # Runs the clickbench benchmark with the partitioned parquet files
@@ -335,7 +335,7 @@ run_clickbench_partitioned() {
     RESULTS_FILE="${RESULTS_DIR}/clickbench_partitioned.json"
     echo "RESULTS_FILE: ${RESULTS_FILE}"
     echo "Running clickbench (partitioned, 100 files) benchmark..."
-    $CARGO_COMMAND --bin embench -- clickbench  --iterations 3 --output-files-number 100 --path "${DATA_DIR}/hits_partitioned" --queries-path "${SCRIPT_DIR}/queries/clickbench/queries.sql" -o "${RESULTS_FILE}"
+    $CARGO_COMMAND --bin embench -- clickbench  --iterations 3 --output_files_number 100 --prefer_hash_join "${PREFER_HASH_JOIN}" --path "${DATA_DIR}/hits_partitioned" --queries-path "${SCRIPT_DIR}/queries/clickbench/queries.sql" -o "${RESULTS_FILE}"
 }
 
 compare_benchmarks() {

--- a/crates/benchmarks/bench.sh
+++ b/crates/benchmarks/bench.sh
@@ -10,9 +10,10 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Set Defaults
 COMMAND=
 BENCHMARK=all
-DATAFUSION_DIR=${DATAFUSION_DIR:-$SCRIPT_DIR/..}
+EMBUCKET_DIR=${EMBUCKET_DIR:-$SCRIPT_DIR/..}
 DATA_DIR=${DATA_DIR:-$SCRIPT_DIR/data}
 CARGO_COMMAND=${CARGO_COMMAND:-"cargo run --release"}
+PREFER_HASH_JOIN=${PREFER_HASH_JOIN:-true}
 VIRTUAL_ENV=${VIRTUAL_ENV:-$SCRIPT_DIR/venv}
 
 usage() {
@@ -52,8 +53,9 @@ clickbench_partitioned: ClickBench queries against a partitioned (100 files) par
 **********
 DATA_DIR            directory to store datasets
 CARGO_COMMAND       command that runs the benchmark binary
-DATAFUSION_DIR      directory to use (default $DATAFUSION_DIR)
+EMBUCKET_DIR        directory to use (default $EMBUCKET_DIR)
 RESULTS_NAME        folder where the benchmark files are stored
+PREFER_HASH_JOIN    Prefer hash join algorithm (default true)
 VENV_PATH           Python venv to use for compare and venv commands (default ./venv, override by <your-venv>/bin/activate)
 "
     exit 1
@@ -101,11 +103,13 @@ main() {
             echo "BENCHMARK: ${BENCHMARK}"
             echo "DATA_DIR: ${DATA_DIR}"
             echo "CARGO_COMMAND: ${CARGO_COMMAND}"
+            echo "PREFER_HASH_JOIN: ${PREFER_HASH_JOIN}"
             echo "***************************"
             case "$BENCHMARK" in
                 all)
                     data_tpch "1"
                     data_tpch "10"
+                    data_tpch "100"
                     data_clickbench_1
                     data_clickbench_partitioned
                     ;;
@@ -114,6 +118,9 @@ main() {
                     ;;
                 tpch10)
                     data_tpch "10"
+                    ;;
+                tpch100)
+                    data_tpch "100"
                     ;;
                 clickbench_1)
                     data_clickbench_1
@@ -130,7 +137,7 @@ main() {
         run)
             # Parse positional parameters
             BENCHMARK=${ARG2:-"${BENCHMARK}"}
-            BRANCH_NAME=$(cd "${DATAFUSION_DIR}" && git rev-parse --abbrev-ref HEAD)
+            BRANCH_NAME=$(cd "${EMBUCKET_DIR}" && git rev-parse --abbrev-ref HEAD)
             BRANCH_NAME=${BRANCH_NAME//\//_} # mind blowing syntax to replace / with _
             RESULTS_NAME=${RESULTS_NAME:-"${BRANCH_NAME}"}
             RESULTS_DIR=${RESULTS_DIR:-"$SCRIPT_DIR/results/$RESULTS_NAME"}
@@ -139,7 +146,7 @@ main() {
             echo "DataFusion Benchmark Script"
             echo "COMMAND: ${COMMAND}"
             echo "BENCHMARK: ${BENCHMARK}"
-            echo "DATAFUSION_DIR: ${DATAFUSION_DIR}"
+            echo "EMBUCKET_DIR: ${EMBUCKET_DIR}"
             echo "BRANCH_NAME: ${BRANCH_NAME}"
             echo "DATA_DIR: ${DATA_DIR}"
             echo "RESULTS_DIR: ${RESULTS_DIR}"
@@ -147,13 +154,14 @@ main() {
             echo "***************************"
 
             # navigate to the appropriate directory
-            pushd "${DATAFUSION_DIR}/benchmarks" > /dev/null
+            pushd "${EMBUCKET_DIR}/benchmarks" > /dev/null
             mkdir -p "${RESULTS_DIR}"
             mkdir -p "${DATA_DIR}"
             case "$BENCHMARK" in
                 all)
                     run_tpch "1"
                     run_tpch "10"
+                    run_tpch "100"
                     run_clickbench_1
                     run_clickbench_partitioned
                     ;;
@@ -162,6 +170,9 @@ main() {
                     ;;
                 tpch10)
                     run_tpch "10"
+                    ;;
+                tpch100)
+                    run_tpch "100"
                     ;;
                 clickbench_1)
                     run_clickbench_1
@@ -261,7 +272,7 @@ run_tpch() {
     QUERY=$([ -n "$ARG3" ] && echo "--query $ARG3" || echo "")
     # debug the target command
     set -x
-    $CARGO_COMMAND --bin embench -- tpch --iterations 3 --path "${TPCH_DIR}" -o "${RESULTS_FILE}" $QUERY
+    $CARGO_COMMAND --bin embench -- tpch --iterations 3 --output_files_number "$SCALE_FACTOR" --path "${TPCH_DIR}" --prefer_hash_join "${PREFER_HASH_JOIN}" -o "${RESULTS_FILE}" $QUERY
     set +x
 }
 
@@ -316,7 +327,7 @@ run_clickbench_1() {
     RESULTS_FILE="${RESULTS_DIR}/clickbench_1.json"
     echo "RESULTS_FILE: ${RESULTS_FILE}"
     echo "Running clickbench (1 file) benchmark..."
-    $CARGO_COMMAND --bin embench -- clickbench  --iterations 3 --path "${DATA_DIR}/hits"  --queries-path "${SCRIPT_DIR}/queries/clickbench/queries.sql" -o "${RESULTS_FILE}"
+    $CARGO_COMMAND --bin embench -- clickbench  --iterations 3 --output-files-number 1 --path "${DATA_DIR}/hits" --queries-path "${SCRIPT_DIR}/queries/clickbench/queries.sql" -o "${RESULTS_FILE}"
 }
 
  # Runs the clickbench benchmark with the partitioned parquet files
@@ -324,7 +335,7 @@ run_clickbench_partitioned() {
     RESULTS_FILE="${RESULTS_DIR}/clickbench_partitioned.json"
     echo "RESULTS_FILE: ${RESULTS_FILE}"
     echo "Running clickbench (partitioned, 100 files) benchmark..."
-    $CARGO_COMMAND --bin embench -- clickbench  --iterations 3 --path "${DATA_DIR}/hits_partitioned" --queries-path "${SCRIPT_DIR}/queries/clickbench/queries.sql" -o "${RESULTS_FILE}"
+    $CARGO_COMMAND --bin embench -- clickbench  --iterations 3 --output-files-number 100 --path "${DATA_DIR}/hits_partitioned" --queries-path "${SCRIPT_DIR}/queries/clickbench/queries.sql" -o "${RESULTS_FILE}"
 }
 
 compare_benchmarks() {

--- a/crates/benchmarks/src/clickbench/run.rs
+++ b/crates/benchmarks/src/clickbench/run.rs
@@ -1,4 +1,7 @@
-use crate::util::{BenchmarkRun, CommonOpt, create_catalog, query_context, table_ref};
+use crate::util::{
+    BenchmarkRun, CommonOpt, create_catalog, query_context, set_session_variable_bool,
+    set_session_variable_number, table_ref,
+};
 use core_executor::service::{ExecutionService, make_test_execution_svc};
 use core_executor::session::UserSession;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -110,14 +113,17 @@ impl RunOpt {
 
         let service = make_test_execution_svc().await;
         let session = service.create_session("session_id").await?;
-        {
-            let state = session.ctx.state_ref();
-            let mut write = state.write();
-            let options = write.config_mut().options_mut();
-            // The hits_partitioned dataset specifies string columns
-            // as binary due to how it was written. Force it to strings
-            options.execution.parquet.binary_as_string = true;
-        }
+
+        // Set the number of output parquet files during copy into
+        set_session_variable_number(
+            "execution.minimum_parallel_output_files",
+            self.common.output_files_number,
+            &session,
+        )
+        .await?;
+        // The hits_partitioned dataset specifies string columns
+        // as binary due to how it was written. Force it to strings
+        set_session_variable_bool("execution.parquet.binary_as_string", true, &session).await?;
 
         println!("Creating catalog, schema, table");
         let path = self.path.to_str().unwrap();
@@ -129,6 +135,7 @@ impl RunOpt {
         for query_id in query_range {
             let mut millis = Vec::with_capacity(iterations);
             benchmark_run.start_new_case(&format!("Query {query_id}"));
+            let session = service.create_session("session_id").await?;
             let sql = queries.get_query(query_id)?;
             println!("Q{query_id}: {sql}");
 

--- a/crates/benchmarks/src/clickbench/run.rs
+++ b/crates/benchmarks/src/clickbench/run.rs
@@ -1,8 +1,8 @@
 use crate::util::{
-    BenchmarkRun, CommonOpt, create_catalog, query_context, set_session_variable_bool,
-    set_session_variable_number, table_ref,
+    BenchmarkRun, CommonOpt, create_catalog, make_test_execution_svc, query_context,
+    set_session_variable_bool, set_session_variable_number, table_ref,
 };
-use core_executor::service::{ExecutionService, make_test_execution_svc};
+use core_executor::service::ExecutionService;
 use core_executor::session::UserSession;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::exec_datafusion_err;

--- a/crates/benchmarks/src/clickbench/run.rs
+++ b/crates/benchmarks/src/clickbench/run.rs
@@ -136,6 +136,14 @@ impl RunOpt {
             let mut millis = Vec::with_capacity(iterations);
             benchmark_run.start_new_case(&format!("Query {query_id}"));
             let session = service.create_session("session_id").await?;
+
+            // Set prefer_hash_join session variable
+            set_session_variable_bool(
+                "optimizer.prefer_hash_join",
+                self.common.prefer_hash_join,
+                &session,
+            )
+            .await?;
             let sql = queries.get_query(query_id)?;
             println!("Q{query_id}: {sql}");
 

--- a/crates/benchmarks/src/tpch/run.rs
+++ b/crates/benchmarks/src/tpch/run.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use super::{TPCH_TABLES, get_query_sql, get_tpch_table_sql};
 use crate::util::{
-    BenchmarkRun, CommonOpt, create_catalog, query_context, set_session_variable_bool,
-    set_session_variable_number,
+    BenchmarkRun, CommonOpt, create_catalog, make_test_execution_svc, query_context,
+    set_session_variable_bool, set_session_variable_number,
 };
 
-use core_executor::service::{CoreExecutionService, ExecutionService, make_test_execution_svc};
+use core_executor::service::{CoreExecutionService, ExecutionService};
 use core_executor::session::UserSession;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::arrow::util::pretty::pretty_format_batches;

--- a/crates/benchmarks/src/tpch/run.rs
+++ b/crates/benchmarks/src/tpch/run.rs
@@ -16,9 +16,6 @@ use datafusion::error::Result;
 use log::info;
 use structopt::StructOpt;
 
-// hack to avoid `default_value is meaningless for bool` errors
-type BoolDefaultTrue = bool;
-
 /// Run the tpch benchmark.
 ///
 /// This benchmarks is derived from the [TPC-H][1] version
@@ -43,10 +40,6 @@ pub struct RunOpt {
     /// Path to machine-readable output file
     #[structopt(parse(from_os_str), short = "o", long = "output")]
     output_path: Option<PathBuf>,
-    /// If true then hash join used, if false then sort merge join
-    /// True by default.
-    #[structopt(short = "j", long = "prefer_hash_join", default_value = "true")]
-    prefer_hash_join: BoolDefaultTrue,
 }
 
 const TPCH_QUERY_START_ID: usize = 1;
@@ -107,7 +100,7 @@ impl RunOpt {
         // Set prefer_hash_join session variable
         set_session_variable_bool(
             "optimizer.prefer_hash_join",
-            self.prefer_hash_join,
+            self.common.prefer_hash_join,
             &session,
         )
         .await?;

--- a/crates/benchmarks/src/util/mod.rs
+++ b/crates/benchmarks/src/util/mod.rs
@@ -2,7 +2,12 @@ mod options;
 mod run;
 
 use core_executor::models::QueryContext;
+use core_executor::service::CoreExecutionService;
 use core_executor::session::UserSession;
+use core_executor::utils::Config;
+use core_history::SlateDBHistoryStore;
+use core_metastore::SlateDBMetastore;
+use core_utils::Db;
 use datafusion::error::Result;
 pub use options::CommonOpt;
 pub use run::{BenchQuery, BenchmarkRun};
@@ -68,4 +73,26 @@ pub async fn set_session_variable_bool(
     let mut query = session.query(var_query, query_context());
     query.execute().await?;
     Ok(())
+}
+
+#[allow(clippy::expect_used, clippy::as_conversions)]
+pub async fn make_test_execution_svc() -> Arc<CoreExecutionService> {
+    // let object_store = LocalFileSystem::new_with_prefix(PathBuf::from("."))
+    //     .map(|fs| Arc::new(fs) as Arc<dyn ObjectStore>)
+    //     .expect("Failed to create file object_store");
+    //
+    // let db = Db::new(Arc::new(
+    //     DbBuilder::new(Path::from("slatedb_prefix"), object_store.clone())
+    //         .build()
+    //         .await
+    //         .expect("Failed to start Slate DB"),
+    // ));
+    let db = Db::memory().await;
+    let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
+    let history_store = Arc::new(SlateDBHistoryStore::new(db));
+    Arc::new(
+        CoreExecutionService::new(metastore, history_store, Arc::new(Config::default()))
+            .await
+            .expect("Failed to create a execution service"),
+    )
 }

--- a/crates/benchmarks/src/util/mod.rs
+++ b/crates/benchmarks/src/util/mod.rs
@@ -47,3 +47,25 @@ pub async fn create_catalog(path: &str, session: &Arc<UserSession>) -> Result<()
     schema_query.execute().await?;
     Ok(())
 }
+
+pub async fn set_session_variable_number(
+    var: &str,
+    value: usize,
+    session: &Arc<UserSession>,
+) -> Result<()> {
+    let var_query = format!("SET datafusion.{var} = {value}");
+    let mut query = session.query(var_query, query_context());
+    query.execute().await?;
+    Ok(())
+}
+
+pub async fn set_session_variable_bool(
+    var: &str,
+    value: bool,
+    session: &Arc<UserSession>,
+) -> Result<()> {
+    let var_query = format!("SET datafusion.{var} = {value}");
+    let mut query = session.query(var_query, query_context());
+    query.execute().await?;
+    Ok(())
+}

--- a/crates/benchmarks/src/util/options.rs
+++ b/crates/benchmarks/src/util/options.rs
@@ -1,5 +1,8 @@
 use structopt::StructOpt;
 
+// hack to avoid `default_value is meaningless for bool` errors
+type BoolDefaultTrue = bool;
+
 #[derive(Debug, StructOpt, Clone)]
 pub struct CommonOpt {
     /// Number of iterations of each test run
@@ -9,4 +12,9 @@ pub struct CommonOpt {
     /// The number of output parquet files
     #[structopt(long = "output_files_number", default_value = "1")]
     pub output_files_number: usize,
+
+    /// If true then hash join used, if false then sort merge join
+    /// True by default.
+    #[structopt(short = "j", long = "prefer_hash_join", default_value = "true")]
+    pub prefer_hash_join: BoolDefaultTrue,
 }

--- a/crates/benchmarks/src/util/options.rs
+++ b/crates/benchmarks/src/util/options.rs
@@ -5,4 +5,8 @@ pub struct CommonOpt {
     /// Number of iterations of each test run
     #[structopt(short = "i", long = "iterations", default_value = "3")]
     pub iterations: usize,
+
+    /// The number of output parquet files
+    #[structopt(long = "output_files_number", default_value = "1")]
+    pub output_files_number: usize,
 }


### PR DESCRIPTION
```
RESULTS_NAME=join_false PREFER_HASH_JOIN=false ./bench.sh run tpch 
RESULTS_NAME=join PREFER_HASH_JOIN=true ./bench.sh run tpch 
./bench.sh compare join join_false 
```

- ability to compare results from different runs
- added splitting parquet files depending on data scale
- create the data for all queries just one time