### PR TITLE
engine: TPC-DS q2 `null` fix

### DIFF
--- a/crates/embucket-functions/src/tests/conversion/snapshots/to_decimal/query_to_decimal_from_null.snap
+++ b/crates/embucket-functions/src/tests/conversion/snapshots/to_decimal/query_to_decimal_from_null.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/conversion/to_decimal.rs
+description: "\"SELECT TO_DECIMAL(NULL)\""
+---
+Ok(
+    [
+        "+------------------+",
+        "| to_decimal(NULL) |",
+        "+------------------+",
+        "|                  |",
+        "+------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/conversion/snapshots/to_decimal/query_to_decimal_from_null_not_null.snap
+++ b/crates/embucket-functions/src/tests/conversion/snapshots/to_decimal/query_to_decimal_from_null_not_null.snap
@@ -1,0 +1,14 @@
+---
+source: crates/embucket-functions/src/tests/conversion/to_decimal.rs
+description: "\"SELECT\n       TO_DECIMAL(column1) as convert_null\n    FROM VALUES (NULL), (10)\""
+---
+Ok(
+    [
+        "+--------------+",
+        "| convert_null |",
+        "+--------------+",
+        "|              |",
+        "| 10           |",
+        "+--------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/conversion/snapshots/to_decimal/query_to_decimal_from_null_not_null_reversed.snap
+++ b/crates/embucket-functions/src/tests/conversion/snapshots/to_decimal/query_to_decimal_from_null_not_null_reversed.snap
@@ -1,0 +1,14 @@
+---
+source: crates/embucket-functions/src/tests/conversion/to_decimal.rs
+description: "\"SELECT\n       TO_DECIMAL(column1) as convert_null\n    FROM VALUES (10), (null)\""
+---
+Ok(
+    [
+        "+--------------+",
+        "| convert_null |",
+        "+--------------+",
+        "| 10           |",
+        "|              |",
+        "+--------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/conversion/snapshots/to_decimal/query_to_decimal_from_null_with_precision_and_scale.snap
+++ b/crates/embucket-functions/src/tests/conversion/snapshots/to_decimal/query_to_decimal_from_null_with_precision_and_scale.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/conversion/to_decimal.rs
+description: "\"SELECT TO_DECIMAL(NULL, 7, 2)\""
+---
+Ok(
+    [
+        "+------------------------------------+",
+        "| to_decimal(NULL,Int64(7),Int64(2)) |",
+        "+------------------------------------+",
+        "|                                    |",
+        "+------------------------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/conversion/to_decimal.rs
+++ b/crates/embucket-functions/src/tests/conversion/to_decimal.rs
@@ -50,3 +50,31 @@ test_query!(
     FROM VALUES (FALSE), (TRUE)",
     snapshot_path = "to_decimal"
 );
+
+test_query!(
+    to_decimal_from_null,
+    "SELECT TO_DECIMAL(NULL)",
+    snapshot_path = "to_decimal"
+);
+
+test_query!(
+    to_decimal_from_null_not_null,
+    "SELECT
+       TO_DECIMAL(column1) as convert_null
+    FROM VALUES (NULL), (10)",
+    snapshot_path = "to_decimal"
+);
+
+test_query!(
+    to_decimal_from_null_not_null_reversed,
+    "SELECT
+       TO_DECIMAL(column1) as convert_null
+    FROM VALUES (10), (null)",
+    snapshot_path = "to_decimal"
+);
+
+test_query!(
+    to_decimal_from_null_with_precision_and_scale,
+    "SELECT TO_DECIMAL(NULL, 7, 2)",
+    snapshot_path = "to_decimal"
+);


### PR DESCRIPTION
Closes #1824

- The problem was that `Null` couldn't be used ad an argument of `to_decimal` udf
- Also fixed a bug with error bubble up for null and any other type with `to_decimal` udf `try_mode` = `true`
- Added insta tests
- Tested locally on tpcds one row for query 2
- No problem with the casting rule itself