### PR TITLE
engine: `regexp_replace` occurrence bug fix

### DIFF
--- a/crates/benchmarks/src/util/options.rs
+++ b/crates/benchmarks/src/util/options.rs
@@ -83,7 +83,7 @@ impl CommonOpt {
     #[must_use]
     pub fn update_config(&self, config: SessionConfig) -> SessionConfig {
         let mut config = config
-            .with_target_partitions(self.partitions.unwrap_or(get_available_parallelism()))
+            .with_target_partitions(self.partitions.unwrap_or_else(get_available_parallelism))
             .with_batch_size(self.batch_size);
         if let Some(sort_spill_reservation_bytes) = self.sort_spill_reservation_bytes {
             config = config.with_sort_spill_reservation_bytes(sort_spill_reservation_bytes);

--- a/crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+++ b/crates/embucket-functions/src/tests/regexp/regexp_replace.rs
@@ -28,3 +28,53 @@ test_query!(
                       2)",
     snapshot_path = "regexp_replace"
 );
+
+test_query!(
+    regexp_replace_first_occurrence_not_forward,
+    "SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',
+                      'times',
+                      'days',
+                      1,
+                      1)",
+    snapshot_path = "regexp_replace"
+);
+
+test_query!(
+    regexp_replace_second_occurrence_not_forward,
+    "SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',
+                      'times',
+                      'days',
+                      1,
+                      2)",
+    snapshot_path = "regexp_replace"
+);
+
+test_query!(
+    regexp_replace_third_occurrence_not_forward,
+    "SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',
+                      'times',
+                      'days',
+                      1,
+                      3)",
+    snapshot_path = "regexp_replace"
+);
+
+test_query!(
+    regexp_replace_first_occurrence_not_forward_with_position,
+    "SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',
+                      'times',
+                      'days',
+                      30,
+                      1) AS result;",
+    snapshot_path = "regexp_replace"
+);
+
+test_query!(
+    regexp_replace_second_occurrence_not_forward_with_position,
+    "SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',
+                      'times',
+                      'days',
+                      30,
+                      2) AS result;",
+    snapshot_path = "regexp_replace"
+);

--- a/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_first_occurrence_not_forward.snap
+++ b/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_first_occurrence_not_forward.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+description: "\"SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',\n                      'times',\n                      'days',\n                      1,\n                      1)\""
+---
+Ok(
+    [
+        "+---------------------------------------------------------------------------------------------------------------------------------+",
+        "| regexp_replace(Utf8(\"It was the best of times, it was the worst of times. times\"),Utf8(\"times\"),Utf8(\"days\"),Int64(1),Int64(1)) |",
+        "+---------------------------------------------------------------------------------------------------------------------------------+",
+        "| It was the best of days, it was the worst of times. times                                                                       |",
+        "+---------------------------------------------------------------------------------------------------------------------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_first_occurrence_not_forward_with_position.snap
+++ b/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_first_occurrence_not_forward_with_position.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+description: "\"SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',\n                      'times',\n                      'days',\n                      30,\n                      1) AS result;\""
+---
+Ok(
+    [
+        "+-----------------------------------------------------------+",
+        "| result                                                    |",
+        "+-----------------------------------------------------------+",
+        "| It was the best of times, it was the worst of days. times |",
+        "+-----------------------------------------------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_second_occurrence_not_forward.snap
+++ b/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_second_occurrence_not_forward.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+description: "\"SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',\n                      'times',\n                      'days',\n                      1,\n                      2)\""
+---
+Ok(
+    [
+        "+---------------------------------------------------------------------------------------------------------------------------------+",
+        "| regexp_replace(Utf8(\"It was the best of times, it was the worst of times. times\"),Utf8(\"times\"),Utf8(\"days\"),Int64(1),Int64(2)) |",
+        "+---------------------------------------------------------------------------------------------------------------------------------+",
+        "| It was the best of times, it was the worst of days. times                                                                       |",
+        "+---------------------------------------------------------------------------------------------------------------------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_second_occurrence_not_forward_with_position.snap
+++ b/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_second_occurrence_not_forward_with_position.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+description: "\"SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',\n                      'times',\n                      'days',\n                      30,\n                      2) AS result;\""
+---
+Ok(
+    [
+        "+-----------------------------------------------------------+",
+        "| result                                                    |",
+        "+-----------------------------------------------------------+",
+        "| It was the best of times, it was the worst of times. days |",
+        "+-----------------------------------------------------------+",
+    ],
+)

--- a/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_third_occurrence_not_forward.snap
+++ b/crates/embucket-functions/src/tests/regexp/snapshots/regexp_replace/query_regexp_replace_third_occurrence_not_forward.snap
@@ -1,0 +1,13 @@
+---
+source: crates/embucket-functions/src/tests/regexp/regexp_replace.rs
+description: "\"SELECT REGEXP_REPLACE('It was the best of times, it was the worst of times. times',\n                      'times',\n                      'days',\n                      1,\n                      3)\""
+---
+Ok(
+    [
+        "+---------------------------------------------------------------------------------------------------------------------------------+",
+        "| regexp_replace(Utf8(\"It was the best of times, it was the worst of times. times\"),Utf8(\"times\"),Utf8(\"days\"),Int64(1),Int64(3)) |",
+        "+---------------------------------------------------------------------------------------------------------------------------------+",
+        "| It was the best of times, it was the worst of times. days                                                                       |",
+        "+---------------------------------------------------------------------------------------------------------------------------------+",
+    ],
+)


### PR DESCRIPTION
Closes #1843

- All `regexp` functions use `occurrence` the same way 
- Except `regexp_replace` - fixed
- Insta tests
- This is needed for #1825 q66 testing of subquery aliasing bug
- **dbt gitlab tested 93.4%**