### PR TITLE
engine: tps ds q66 fix

### DIFF
--- a/crates/embucket-functions/src/tests/visitors.rs
+++ b/crates/embucket-functions/src/tests/visitors.rs
@@ -404,6 +404,12 @@ fn test_inline_aliases_in_query() -> DFResult<()> {
             WHERE end_tstamp > '2025-10-01' and user_id is not null",
             "SELECT last_value(user_id) AS user_id, max(collector_tstamp) OVER (PARTITION BY domain_userid) AS end_tstamp FROM embucket.public_scratch.snowplow_web_base_events_this_run WHERE end_tstamp > '2025-10-01' AND last_value(user_id) IS NOT NULL"
         ),
+        ("SELECT 'test' AS name, length(name) FROM (SELECT name FROM (VALUES ('test')))",
+         "SELECT 'test' AS name, length(name) FROM (SELECT name FROM (VALUES ('test')))"),
+        ("SELECT regexp_replace(name, 'yes', '', 1, 1) AS name, regexp_replace(name, 'yes', '', 1, 1) AS test FROM (SELECT column1 AS name FROM (VALUES ('yesnotyes')))",
+        "SELECT regexp_replace(name, 'yes', '', 1, 1) AS name, regexp_replace(name, 'yes', '', 1, 1) AS test FROM (SELECT column1 AS name FROM (VALUES ('yesnotyes')))"),
+        ("SELECT sum(jan_sales) AS jan_sales, sum(jan_sales / 1) AS jan_sales_per_sq_foot FROM (SELECT sum(CASE WHEN d_moy = 1 THEN ws_ext_sales_price * ws_quantity ELSE 0 END) AS jan_sales FROM web_sales, date_dim UNION ALL SELECT sum(CASE WHEN d_moy = 1 THEN cs_sales_price * cs_quantity ELSE 0 END) AS jan_sales FROM catalog_sales, date_dim)",
+         "SELECT sum(jan_sales) AS jan_sales, sum(jan_sales / 1) AS jan_sales_per_sq_foot FROM (SELECT sum(CASE WHEN d_moy = 1 THEN ws_ext_sales_price * ws_quantity ELSE 0 END) AS jan_sales FROM web_sales, date_dim UNION ALL SELECT sum(CASE WHEN d_moy = 1 THEN cs_sales_price * cs_quantity ELSE 0 END) AS jan_sales FROM catalog_sales, date_dim)"),
     ];
 
     for (input, expected) in cases {

--- a/crates/embucket-functions/src/visitors/inline_aliases_in_query.rs
+++ b/crates/embucket-functions/src/visitors/inline_aliases_in_query.rs
@@ -1,8 +1,8 @@
-use datafusion::logical_expr::sqlparser::ast::{Expr, Function, VisitMut};
+use datafusion::logical_expr::sqlparser::ast::{Expr, Function, SetOperator, VisitMut};
 use datafusion::sql::sqlparser::ast::{
-    Query, SelectItem, SetExpr, Statement, VisitorMut, visit_expressions_mut,
+    Query, SelectItem, SetExpr, Statement, TableFactor, VisitorMut, visit_expressions_mut,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::ControlFlow;
 
 /// A visitor that performs **safe alias inlining** inside the `SELECT` projection of a SQL query.
@@ -33,6 +33,13 @@ use std::ops::ControlFlow;
 /// ```sql
 /// SELECT a + b AS sum_ab, (a + b) * 2 FROM my_table
 /// ```
+/// ```sql
+/// SELECT 'test' as name, length(name) FROM (SELECT name FROM VALUES ('test'))
+/// ```
+/// Output (after inlining, doesn't change anything):
+/// ```sql
+/// SELECT 'test' as name, length(name) FROM (SELECT name FROM VALUES ('test'))
+/// ```
 #[derive(Debug, Default)]
 pub struct InlineAliasesInSelect {}
 
@@ -43,14 +50,39 @@ impl VisitorMut for InlineAliasesInSelect {
         if let SetExpr::Select(select) = &mut *query.body {
             let mut alias_expr_map = HashMap::new();
 
+            let mut subquery_idents = HashSet::new();
+
+            for table in &mut select.from {
+                //Here we go over all parenthesized subqueries in the FROM clause. Ex: SELECT * FROM `(SELECT * FROM table)`, `(SELECT * FROM table)`
+                if let TableFactor::Derived { subquery, .. } = &mut table.relation {
+                    //Here we go over all SELECTS & UNIONs in the parentheses. Ex: SELECT * FROM `(SELECT * FROM table UNION ALL SELECT * FROM table)`
+                    traverse_set_expr(&mut subquery_idents, &subquery.body);
+                }
+            }
+
             for item in &mut select.projection {
                 match item {
                     SelectItem::ExprWithAlias { expr, alias } => {
-                        substitute_aliases(expr, &alias_expr_map, Some(&alias.value), None);
-                        alias_expr_map.insert(alias.value.clone(), expr.clone());
+                        //Don't substitute aliases for the same alias & subquery idents
+                        substitute_aliases(
+                            expr,
+                            &alias_expr_map,
+                            Some(&alias.value),
+                            Some(&|e| contains_ident_value(&subquery_idents, e)),
+                        );
+                        //Don't add to a substitution map if the alias is the same as the subquery ident
+                        if !subquery_idents.contains(&alias.value) {
+                            alias_expr_map.insert(alias.value.clone(), expr.clone());
+                        }
                     }
                     SelectItem::UnnamedExpr(expr) => {
-                        substitute_aliases(expr, &alias_expr_map, None, None);
+                        //Don't substitute subquery idents
+                        substitute_aliases(
+                            expr,
+                            &alias_expr_map,
+                            None,
+                            Some(&|e| contains_ident_value(&subquery_idents, e)),
+                        );
                     }
                     _ => {}
                 }
@@ -65,13 +97,23 @@ impl VisitorMut for InlineAliasesInSelect {
                     selection,
                     &alias_expr_map,
                     None,
-                    Some(&|e| matches!(e, Expr::Function(Function { over: Some(_), .. }))),
+                    //Just a precation, not sure if we need to check with teh subquery here
+                    Some(&|e| {
+                        matches!(e, Expr::Function(Function { over: Some(_), .. }))
+                            || contains_ident_value(&subquery_idents, e)
+                    }),
                 );
             }
 
             // Rewrite QUALIFY
             if let Some(qualify) = select.qualify.as_mut() {
-                substitute_aliases(qualify, &alias_expr_map, None, None);
+                //Just a precation, not sure if we need to check with teh subquery here
+                substitute_aliases(
+                    qualify,
+                    &alias_expr_map,
+                    None,
+                    Some(&|e| contains_ident_value(&subquery_idents, e)),
+                );
             }
         }
 
@@ -114,6 +156,44 @@ fn substitute_aliases(
         }
         ControlFlow::Continue(())
     });
+}
+
+fn contains_ident_value(subquery_idents: &HashSet<String>, expr: &Expr) -> bool {
+    if let Expr::Identifier(ident) = expr {
+        subquery_idents.contains(&ident.value)
+    } else {
+        false
+    }
+}
+
+/// Recursively traverses the subquery to find all identifiers
+fn traverse_set_expr(subquery_idents: &mut HashSet<String>, set_expr: &SetExpr) {
+    //Recursion shouldn't be an issue, since we only traverse one level of the subquery (one level of parentheses)
+    match set_expr {
+        SetExpr::Select(select) => {
+            select.projection.iter().for_each(|item| match item {
+                SelectItem::ExprWithAlias { alias, .. } => {
+                    subquery_idents.insert(alias.value.clone());
+                }
+                SelectItem::UnnamedExpr(expr) => {
+                    if let Expr::Identifier(ident) = expr {
+                        subquery_idents.insert(ident.value.clone());
+                    }
+                }
+                _ => {}
+            });
+        }
+        SetExpr::SetOperation {
+            op, left, right, ..
+        } if op == &SetOperator::Union => {
+            let () = traverse_set_expr(subquery_idents, left);
+            let () = traverse_set_expr(subquery_idents, right);
+        }
+        SetExpr::Query(query) => {
+            let () = traverse_set_expr(subquery_idents, &query.body);
+        }
+        _ => {}
+    }
 }
 
 pub fn visit(stmt: &mut Statement) {

--- a/crates/embucket-functions/src/visitors/inline_aliases_in_query.rs
+++ b/crates/embucket-functions/src/visitors/inline_aliases_in_query.rs
@@ -175,10 +175,8 @@ fn traverse_set_expr(subquery_idents: &mut HashSet<String>, set_expr: &SetExpr) 
                 SelectItem::ExprWithAlias { alias, .. } => {
                     subquery_idents.insert(alias.value.clone());
                 }
-                SelectItem::UnnamedExpr(expr) => {
-                    if let Expr::Identifier(ident) = expr {
-                        subquery_idents.insert(ident.value.clone());
-                    }
+                SelectItem::UnnamedExpr(Expr::Identifier(ident)) => {
+                    subquery_idents.insert(ident.value.clone());
                 }
                 _ => {}
             });


### PR DESCRIPTION
Closes #1825

- Subquery idents & aliases can't be substituted for a value
- Fixed our inline aliases in query visitor to adhere to this rule
- Uses safe recursion, since we only check one subquery at a time
- If a `SELECT` has `FROM` a subquery on the top level we add those idents and aliases to a per level set, to check if substitution is required
- Extra visitor tests
- **tps ds q66 works**
- Regression testing:
  - [x] **dbt-gitlab** works (93.4%)
  - [x] **dbt-snowplow** works (100%)