### PR TITLE
Support async exec in api-ui REST API

### DIFF
--- a/crates/api-ui/src/queries/models.rs
+++ b/crates/api-ui/src/queries/models.rs
@@ -18,7 +18,7 @@ pub struct Column {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[schema(as = Row, value_type = Vec<Value>)]
-pub struct Row(Vec<Value>);
+pub struct Row(pub Vec<Value>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -35,10 +35,17 @@ impl TryFrom<&str> for ResultSet {
     }
 }
 
+const fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryCreatePayload {
     pub worksheet_id: Option<WorksheetId>,
+    #[serde(default = "default_true")]
+    #[schema(default = true)]
+    pub async_exec: bool,
     pub query: String,
     pub context: Option<HashMap<String, String>>,
 }

--- a/crates/api-ui/src/tests/auth.rs
+++ b/crates/api-ui/src/tests/auth.rs
@@ -137,6 +137,7 @@ where
         &format!("http://{addr}/ui/queries"),
         json!(QueryCreatePayload {
             worksheet_id: None,
+            async_exec: false,
             query: query.to_string(),
             context: None,
         })

--- a/crates/api-ui/src/tests/dashboard.rs
+++ b/crates/api-ui/src/tests/dashboard.rs
@@ -122,6 +122,7 @@ async fn test_ui_dashboard() {
 
     let query_payload = QueryCreatePayload {
         worksheet_id: Some(worksheet_id),
+        async_exec: false,
         query: format!(
             "create or replace Iceberg TABLE {}.{}.{}
         external_volume = ''

--- a/crates/api-ui/src/tests/navigation_trees.rs
+++ b/crates/api-ui/src/tests/navigation_trees.rs
@@ -114,6 +114,7 @@ async fn test_ui_databases_navigation() {
 
     let query_payload = QueryCreatePayload {
         worksheet_id: Some(worksheet_id),
+        async_exec: false,
         query: format!(
             "CREATE TABLE {}.{}.{} (APP_ID TEXT)",
             expected1.name.clone(),

--- a/crates/api-ui/src/tests/queries.rs
+++ b/crates/api-ui/src/tests/queries.rs
@@ -23,6 +23,7 @@ async fn test_ui_queries_no_worksheet() {
         &format!("http://{addr}/ui/queries"),
         json!(QueryCreatePayload {
             worksheet_id: Some(0),
+            async_exec: false,
             query: "SELECT 1".to_string(),
             context: None,
         })
@@ -100,6 +101,7 @@ async fn test_ui_queries_with_worksheet() {
         &format!("http://{addr}/ui/queries"),
         json!(QueryCreatePayload {
             worksheet_id: Some(worksheet.id),
+            async_exec: false,
             query: "SELECT 1, 2".to_string(),
             context: None,
         })
@@ -130,6 +132,7 @@ async fn test_ui_queries_with_worksheet() {
         &format!("http://{addr}/ui/queries"),
         json!(QueryCreatePayload {
             worksheet_id: Some(worksheet.id),
+            async_exec: false,
             query: "SELECT 2".to_string(),
             context: None,
         })
@@ -156,6 +159,7 @@ async fn test_ui_queries_with_worksheet() {
         &format!("http://{addr}/ui/queries"),
         json!(QueryCreatePayload {
             worksheet_id: Some(worksheet.id),
+            async_exec: false,
             query: "SELECT foo".to_string(),
             context: None,
         })
@@ -178,6 +182,7 @@ async fn test_ui_queries_with_worksheet() {
         &format!("http://{addr}/ui/queries"),
         json!(QueryCreatePayload {
             worksheet_id: Some(worksheet.id),
+            async_exec: false,
             query: "SELECT foo".to_string(),
             context: None,
         })
@@ -284,6 +289,7 @@ async fn test_ui_queries_search() {
         &format!("http://{addr}/ui/queries"),
         json!(QueryCreatePayload {
             worksheet_id: Some(worksheet.id),
+            async_exec: false,
             query: "SELECT 1, 2".to_string(),
             context: None,
         })
@@ -298,6 +304,7 @@ async fn test_ui_queries_search() {
         &format!("http://{addr}/ui/queries"),
         json!(QueryCreatePayload {
             worksheet_id: Some(worksheet.id),
+            async_exec: false,
             query: "SELECT 2".to_string(),
             context: None,
         })
@@ -312,6 +319,7 @@ async fn test_ui_queries_search() {
         &format!("http://{addr}/ui/queries"),
         json!(QueryCreatePayload {
             worksheet_id: Some(worksheet.id),
+            async_exec: false,
             query: "CREATE".to_string(),
             context: None,
         })
@@ -365,4 +373,54 @@ async fn test_ui_queries_search() {
     // check items returned in descending order
     assert_eq!(queries.len(), 2);
     assert!(queries[0].start_time > queries[1].start_time);
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn test_ui_async_query_infer_default_exec_mode() {
+    let addr = run_test_server().await;
+    let client = reqwest::Client::new();
+
+    // asyncExec = true by default
+    let payload = r#"{"query":"select 1","worksheetId": null,"context":{"database":"embucket","schema":"embucket"}}"#;
+
+    // let payload = json!(QueryCreatePayload {
+    //     worksheet_id: Some(0),
+    //     async_exec: true,
+    //     query: "SELECT 1".to_string(),
+    //     context: None,
+    // })
+    // .to_string();
+
+    let query_record = http_req::<QueryRecord>(
+        &client,
+        Method::POST,
+        &format!("http://{addr}/ui/queries"),
+        payload.to_string(),
+    )
+    .await
+    .expect("Create query error");
+
+    let expected_submit_result = ResultSet::try_from(r#"{"columns":[],"rows":[]}"#)
+        .expect("Failed to deserialize json snippet #1");
+
+    assert_eq!(query_record.status, QueryStatus::Running);
+    assert_eq!(query_record.result, expected_submit_result);
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    let QueryGetResponse(query_record) = http_req::<QueryGetResponse>(
+        &client,
+        Method::GET,
+        &format!("http://{addr}/ui/queries/{}", query_record.id),
+        String::new(),
+    )
+    .await
+    .expect("Get query error");
+    let expected_result =
+        ResultSet::try_from(r#"{"columns":[{"name":"Int64(1)","type":"fixed"}],"rows":[[1]]}"#)
+            .expect("Failed to deserialize json snippet #2");
+
+    assert_eq!(query_record.status, QueryStatus::Successful);
+    assert_eq!(query_record.result, expected_result);
 }

--- a/crates/api-ui/src/tests/tables.rs
+++ b/crates/api-ui/src/tests/tables.rs
@@ -89,6 +89,7 @@ async fn test_ui_tables() {
 
     let query_payload = QueryCreatePayload {
         worksheet_id: Some(worksheet_id),
+        async_exec: false,
         query: format!(
             "create TABLE {}.{}.{}
         external_volume = ''
@@ -120,6 +121,7 @@ async fn test_ui_tables() {
 
     let query_payload = QueryCreatePayload {
         worksheet_id: Some(worksheet_id),
+        async_exec: false,
         query: format!(
             "INSERT INTO {}.{}.{} (APP_ID, PLATFORM, EVENT, TXN_ID, EVENT_TIME)
         VALUES ('12345', 'iOS', 'login', '123456', '2021-01-01T00:00:00'),
@@ -222,6 +224,7 @@ async fn test_ui_tables() {
     //Create three more tables
     let query_payload = QueryCreatePayload {
         worksheet_id: Some(worksheet_id),
+        async_exec: false,
         query: format!(
             "create TABLE {}.{}.{}
         external_volume = ''
@@ -253,6 +256,7 @@ async fn test_ui_tables() {
 
     let query_payload = QueryCreatePayload {
         worksheet_id: Some(worksheet_id),
+        async_exec: false,
         query: format!(
             "create TABLE {}.{}.{}
         external_volume = ''
@@ -284,6 +288,7 @@ async fn test_ui_tables() {
 
     let query_payload = QueryCreatePayload {
         worksheet_id: Some(worksheet_id),
+        async_exec: false,
         query: format!(
             "create TABLE {}.{}.{}
         external_volume = ''
@@ -372,6 +377,7 @@ async fn test_ui_tables() {
     //Create a table with another name
     let query_payload = QueryCreatePayload {
         worksheet_id: Some(worksheet_id),
+        async_exec: false,
         query: format!(
             "create TABLE {}.{}.{}
         external_volume = ''

--- a/crates/embucket-seed/src/requests/service_client.rs
+++ b/crates/embucket-seed/src/requests/service_client.rs
@@ -270,6 +270,7 @@ impl ServiceClient for BasicAuthClient {
         let url = format!("http://{}/ui/queries", self.addr);
         let query_payload = QueryCreatePayload {
             worksheet_id: None,
+            async_exec: false,
             query: query.to_string(),
             context: None,
         };


### PR DESCRIPTION
Related to #1854

* Added  async_exec to the QueryCreatePayload, assigned default  value = true, reflected in open api spec
* Extended POST /ui/queries handler
  - on asyncExec=true it returns QueryRecord with status=Running
  - on asyncExec=false it returns QueryRecord with  result embedded

This doesn't include handler aborting queries.