### PR TITLE
engine: Decimal cast fix

### DIFF
--- a/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
+++ b/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
@@ -105,7 +105,7 @@ impl CastAnalyzer {
                     args: vec![expr.clone()],
                 })))
             }
-            data_type @ (DataType::Decimal128(_, _) | DataType::Decimal256(_, _)) => {
+            data_type @ DataType::Decimal128(_, _) => {
                 Self::rewrite_numeric_cast(expr, data_type, try_mode)
             }
             data_type @ (DataType::Int32 | DataType::Int64)
@@ -124,20 +124,28 @@ impl CastAnalyzer {
         data_type: DataType,
         try_mode: bool,
     ) -> DFResult<Transformed<Expr>> {
-        let internal = Expr::ScalarFunction(ScalarFunction {
-            func: Arc::new(ScalarUDF::from(ToDecimalFunc::new(try_mode))),
-            args: vec![expr.clone()],
-        });
-        let new_expr = if try_mode {
-            Expr::TryCast(TryCast {
-                expr: Box::new(internal),
-                data_type,
+        let func = Arc::new(ScalarUDF::from(ToDecimalFunc::new(try_mode)));
+        let new_expr = if let DataType::Decimal128(precision, scale) = data_type {
+            Expr::ScalarFunction(ScalarFunction {
+                func,
+                args: vec![expr.clone(), Expr::Literal(ScalarValue::UInt8(Some(precision)), None), Expr::Literal(ScalarValue::Int8(Some(scale)), None)],
             })
         } else {
-            Expr::Cast(Cast {
-                expr: Box::new(internal),
-                data_type,
-            })
+            let internal = Expr::ScalarFunction(ScalarFunction {
+                func,
+                args: vec![expr.clone()],
+            });
+            if try_mode {
+                Expr::TryCast(TryCast {
+                    expr: Box::new(internal),
+                    data_type,
+                })
+            } else {
+                Expr::Cast(Cast {
+                    expr: Box::new(internal),
+                    data_type,
+                })
+            }
         };
         Ok(Transformed::yes(new_expr))
     }

--- a/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
+++ b/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
@@ -128,7 +128,11 @@ impl CastAnalyzer {
         let new_expr = if let DataType::Decimal128(precision, scale) = data_type {
             Expr::ScalarFunction(ScalarFunction {
                 func,
-                args: vec![expr.clone(), Expr::Literal(ScalarValue::UInt8(Some(precision)), None), Expr::Literal(ScalarValue::Int8(Some(scale)), None)],
+                args: vec![
+                    expr.clone(),
+                    Expr::Literal(ScalarValue::UInt8(Some(precision)), None),
+                    Expr::Literal(ScalarValue::Int8(Some(scale)), None),
+                ],
             })
         } else {
             let internal = Expr::ScalarFunction(ScalarFunction {

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/decimal.rs
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/decimal.rs
@@ -11,3 +11,21 @@ test_query!(
     "SELECT column1::NUMBER as v FROM VALUES (FALSE), (TRUE)",
     snapshot_path = "decimal"
 );
+
+test_query!(
+    decimal_cast_no_truncation,
+    "SELECT column1::NUMBER as v FROM VALUES (99.63), (99.49)",
+    snapshot_path = "decimal"
+);
+
+test_query!(
+    decimal_cast_no_truncation_utf8,
+    "SELECT column1::NUMBER as v FROM VALUES ('99.63'), ('99.49')",
+    snapshot_path = "decimal"
+);
+
+test_query!(
+    decimal_cast_decimal,
+    "SELECT column1::NUMBER(5, 2) as v FROM VALUES (99.63), (99.49)",
+    snapshot_path = "decimal"
+);

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/decimal/query_decimal_cast_decimal.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/decimal/query_decimal_cast_decimal.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/sql/logical_analyzer/casting/decimal.rs
+description: "\"SELECT column1::NUMBER(5, 2) as v FROM VALUES (99.63), (99.49)\""
+---
+Ok(
+    [
+        "+-------+",
+        "| v     |",
+        "+-------+",
+        "| 99.63 |",
+        "| 99.49 |",
+        "+-------+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/decimal/query_decimal_cast_no_truncation.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/decimal/query_decimal_cast_no_truncation.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/sql/logical_analyzer/casting/decimal.rs
+description: "\"SELECT column1::NUMBER as v FROM VALUES (99.63), (99.49)\""
+---
+Ok(
+    [
+        "+-----+",
+        "| v   |",
+        "+-----+",
+        "| 100 |",
+        "| 99  |",
+        "+-----+",
+    ],
+)

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/decimal/query_decimal_cast_no_truncation_utf8.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/decimal/query_decimal_cast_no_truncation_utf8.snap
@@ -1,0 +1,14 @@
+---
+source: crates/core-executor/src/tests/sql/logical_analyzer/casting/decimal.rs
+description: "\"SELECT column1::NUMBER as v FROM VALUES ('99.63'), ('99.49')\""
+---
+Ok(
+    [
+        "+-----+",
+        "| v   |",
+        "+-----+",
+        "| 100 |",
+        "| 99  |",
+        "+-----+",
+    ],
+)


### PR DESCRIPTION
Closes #1850 & #1853

- Fixed incorrect truncation in decimal to decimal cast
- Using `to_decimal` internally and then casting to the correct decimal precision and scale resulted in all decimal values truncated to int like values
- Using `to_decimal` with the correct precision and scale fixes it, also no need for additional casting
- Added insta tests
- Related to tps ds q13
- Regression testing:
  - [x] **dbt-gitlab** works (93.4%)
  - [x] **dbt-snowplow** works (100%)

P.S. cc @YevheniiNiestierov 