### PR TITLE
engine: Integer cast fix

### DIFF
--- a/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
+++ b/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
@@ -57,7 +57,9 @@ impl CastAnalyzer {
 
             let transformed_expr = expr.transform_up(|e| match &e {
                 Expr::Cast(cast) => self.rewrite_cast_to(&cast.data_type, &cast.expr, &e, false),
-                Expr::TryCast(try_cast) => self.rewrite_cast_to(&try_cast.data_type, &try_cast.expr, &e, true),
+                Expr::TryCast(try_cast) => {
+                    self.rewrite_cast_to(&try_cast.data_type, &try_cast.expr, &e, true)
+                }
                 _ => Ok(Transformed::no(e)),
             })?;
 

--- a/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
+++ b/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
@@ -98,9 +98,9 @@ impl CastAnalyzer {
                     args: vec![expr.clone()],
                 })))
             }
-            data_type @ (DataType::Decimal128(_, _)
-            | DataType::Int32
-            | DataType::Int64) => Self::rewrite_numeric_cast(expr, data_type, try_mode),
+            data_type @ (DataType::Decimal128(_, _) | DataType::Int32 | DataType::Int64) => {
+                Self::rewrite_numeric_cast(expr, data_type, try_mode)
+            }
             _ => Ok(Transformed::no(original_expr.clone())),
         }
     }

--- a/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
+++ b/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
@@ -4,12 +4,12 @@ use datafusion::arrow::datatypes::TimeUnit;
 use datafusion::error::Result as DFResult;
 use datafusion::logical_expr::LogicalPlan;
 use datafusion::optimizer::AnalyzerRule;
+use datafusion_common::ScalarValue;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
-use datafusion_common::{DFSchemaRef, ScalarValue};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::expr_rewriter::NamePreserver;
-use datafusion_expr::{Cast, Expr, ExprSchemable, ReturnFieldArgs, ScalarUDF, TryCast};
+use datafusion_expr::{Cast, Expr, ReturnFieldArgs, ScalarUDF, TryCast};
 use embucket_functions::conversion::to_array::ToArrayFunc;
 use embucket_functions::conversion::to_date::ToDateFunc;
 use embucket_functions::conversion::to_decimal::ToDecimalFunc;
@@ -56,16 +56,10 @@ impl CastAnalyzer {
             let original_name = name_preserver.save(&expr);
 
             let transformed_expr = expr.transform_up(|e| match &e {
-                Expr::Cast(cast) => {
-                    self.rewrite_cast_to(plan.schema(), &cast.data_type, &cast.expr, &e, false)
+                Expr::Cast(cast) => self.rewrite_cast_to(&cast.data_type, &cast.expr, &e, false),
+                Expr::TryCast(try_cast) => {
+                    self.rewrite_cast_to(&try_cast.data_type, &try_cast.expr, &e, true)
                 }
-                Expr::TryCast(try_cast) => self.rewrite_cast_to(
-                    plan.schema(),
-                    &try_cast.data_type,
-                    &try_cast.expr,
-                    &e,
-                    true,
-                ),
                 _ => Ok(Transformed::no(e)),
             })?;
 
@@ -76,7 +70,6 @@ impl CastAnalyzer {
 
     fn rewrite_cast_to(
         &self,
-        schema: &DFSchemaRef,
         data_type: &DataType,
         expr: &Expr,
         original_expr: &Expr,
@@ -105,14 +98,9 @@ impl CastAnalyzer {
                     args: vec![expr.clone()],
                 })))
             }
-            data_type @ DataType::Decimal128(_, _) => {
-                Self::rewrite_numeric_cast(expr, data_type, try_mode)
-            }
-            data_type @ (DataType::Int32 | DataType::Int64)
-                if matches!(expr.get_type(schema), Ok(DataType::Utf8)) =>
-            {
-                Self::rewrite_numeric_cast(expr, data_type, try_mode)
-            }
+            data_type @ (DataType::Decimal128(_, _)
+            | DataType::Int32
+            | DataType::Int64) => Self::rewrite_numeric_cast(expr, data_type, try_mode),
             _ => Ok(Transformed::no(original_expr.clone())),
         }
     }

--- a/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
+++ b/crates/core-executor/src/datafusion/logical_analyzer/cast_analyzer.rs
@@ -57,9 +57,7 @@ impl CastAnalyzer {
 
             let transformed_expr = expr.transform_up(|e| match &e {
                 Expr::Cast(cast) => self.rewrite_cast_to(&cast.data_type, &cast.expr, &e, false),
-                Expr::TryCast(try_cast) => {
-                    self.rewrite_cast_to(&try_cast.data_type, &try_cast.expr, &e, true)
-                }
+                Expr::TryCast(try_cast) => self.rewrite_cast_to(&try_cast.data_type, &try_cast.expr, &e, true),
                 _ => Ok(Transformed::no(e)),
             })?;
 

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/integer.rs
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/integer.rs
@@ -5,7 +5,7 @@ test_query!(
     "SELECT * FROM test",
     setup_queries = [
         "CREATE TABLE test (a INT32)",
-        "INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459')"
+        "INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
     ],
     snapshot_path = "integer"
 );
@@ -15,7 +15,7 @@ test_query!(
     "SELECT * FROM test",
     setup_queries = [
         "CREATE TABLE test (a INT64)",
-        "INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459')"
+        "INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
     ],
     snapshot_path = "integer"
 );
@@ -25,7 +25,7 @@ test_query!(
     "SELECT * FROM test",
     setup_queries = [
         "CREATE TABLE test (a INT)",
-        "INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459')"
+        "INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
     ],
     snapshot_path = "integer"
 );
@@ -35,7 +35,47 @@ test_query!(
     "SELECT * FROM test",
     setup_queries = [
         "CREATE TABLE test (a INTEGER)",
-        "INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459')"
+        "INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
+    ],
+    snapshot_path = "integer"
+);
+
+test_query!(
+    int32_cast_decimal,
+    "SELECT * FROM test",
+    setup_queries = [
+        "CREATE TABLE test (a INT32)",
+        "INSERT INTO test VALUES (50), (50.0), (50.9), (50.5), (50.45), (50.459), (50.49)"
+    ],
+    snapshot_path = "integer"
+);
+
+test_query!(
+    int64_cast_decimal,
+    "SELECT * FROM test",
+    setup_queries = [
+        "CREATE TABLE test (a INT64)",
+        "INSERT INTO test VALUES (50), (50.0), (50.9), (50.5), (50.45), (50.459), (50.49)"
+    ],
+    snapshot_path = "integer"
+);
+
+test_query!(
+    int_cast_decimal,
+    "SELECT * FROM test",
+    setup_queries = [
+        "CREATE TABLE test (a INT)",
+        "INSERT INTO test VALUES (50), (50.0), (50.9), (50.5), (50.45), (50.459), (50.49)"
+    ],
+    snapshot_path = "integer"
+);
+
+test_query!(
+    integer_cast_decimal,
+    "SELECT * FROM test",
+    setup_queries = [
+        "CREATE TABLE test (a INTEGER)",
+        "INSERT INTO test VALUES (50), (50.0), (50.9), (50.5), (50.45), (50.459), (50.49)"
     ],
     snapshot_path = "integer"
 );

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int32_cast.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int32_cast.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/core-executor/src/tests/sql/logical_analyzer/casting/integer.rs
 description: "\"SELECT * FROM test\""
-info: "Setup queries: CREATE TABLE test (a INT32); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459')"
+info: "Setup queries: CREATE TABLE test (a INT32); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
 ---
 Ok(
     [
@@ -12,6 +12,7 @@ Ok(
         "| 50 |",
         "| 51 |",
         "| 51 |",
+        "| 50 |",
         "| 50 |",
         "| 50 |",
         "+----+",

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int32_cast_decimal.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int32_cast_decimal.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/core-executor/src/tests/sql/logical_analyzer/casting/integer.rs
 description: "\"SELECT * FROM test\""
-info: "Setup queries: CREATE TABLE test (a INT64); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
+info: "Setup queries: CREATE TABLE test (a INT32); INSERT INTO test VALUES (50), (50.0), (50.9), (50.5), (50.45), (50.459), (50.49)"
 ---
 Ok(
     [

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int64_cast_decimal.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int64_cast_decimal.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/core-executor/src/tests/sql/logical_analyzer/casting/integer.rs
 description: "\"SELECT * FROM test\""
-info: "Setup queries: CREATE TABLE test (a INT64); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
+info: "Setup queries: CREATE TABLE test (a INT64); INSERT INTO test VALUES (50), (50.0), (50.9), (50.5), (50.45), (50.459), (50.49)"
 ---
 Ok(
     [

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int_cast.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int_cast.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/core-executor/src/tests/sql/logical_analyzer/casting/integer.rs
 description: "\"SELECT * FROM test\""
-info: "Setup queries: CREATE TABLE test (a INT); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459')"
+info: "Setup queries: CREATE TABLE test (a INT); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
 ---
 Ok(
     [
@@ -12,6 +12,7 @@ Ok(
         "| 50 |",
         "| 51 |",
         "| 51 |",
+        "| 50 |",
         "| 50 |",
         "| 50 |",
         "+----+",

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int_cast_decimal.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_int_cast_decimal.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/core-executor/src/tests/sql/logical_analyzer/casting/integer.rs
 description: "\"SELECT * FROM test\""
-info: "Setup queries: CREATE TABLE test (a INT64); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
+info: "Setup queries: CREATE TABLE test (a INT); INSERT INTO test VALUES (50), (50.0), (50.9), (50.5), (50.45), (50.459), (50.49)"
 ---
 Ok(
     [

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_integer_cast.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_integer_cast.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/core-executor/src/tests/sql/logical_analyzer/casting/integer.rs
 description: "\"SELECT * FROM test\""
-info: "Setup queries: CREATE TABLE test (a INTEGER); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459')"
+info: "Setup queries: CREATE TABLE test (a INTEGER); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
 ---
 Ok(
     [
@@ -12,6 +12,7 @@ Ok(
         "| 50 |",
         "| 51 |",
         "| 51 |",
+        "| 50 |",
         "| 50 |",
         "| 50 |",
         "+----+",

--- a/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_integer_cast_decimal.snap
+++ b/crates/core-executor/src/tests/sql/logical_analyzer/casting/snapshots/integer/query_integer_cast_decimal.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/core-executor/src/tests/sql/logical_analyzer/casting/integer.rs
 description: "\"SELECT * FROM test\""
-info: "Setup queries: CREATE TABLE test (a INT64); INSERT INTO test VALUES ('50'), ('50.0'), ('50.9'), ('50.5'), ('50.45'), ('50.459'), ('50.49')"
+info: "Setup queries: CREATE TABLE test (a INTEGER); INSERT INTO test VALUES (50), (50.0), (50.9), (50.5), (50.45), (50.459), (50.49)"
 ---
 Ok(
     [


### PR DESCRIPTION
Closes #1851

- Fixed incorrect truncation in decimal to integer cast
- Using `to_decimal` internally and then casting to the `int32` or `int64` types respectively
- However, this was only appiled for if the type was `utf8`, e.x.: `SELECT '99.63'::INTEGER` not for a "real" decimal - fixed
- Added insta tests
- Related to tps ds q54
- Regression testing:
  - [x] **dbt-gitlab** works (93.4%)
  - [x] **dbt-snowplow** works (100%)

P.S. cc @YevheniiNiestierov 