### PR TITLE
Register some DF UDF functions in duckdb

### DIFF
--- a/crates/core-executor/src/query.rs
+++ b/crates/core-executor/src/query.rs
@@ -512,7 +512,14 @@ impl UserQuery {
         let sql = self.query.clone();
 
         let conn = Connection::open_in_memory().context(ex_error::DuckdbSnafu)?;
-        register_all_udfs(&conn)?;
+        let failed = register_all_udfs(&conn, self.session.ctx.state().scalar_functions())?;
+        if !failed.is_empty() {
+            tracing::warn!(
+                "Some UDFs were not registered/overloaded in DuckDB: {:?}",
+                failed
+            );
+        }
+
         apply_connection_setup_queries(&conn, &setup_queries)?;
 
         if self.session.config.use_duck_db_explain

--- a/crates/embucket-functions/src/datetime/date_part_extract.rs
+++ b/crates/embucket-functions/src/datetime/date_part_extract.rs
@@ -13,6 +13,7 @@ use datafusion_expr::registry::FunctionRegistry;
 use datafusion_expr::{ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility};
 use snafu::OptionExt;
 use std::any::Any;
+use std::fmt;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
@@ -35,6 +36,30 @@ pub enum Interval {
     Hour,
     Minute,
     Second,
+}
+
+impl fmt::Display for Interval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Year => "year",
+            Self::YearOfWeek => "yearofweek",
+            Self::YearOfWeekIso => "yearofweekiso",
+            Self::Day => "day",
+            Self::DayOfMonth => "dayofmonth",
+            Self::DayOfWeek => "dayofweek",
+            Self::DayOfWeekIso => "dayofweekiso",
+            Self::DayOfYear => "dayofyear",
+            Self::Week => "week",
+            Self::WeekOfYear => "weekofyear",
+            Self::WeekIso => "weekiso",
+            Self::Month => "month",
+            Self::Quarter => "quarter",
+            Self::Hour => "hour",
+            Self::Minute => "minute",
+            Self::Second => "second",
+        };
+        write!(f, "{s}")
+    }
 }
 
 /// `YEAR*` / `DAY*` / `WEEK*` / `MONTH` / `QUARTER` / `HOUR` / `MINUTE` / `SECOND` SQL function

--- a/crates/embucket-functions/src/regexp/mod.rs
+++ b/crates/embucket-functions/src/regexp/mod.rs
@@ -1,9 +1,9 @@
 pub mod errors;
 pub mod regexp_instr;
-mod regexp_like;
-mod regexp_replace;
-mod regexp_substr;
-mod regexp_substr_all;
+pub mod regexp_like;
+pub mod regexp_replace;
+pub mod regexp_substr;
+pub mod regexp_substr_all;
 
 use crate::regexp::regexp_instr::RegexpInstrFunc;
 use crate::regexp::regexp_like::RegexpLikeFunc;

--- a/crates/embucket-functions/src/regexp/regexp_like.rs
+++ b/crates/embucket-functions/src/regexp/regexp_like.rs
@@ -55,6 +55,7 @@ impl Default for RegexpLikeFunc {
 }
 
 impl RegexpLikeFunc {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             signature: Signature::one_of(

--- a/crates/embucket-functions/src/regexp/regexp_replace.rs
+++ b/crates/embucket-functions/src/regexp/regexp_replace.rs
@@ -59,6 +59,7 @@ impl Default for RegexpReplaceFunc {
 }
 
 impl RegexpReplaceFunc {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             signature: Signature::one_of(

--- a/crates/embucket-functions/src/regexp/regexp_substr.rs
+++ b/crates/embucket-functions/src/regexp/regexp_substr.rs
@@ -65,6 +65,7 @@ impl Default for RegexpSubstrFunc {
 }
 
 impl RegexpSubstrFunc {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             signature: Signature::one_of(

--- a/crates/embucket-functions/src/regexp/regexp_substr_all.rs
+++ b/crates/embucket-functions/src/regexp/regexp_substr_all.rs
@@ -67,6 +67,7 @@ impl Default for RegexpSubstrAllFunc {
 }
 
 impl RegexpSubstrAllFunc {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             signature: Signature::one_of(

--- a/crates/embucket-functions/src/string-binary/parse_ip.rs
+++ b/crates/embucket-functions/src/string-binary/parse_ip.rs
@@ -7,9 +7,7 @@ use datafusion::logical_expr::{
 };
 use datafusion_common::ScalarValue;
 use datafusion_common::cast::as_generic_string_array;
-use datafusion_common::types::{
-    NativeType, logical_float16, logical_float32, logical_float64, logical_string,
-};
+use datafusion_common::types::{NativeType, logical_float32, logical_float64, logical_string};
 use datafusion_expr::{ScalarFunctionArgs, ScalarUDFImpl};
 use ipnet::IpNet;
 use serde_json::json;
@@ -65,7 +63,6 @@ impl ParseIpFunc {
                             TypeSignatureClass::Native(logical_float64()),
                             vec![
                                 TypeSignatureClass::Integer,
-                                TypeSignatureClass::Native(logical_float16()),
                                 TypeSignatureClass::Native(logical_float32()),
                             ],
                             NativeType::Float64,


### PR DESCRIPTION

- added logic to register the following UDF funcs in duckdb
  - String binary
  - Regexp
  - Contitional
  - Crypto
  - Datetime
  - Numeric
  - System
- ```Some UDFs were not registered/overloaded in DuckDB: [\"length\", \"lower\", \"split\", \"substr\", \"replace\", \"regexp_replace\", \"md5\", \"datediff\", \"dayname\", \"last_day\", \"monthname\", \"year\", \"day\", \"dayofmonth\", \"dayofweek\", \"dayofyear\", \"week\", \"weekofyear\", \"month\", \"quarter\", \"hour\", \"minute\", \"second\"]```
- Removed float16 from parse_ip since this type is not supported by duckdb types convertor

**Next steps is to** 
- try to fix funs overloading
- check slt tests
- add session udfs like current_ip, etc.
