### PR TITLE
Issues/1887 id clashes on multiple queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "error-stack-trace",
  "futures",
  "mockall",
+ "parking_lot",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/api-ui/src/navigation_trees/error.rs
+++ b/crates/api-ui/src/navigation_trees/error.rs
@@ -15,13 +15,14 @@ pub enum Error {
 
 // Select which status code to return.
 impl IntoStatusCode for Error {
+    #[allow(clippy::match_wildcard_for_single_variants)]
     fn status_code(&self) -> StatusCode {
         match self {
-            Self::Execution { source, .. } => match source {
-                core_executor::Error::ConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
-                _ => StatusCode::INTERNAL_SERVER_ERROR,
-            }
-            _ => StatusCode::INTERNAL_SERVER_ERROR
+            Self::Execution {
+                source: core_executor::Error::ConcurrencyLimit { .. },
+                ..
+            } => StatusCode::TOO_MANY_REQUESTS,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/crates/api-ui/src/navigation_trees/error.rs
+++ b/crates/api-ui/src/navigation_trees/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
 // Select which status code to return.
 impl IntoStatusCode for Error {
     fn status_code(&self) -> StatusCode {
-        StatusCode::INTERNAL_SERVER_ERROR
+        match self {
+            Self::Execution { source, .. } => match source {
+                core_executor::Error::ConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            }
+            _ => StatusCode::INTERNAL_SERVER_ERROR
+        }
     }
 }

--- a/crates/api-ui/src/queries/error.rs
+++ b/crates/api-ui/src/queries/error.rs
@@ -97,7 +97,7 @@ impl IntoStatusCode for Error {
                 QueryError::Execution { source, .. } => match source {
                     core_executor::Error::ConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
                     _ => StatusCode::UNPROCESSABLE_ENTITY,
-                }
+                },
                 QueryError::Store { .. } => StatusCode::BAD_REQUEST,
                 QueryError::ResultParse { .. }
                 | QueryError::Utf8 { .. }
@@ -110,7 +110,7 @@ impl IntoStatusCode for Error {
                 QueryError::Execution { source, .. } => match source {
                     core_executor::Error::ConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
                     _ => StatusCode::INTERNAL_SERVER_ERROR,
-                }
+                },
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             },
             Self::GetQueryRecord { source, .. } => match &source {

--- a/crates/api-ui/src/queries/error.rs
+++ b/crates/api-ui/src/queries/error.rs
@@ -94,7 +94,10 @@ impl IntoStatusCode for Error {
     fn status_code(&self) -> StatusCode {
         match self {
             Self::Query { source, .. } => match &source {
-                QueryError::Execution { .. } => StatusCode::UNPROCESSABLE_ENTITY,
+                QueryError::Execution { source, .. } => match source {
+                    core_executor::Error::ConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
+                    _ => StatusCode::UNPROCESSABLE_ENTITY,
+                }
                 QueryError::Store { .. } => StatusCode::BAD_REQUEST,
                 QueryError::ResultParse { .. }
                 | QueryError::Utf8 { .. }
@@ -104,6 +107,10 @@ impl IntoStatusCode for Error {
             },
             Self::Queries { source, .. } => match &source {
                 QueryError::ResultParse { .. } => StatusCode::UNPROCESSABLE_ENTITY,
+                QueryError::Execution { source, .. } => match source {
+                    core_executor::Error::ConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
+                    _ => StatusCode::INTERNAL_SERVER_ERROR,
+                }
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             },
             Self::GetQueryRecord { source, .. } => match &source {

--- a/crates/api-ui/src/volumes/error.rs
+++ b/crates/api-ui/src/volumes/error.rs
@@ -88,7 +88,10 @@ impl IntoStatusCode for Error {
                 core_metastore::Error::Validation { .. } => StatusCode::UNPROCESSABLE_ENTITY,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             },
-            Self::List { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::List { source, .. } => match source {
+                core_executor::Error::ConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            },
             Self::VolumeNotFound { .. } => StatusCode::NOT_FOUND,
         }
     }

--- a/crates/api-ui/src/web_assets/handler.rs
+++ b/crates/api-ui/src/web_assets/handler.rs
@@ -8,7 +8,7 @@ use axum::{
     body::Body,
     extract::Path,
     http::header,
-    response::{IntoResponse, Redirect, Response},
+    response::Response,
 };
 use mime_guess;
 use snafu::ResultExt;

--- a/crates/api-ui/src/web_assets/handler.rs
+++ b/crates/api-ui/src/web_assets/handler.rs
@@ -4,12 +4,7 @@ use super::error::{
 };
 use crate::error::{Error, Result};
 use api_ui_static_assets::WEB_ASSETS_TARBALL;
-use axum::{
-    body::Body,
-    extract::Path,
-    http::header,
-    response::Response,
-};
+use axum::{body::Body, extract::Path, http::header, response::Response};
 use mime_guess;
 use snafu::ResultExt;
 use std::io::Cursor;

--- a/crates/api-ui/src/worksheets/error.rs
+++ b/crates/api-ui/src/worksheets/error.rs
@@ -89,7 +89,7 @@ impl IntoStatusCode for Error {
                 core_executor::Error::ConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             },
-            | Self::Datetime { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Datetime { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/crates/api-ui/src/worksheets/error.rs
+++ b/crates/api-ui/src/worksheets/error.rs
@@ -85,7 +85,11 @@ impl IntoStatusCode for Error {
                 },
                 WorksheetError::NothingToUpdate { .. } => StatusCode::BAD_REQUEST,
             },
-            Self::List { .. } | Self::Datetime { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::List { source, .. } => match source {
+                core_executor::Error::ConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            | Self::Datetime { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/crates/benchmarks/src/util/mod.rs
+++ b/crates/benchmarks/src/util/mod.rs
@@ -93,11 +93,7 @@ pub async fn make_test_execution_svc() -> Arc<CoreExecutionService> {
     // ));
     let db = Db::memory().await;
     let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
-    let history_store = Arc::new(
-        SlateDBHistoryStore::new(db.clone())
-            .await
-            .expect("Failed to create history store"),
-    );
+    let history_store = Arc::new(SlateDBHistoryStore::new_in_memory().await);
     Arc::new(
         CoreExecutionService::new(metastore, history_store, Arc::new(Config::default()))
             .await

--- a/crates/core-executor/src/tests/e2e/e2e_common.rs
+++ b/crates/core-executor/src/tests/e2e/e2e_common.rs
@@ -693,9 +693,7 @@ pub async fn create_executor(
 
     let db = object_store_type.db().await?;
     let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
-    let history_store = Arc::new(
-        SlateDBHistoryStore::new_in_memory().await,
-    );
+    let history_store = Arc::new(SlateDBHistoryStore::new_in_memory().await);
     let execution_svc = CoreExecutionService::new(
         metastore.clone(),
         history_store.clone(),
@@ -736,9 +734,7 @@ pub async fn create_executor_with_early_volumes_creation(
     let used_volumes =
         create_volumes(metastore.clone(), &object_store_type, override_volumes).await?;
 
-    let history_store = Arc::new(
-        SlateDBHistoryStore::new_in_memory().await,
-    );
+    let history_store = Arc::new(SlateDBHistoryStore::new_in_memory().await);
     let execution_svc = CoreExecutionService::new(
         metastore.clone(),
         history_store.clone(),

--- a/crates/core-executor/src/tests/e2e/e2e_common.rs
+++ b/crates/core-executor/src/tests/e2e/e2e_common.rs
@@ -694,9 +694,7 @@ pub async fn create_executor(
     let db = object_store_type.db().await?;
     let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
     let history_store = Arc::new(
-        SlateDBHistoryStore::new(db.clone())
-            .await
-            .context(TestHistoryStoreSnafu)?,
+        SlateDBHistoryStore::new_in_memory().await,
     );
     let execution_svc = CoreExecutionService::new(
         metastore.clone(),
@@ -739,9 +737,7 @@ pub async fn create_executor_with_early_volumes_creation(
         create_volumes(metastore.clone(), &object_store_type, override_volumes).await?;
 
     let history_store = Arc::new(
-        SlateDBHistoryStore::new(db.clone())
-            .await
-            .context(TestHistoryStoreSnafu)?,
+        SlateDBHistoryStore::new_in_memory().await,
     );
     let execution_svc = CoreExecutionService::new(
         metastore.clone(),

--- a/crates/core-executor/src/tests/service.rs
+++ b/crates/core-executor/src/tests/service.rs
@@ -15,8 +15,8 @@ use core_metastore::{
     Volume as MetastoreVolume,
 };
 use datafusion::{arrow::csv::reader::Format, assert_batches_eq};
-use std::sync::Arc;
 use futures::future::join_all;
+use std::sync::Arc;
 
 #[tokio::test]
 #[allow(clippy::expect_used)]
@@ -587,9 +587,9 @@ async fn test_max_concurrency_level2() {
     );
 }
 
-
 #[tokio::test(flavor = "multi_thread")]
 #[allow(clippy::expect_used)]
+#[allow(clippy::items_after_statements)]
 async fn test_parallel_run() {
     const MAX_CONCURRENCY_LEVEL: usize = 10;
     let metastore = Arc::new(SlateDBMetastore::new_in_memory().await);
@@ -605,24 +605,22 @@ async fn test_parallel_run() {
     );
 
     let _ = execution_svc
-            .create_session("test_session_id")
-            .await
-            .expect("Failed to create session");
+        .create_session("test_session_id")
+        .await
+        .expect("Failed to create session");
 
-    async fn exec_query(execution_svc: Arc<dyn ExecutionService>, sql: &str) -> crate::Result<QueryResult> {
-        execution_svc.query(
-            "test_session_id",
-            sql,
-            QueryContext::default(),
-        ).await
+    async fn exec_query(
+        execution_svc: Arc<dyn ExecutionService>,
+        sql: &str,
+    ) -> crate::Result<QueryResult> {
+        execution_svc
+            .query("test_session_id", sql, QueryContext::default())
+            .await
     }
 
     let mut futures = Vec::new();
     for _ in 0..MAX_CONCURRENCY_LEVEL {
-        let future = tokio::task::spawn(exec_query(
-            execution_svc.clone(),
-            "SELECT 1",
-        ));
+        let future = tokio::task::spawn(exec_query(execution_svc.clone(), "SELECT 1"));
         futures.push(future);
     }
 

--- a/crates/core-history/Cargo.toml
+++ b/crates/core-history/Cargo.toml
@@ -29,6 +29,7 @@ rusqlite = { workspace = true }
 cfg-if = { workspace = true }
 deadpool-sqlite = { workspace = true }
 tokio = { workspace = true }
+parking_lot = "0.12.4"
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/core-history/src/entities/query.rs
+++ b/crates/core-history/src/entities/query.rs
@@ -3,7 +3,11 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use core_utils::iterable::IterableEntity;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Display, str::FromStr};
+use std::{fmt::Display, str::FromStr, sync::LazyLock};
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+static LATEST_TIMESTAMP: LazyLock<Arc<Mutex<i64>>> = LazyLock::new(|| Arc::new(Mutex::new(0_i64)));
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -75,8 +79,22 @@ impl QueryRecord {
     #[must_use]
     pub fn new(query: &str, worksheet_id: Option<WorksheetId>) -> Self {
         let start_time = Utc::now();
+
+        // following block forces returned QueryRecordId to be unique
+        let mut latest_timestamp = LATEST_TIMESTAMP.lock();
+        let mut current_timestamp = start_time.timestamp_micros();
+        // it can be equal if two queries executed just simultaneously
+        // ot it is can be less at previous invocation we already fixed the timestamp
+        if current_timestamp <= *latest_timestamp {
+            // just bump to the next microsecond
+            *latest_timestamp += 1;
+            current_timestamp = *latest_timestamp;
+        } else {
+            *latest_timestamp = current_timestamp;
+        }
+
         Self {
-            id: Self::inverted_id(QueryRecordId(start_time.timestamp_micros())),
+            id: Self::inverted_id(QueryRecordId(current_timestamp)),
             worksheet_id,
             query: String::from(query),
             start_time,

--- a/crates/core-history/src/entities/query.rs
+++ b/crates/core-history/src/entities/query.rs
@@ -2,10 +2,10 @@ use crate::{QueryRecordId, WorksheetId};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use core_utils::iterable::IterableEntity;
-use serde::{Deserialize, Serialize};
-use std::{fmt::Display, str::FromStr, sync::LazyLock};
 use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::{fmt::Display, str::FromStr, sync::LazyLock};
 
 static LATEST_TIMESTAMP: LazyLock<Arc<Mutex<i64>>> = LazyLock::new(|| Arc::new(Mutex::new(0_i64)));
 

--- a/crates/core-history/src/sqlite_history_store.rs
+++ b/crates/core-history/src/sqlite_history_store.rs
@@ -63,14 +63,18 @@ impl std::fmt::Debug for SlateDBHistoryStore {
 
 impl SlateDBHistoryStore {
     #[allow(clippy::expect_used)]
-    pub async fn new(db: core_utils::Db, history_db_name: String, results_db_name: String) -> Result<Self> {
+    pub async fn new(
+        db: core_utils::Db,
+        history_db_name: String,
+        results_db_name: String,
+    ) -> Result<Self> {
         // try creating dirs for every separate db file
         if let Some(dir_path) = std::path::Path::new(&history_db_name).parent() {
             std::fs::create_dir_all(dir_path).context(history_err::CreateDirSnafu)?;
         }
         if let Some(dir_path) = std::path::Path::new(&results_db_name).parent() {
             std::fs::create_dir_all(dir_path).context(history_err::CreateDirSnafu)?;
-        }        
+        }
 
         let history_store = Self {
             queries_db: SqliteDb::new(db.slate_db(), &history_db_name)
@@ -763,7 +767,14 @@ impl HistoryStore for SlateDBHistoryStore {
                     // in case if there are no results available for this query
                     // return empty resut set
                     if err == rusqlite::Error::QueryReturnedNoRows {
-                        return Ok((0, ResultSet::default().serialize_with_soft_limit(0).unwrap().into(), String::new()));
+                        return Ok((
+                            0,
+                            ResultSet::default()
+                                .serialize_with_soft_limit(0)
+                                .unwrap_or_default()
+                                .into(),
+                            String::new(),
+                        ));
                     }
                     Err(err)
                 })

--- a/crates/embucketd/src/cli.rs
+++ b/crates/embucketd/src/cli.rs
@@ -237,14 +237,14 @@ pub struct CliOpts {
     #[arg(
         long,
         env = "QUERY_HISTORY_DB_NAME",
-        default_value = "sqlite_data/queries.db",
+        default_value = "sqlite_data/queries.db"
     )]
     pub query_history_db_name: String,
 
     #[arg(
         long,
         env = "QUERY_RESULTS_DB_NAME",
-        default_value = "sqlite_data/results.db",
+        default_value = "sqlite_data/results.db"
     )]
     pub query_results_db_name: String,
 

--- a/crates/embucketd/src/cli.rs
+++ b/crates/embucketd/src/cli.rs
@@ -234,6 +234,20 @@ pub struct CliOpts {
     )]
     pub query_history_rows_limit: usize,
 
+    #[arg(
+        long,
+        env = "QUERY_HISTORY_DB_NAME",
+        default_value = "sqlite_data/queries.db",
+    )]
+    pub query_history_db_name: String,
+
+    #[arg(
+        long,
+        env = "QUERY_RESULTS_DB_NAME",
+        default_value = "sqlite_data/results.db",
+    )]
+    pub query_results_db_name: String,
+
     // should unset JWT_SECRET env var after loading
     #[arg(
         long,
@@ -289,21 +303,21 @@ enum StoreBackend {
 
 impl CliOpts {
     #[allow(clippy::unwrap_used, clippy::as_conversions)]
-    pub fn object_store_backend(self) -> ObjectStoreResult<Arc<dyn ObjectStore>> {
+    pub fn object_store_backend(&self) -> ObjectStoreResult<Arc<dyn ObjectStore>> {
         match self.backend {
             StoreBackend::S3 => {
                 let s3_allow_http = self.allow_http.unwrap_or(false);
 
                 let s3_builder = AmazonS3Builder::new()
-                    .with_access_key_id(self.access_key_id.unwrap())
-                    .with_secret_access_key(self.secret_access_key.unwrap())
-                    .with_region(self.region.unwrap())
-                    .with_bucket_name(self.bucket.unwrap())
+                    .with_access_key_id(self.access_key_id.clone().unwrap())
+                    .with_secret_access_key(self.secret_access_key.clone().unwrap())
+                    .with_region(self.region.clone().unwrap())
+                    .with_bucket_name(self.bucket.clone().unwrap())
                     .with_conditional_put(S3ConditionalPut::ETagMatch);
 
-                if let Some(endpoint) = self.endpoint {
+                if let Some(endpoint) = &self.endpoint {
                     s3_builder
-                        .with_endpoint(&endpoint)
+                        .with_endpoint(endpoint)
                         .with_allow_http(s3_allow_http)
                         .build()
                         .map(|s3| Arc::new(s3) as Arc<dyn ObjectStore>)
@@ -314,7 +328,7 @@ impl CliOpts {
                 }
             }
             StoreBackend::File => {
-                let file_storage_path = self.file_storage_path.unwrap();
+                let file_storage_path = self.file_storage_path.clone().unwrap();
                 let path = file_storage_path.as_path();
                 if !path.exists() || !path.is_dir() {
                     fs::create_dir(path).unwrap();

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -203,11 +203,14 @@ async fn async_main(
     let db = Db::new(slate_db);
 
     let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
-    let history_store = Arc::new(SlateDBHistoryStore::new(
-        db.clone(),
-        opts.query_history_db_name.clone(),
-        opts.query_results_db_name.clone(),
-    ).await?);
+    let history_store = Arc::new(
+        SlateDBHistoryStore::new(
+            db.clone(),
+            opts.query_history_db_name.clone(),
+            opts.query_results_db_name.clone(),
+        )
+        .await?,
+    );
 
     tracing::info!("Creating execution service");
     let execution_svc = Arc::new(

--- a/crates/embucketd/src/main.rs
+++ b/crates/embucketd/src/main.rs
@@ -203,7 +203,11 @@ async fn async_main(
     let db = Db::new(slate_db);
 
     let metastore = Arc::new(SlateDBMetastore::new(db.clone()));
-    let history_store = Arc::new(SlateDBHistoryStore::new(db.clone()).await?);
+    let history_store = Arc::new(SlateDBHistoryStore::new(
+        db.clone(),
+        opts.query_history_db_name.clone(),
+        opts.query_results_db_name.clone(),
+    ).await?);
 
     tracing::info!("Creating execution service");
     let execution_svc = Arc::new(


### PR DESCRIPTION
Workaround Closes #1887 
Closes #1883
Adds TOO_MANY_REQUESTS in api-ui on concurrency limit, instead of INTERNAL_SERVER_ERROR
