### PR TITLE
Fix variant_element double quotes for strings 

### DIFF
--- a/crates/embucket-functions/src/semi-structured/variant/variant_element.rs
+++ b/crates/embucket-functions/src/semi-structured/variant/variant_element.rs
@@ -1,4 +1,3 @@
-use crate::datetime::timestamp_from_parts::take_function_args;
 use crate::macros::make_udf_function;
 use crate::semi_structured::errors;
 use datafusion::arrow::array::Array;
@@ -6,6 +5,7 @@ use datafusion::arrow::array::builder::StringBuilder;
 use datafusion::arrow::array::cast::AsArray;
 use datafusion::arrow::compute::cast;
 use datafusion::arrow::datatypes::DataType;
+use datafusion_common::utils::take_function_args;
 use datafusion_common::{
     Result as DFResult, ScalarValue,
     types::{


### PR DESCRIPTION
The issue was caused by using Value::to_string() on JSON String values.
When `Value::String("test")` is serialized via `to_string()`, it becomes `"\"test\""`, because the JSON serializer escapes the inner string.
For flatten = true, we now detect Value::String and extract the raw inner string instead of serializing it as JSON.